### PR TITLE
Upgrade to Brighterscript 0.60.6

### DIFF
--- a/dist/components/rum/RumViewScope.brs
+++ b/dist/components/rum/RumViewScope.brs
@@ -200,9 +200,10 @@ end sub
 ' @param writer (object) the writer node (see WriterTask component)
 ' ----------------------------------------------------------------
 sub addAction(action as object, writer as object)
+    ' TODO RUMM-2586 handle mutliple consecutive actions
     if (action.type = "custom")
         sendCustomAction(action.target, writer)
-    else ' TODO RUMM-2586 handle mutliple consecutive actions
+    else
         m.top.activeAction = CreateObject("roSGNode", "RumActionScope")
         m.top.activeAction.target = action.target
         m.top.activeAction.actionType = action.type

--- a/library/bsconfig.json
+++ b/library/bsconfig.json
@@ -9,8 +9,8 @@
         "@rokucommunity/bslint"
     ],
     "createPackage": false,
-    "retainStagingFolder": true,
-    "stagingFolderPath": "../dist",
+    "retainStagingDir": true,
+    "stagingDir": "../dist",
     "diagnosticFilters": [
         "source/roku_modules/**/*.*"
     ],

--- a/library/components/rum/RumViewScope.bs
+++ b/library/components/rum/RumViewScope.bs
@@ -208,10 +208,10 @@ end sub
 ' @param writer (object) the writer node (see WriterTask component)
 ' ----------------------------------------------------------------
 sub addAction(action as object, writer as object)
+    ' TODO RUMM-2586 handle mutliple consecutive actions
     if (action.type = "custom")
         sendCustomAction(action.target, writer)
     else
-        ' TODO RUMM-2586 handle mutliple consecutive actions
         m.top.activeAction = CreateObject("roSGNode", "RumActionScope")
         m.top.activeAction.target = action.target
         m.top.activeAction.actionType = action.type

--- a/library/package.json
+++ b/library/package.json
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "@rokucommunity/bslint": "^0.7.4",
-    "brighterscript": "^0.59.0"
+    "brighterscript": "^0.60.6"
   }
 }

--- a/sample/bsconfig.json
+++ b/sample/bsconfig.json
@@ -13,6 +13,7 @@
         "@rokucommunity/bslint"
     ],
     "createPackage": true,
+    "retainStagingDir": true,
     "diagnosticFilters": [
         "components/roku_modules/**/*.*",
         "source/roku_modules/**/*.*",

--- a/sample/components/screens/VideoScreen.bs
+++ b/sample/components/screens/VideoScreen.bs
@@ -2,7 +2,6 @@
 ' This product includes software developed at Datadog (https://www.datadoghq.com/).
 ' Copyright 2022-Today Datadog, Inc.
 
-
 import "pkg:/source/roku_modules/datadogroku/datadogSdk.brs"
 import "pkg:/source/roku_modules/datadogroku/internalLogger.brs"
 import "pkg:/source/roku_modules/datadogroku/timeUtils.brs"

--- a/sample/package.json
+++ b/sample/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@rokucommunity/bslint": "^0.7.4",
-    "brighterscript": "^0.59.0"
+    "brighterscript": "^0.60.6"
   },
   "dependencies": {
     "datadog-roku": "../"

--- a/test/bsconfig.json
+++ b/test/bsconfig.json
@@ -12,7 +12,7 @@
         "@rokucommunity/bslint"
     ],
     "createPackage": true,
-    "retainStagingFolder": true,
+    "retainStagingDir": true,
     "diagnosticFilters": [
         "components/roku_modules/**/*.*",
         "source/roku_modules/**/*.*",

--- a/test/package.json
+++ b/test/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@rokucommunity/bslint": "^0.7.4",
-    "brighterscript": "^0.59.0"
+    "brighterscript": "^0.60.6"
   },
   "dependencies": {
     "datadog-roku": "../"

--- a/tools/copyright/check_copyright.sh
+++ b/tools/copyright/check_copyright.sh
@@ -17,7 +17,6 @@ function files {
 
 FILES_WITH_MISSING_LICENSE=""
 
-
 for file in $(files); do
 	if ! grep -q "Apache License Version 2.0" "$file"; then
 		FILES_WITH_MISSING_LICENSE="${FILES_WITH_MISSING_LICENSE}\n${file}"


### PR DESCRIPTION
[0.60.6](https://github.com/rokucommunity/brighterscript/compare/v0.60.5...0.60.6)
- 2022-11-08
 - double `super` call transpile in subclasses ([#740](https://github.com/rokucommunity/brighterscript/pull/740))
 - issues with Roku doc scraper and adds missing components ([#736](https://github.com/rokucommunity/brighterscript/pull/736))

[0.60.5](https://github.com/rokucommunity/brighterscript/compare/v0.60.4...0.60.5)
- 2022-11-03
 - Refactor SymbolTable and AST parent logic so that SymbolTables get their parent symbol table from its own (AstNode)
([#732](https://github.com/rokucommunity/brighterscript/pull/732))
 - Significant performance boost in `validate()` by caching `getCallableByName`
([#739](https://github.com/rokucommunity/brighterscript/pull/739))
 - Add diagnostic when using namespaces as variables ([#738](https://github.com/rokucommunity/brighterscript/pull/738))
 - Fix crash in `getDefinition` ([#734](https://github.com/rokucommunity/brighterscript/pull/734))

[0.60.4](https://github.com/rokucommunity/brighterscript/compare/v0.60.3...0.60.4)
- 2022-10-28
 - Add `name` to symbol table ([#728](https://github.com/rokucommunity/brighterscript/pull/728))
 - Allow `continue` as local var ([#730](https://github.com/rokucommunity/brighterscript/pull/730))
 - language server semanticToken request now waits until validate finishes
([#727](https://github.com/rokucommunity/brighterscript/pull/727))

[0.60.3](https://github.com/rokucommunity/brighterscript/compare/v0.60.2...0.60.3)
- 2022-10-20
 - better parse recovery for unknown function parameter types ([#722](https://github.com/rokucommunity/brighterscript/pull/722))

[0.60.2](https://github.com/rokucommunity/brighterscript/compare/v0.60.1...0.60.2)
- 2022-10-18
 - if statement block var bug ([#698](https://github.com/rokucommunity/brighterscript/pull/698))

[0.60.1](https://github.com/rokucommunity/brighterscript/compare/v0.60.0...0.60.1)
- 2022-10-18
 - Beter location for bs1042 ([#719](https://github.com/rokucommunity/brighterscript/pull/719))

[0.60.0](https://github.com/rokucommunity/brighterscript/compare/v0.59.0...0.60.0)
- 2022-10-10
 - goto definition for enum statements and enum members ([#715](https://github.com/rokucommunity/brighterscript/pull/715))
 - nested namespace support ([#708](https://github.com/rokucommunity/brighterscript/pull/708))
 - upgrade to [roku-deploy@3.9.2](https://github.com/rokucommunity/roku-deploy/blob/master/CHANGELOG.md#392---2022-10-03). Notable changes since 3.9.1:
     - Replace minimatch with picomatch
([roku-deploy#101](https://github.com/rokucommunity/roku-deploy/pull/101))
 - fixes signature help resolution for callexpressions ([#707](https://github.com/rokucommunity/brighterscript/pull/707))
 - Fix transpilation of simple else block with leading comment ([#712](https://github.com/rokucommunity/brighterscript/pull/712))
