### PR TITLE
RUMM-2487 capture last exit reason

### DIFF
--- a/dist/components/core/MultiTrackUploaderTask.brs
+++ b/dist/components/core/MultiTrackUploaderTask.brs
@@ -70,7 +70,8 @@ sub uploadAvailableFilesForTrack(trackInfo as object)
 end sub
 
 ' ----------------------------------------------------------------
-' Verify if the given file is uploadable
+' Verify if the given file is uploadable, meaning it's name is a timestamp,
+' and it's old enough that no writer will attempt appending data in it.
 ' @param path (string) the path of the file to upload
 ' @return (boolean) if the file is valid for upload
 ' ----------------------------------------------------------------

--- a/dist/components/core/MultiTrackUploaderTask.brs
+++ b/dist/components/core/MultiTrackUploaderTask.brs
@@ -75,6 +75,10 @@ end sub
 ' @return (boolean) if the file is valid for upload
 ' ----------------------------------------------------------------
 function isFileValidForUpload(filename as string) as boolean
+    if (filename.Left(1) = "_")
+        ddLogVerbose("Ignoring file " + filename)
+        return false
+    end if
     fileTimestamp& = strToLong(filename)
     uploadTimestamp& = fileTimestamp& + 30000
     currentTimestamp& = getTimestamp()

--- a/dist/components/core/WriterTask.brs
+++ b/dist/components/core/WriterTask.brs
@@ -73,7 +73,7 @@ function getWriteableFile(eventSize as integer) as string
     folderExists = m.fileSystem.Exists(folderPath)
     if (not folderExists)
         ddLogVerbose("Folder for track " + m.top.trackType + " doesn't exist")
-        mkdirs(folderPath)
+        mkDirs(folderPath)
     end if
     currentTimestamp& = getTimestamp()
     filenames = ListDir(folderPath).ToArray()

--- a/dist/components/rum/RumActionScope.xml
+++ b/dist/components/rum/RumActionScope.xml
@@ -8,6 +8,7 @@
     <script type="text/brightscript" uri="pkg:/source/timeUtils.brs" />
     <script type="text/brightscript" uri="pkg:/source/rum/rumRawEvents.brs" />
     <script type="text/brightscript" uri="pkg:/source/rum/rumHelper.brs" />
+    <script type="text/brightscript" uri="pkg:/source/fileUtils.brs" />
     <script type="text/brightscript" uri="pkg:/source/datadogSdk.brs" />
     <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
 </component>

--- a/dist/components/rum/RumAgent.xml
+++ b/dist/components/rum/RumAgent.xml
@@ -7,6 +7,7 @@
         <field id="service" type="string" />
         <field id="keepAliveDelayMs" type="integer" value="15000" />
         <field id="sessionSampleRate" type="integer" value="100" />
+        <field id="lastExitOrTerminationReason" type="string" />
         <field id="uploader" type="node" />
         <field id="writer" type="node" />
         <field id="rumScope" type="node" />
@@ -16,12 +17,15 @@
         <function name="addAction" />
         <function name="addError" />
         <function name="addResource" />
+        <function name="sendCrash" />
         <function name="addConfigTelemetry" />
         <function name="addErrorTelemetry" />
         <function name="addDebugTelemetry" />
     </interface>
     <script type="text/brightscript" uri="pkg:/components/rum/RumAgent.brs" />
     <script type="text/brightscript" uri="pkg:/source/rum/rumRawEvents.brs" />
+    <script type="text/brightscript" uri="pkg:/source/rum/rumHelper.brs" />
+    <script type="text/brightscript" uri="pkg:/source/fileUtils.brs" />
     <script type="text/brightscript" uri="pkg:/source/internalLogger.brs" />
     <script type="text/brightscript" uri="pkg:/source/datadogSdk.brs" />
     <script type="text/brightscript" uri="pkg:/source/bslib.brs" />

--- a/dist/components/rum/RumCrashReporterTask.brs
+++ b/dist/components/rum/RumCrashReporterTask.brs
@@ -1,0 +1,135 @@
+' Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+' This product includes software developed at Datadog (https://www.datadoghq.com/).
+' Copyright 2022-Today Datadog, Inc.
+'import "pkg:/source/fileUtils.bs"
+' *****************************************************************
+' * RumCrashReporterTask : a node capable of writing data to a file on disk
+' *****************************************************************
+'import "pkg:/source/rum/rumHelper.bs"
+
+' ----------------------------------------------------------------
+' Initialize the component
+' ----------------------------------------------------------------
+sub init()
+    ddLogThread("RumCrashReporterTask.init()")
+    m.port = createObject("roMessagePort")
+    m.top.functionName = "sendCrashReport"
+end sub
+
+' ----------------------------------------------------------------
+' Reads the last known view event and send the crash report
+' ----------------------------------------------------------------
+sub sendCrashReport()
+    ddLogThread("RumCrashReporterTask.sendCrashReport()")
+    currentSessionlastViewEventFilePath = lastViewEventFilePath(m.top.instanceId)
+    unexpectedExitStatus = [
+        "EXIT_BRIGHTSCRIPT_CRASH"
+        "EXIT_BRIGHTSCRIPT_TIMEOUT"
+        "EXIT_GRAPHICS_NOT_RELEASED"
+        "EXIT_SIGNAL_TIMEOUT"
+        "EXIT_OUT_OF_MEMORY"
+        "EXIT_MEM_LIMIT_EXCEEDED_FG"
+        "EXIT_MEM_LIMIT_EXCEEDED_BG"
+    ]
+    keep = false
+    for each status in unexpectedExitStatus
+        if (m.top.lastExitOrTerminationReason = status)
+            keep = true
+        end if
+    end for
+    if (not keep)
+        ddLogInfo("Last exit status " + m.top.lastExitOrTerminationReason + " is not a crash, ignoring")
+    end if
+    folderPath = trackFolderPath("rum")
+    filenames = ListDir(folderPath)
+    for each filename in filenames
+        filePath = folderPath + "/" + filename
+        ddLogVerbose("RumCrashreporterTask, checking file: " + filename)
+        if (filePath = currentSessionlastViewEventFilePath)
+            ddLogVerbose("Ignoring current session file: " + filename)
+        else if (filename.Left(10) = "_last_view")
+            if (keep)
+                ddLogVerbose("Found last view file " + filePath)
+                sendCrashReportFromViewEventFile(filePath)
+            end if
+            ddLogVerbose("Deleting file " + filePath)
+            DeleteFile(filePath)
+        end if
+    end for
+    ddLogVerbose("RumCrashreporterTask, all checks done")
+end sub
+
+' ----------------------------------------------------------------
+' Sends a crash report linked to the view stored in the given path
+' @param filepath (string) the path to the file holding the last known view event
+' ----------------------------------------------------------------
+sub sendCrashReportFromViewEventFile(filepath as string)
+    ddLogVerbose("Reading file " + filepath)
+    lastViewEventJson = ReadAsciiFile(filepath)
+    if (lastViewEventJson = "" or lastViewEventJson = invalid)
+        ddLogWarning("A crash was detected but the last known view is empty, ignoring")
+        return
+    end if
+    ddLogVerbose("Parsing event from " + filepath)
+    lastViewEvent = ParseJson(lastViewEventJson)
+    if (lastViewEvent = invalid)
+        ddLogError("A crash was detected but the last view event is invalid")
+        ddLogError(lastViewEventJson)
+        return
+    end if
+    print "LastView:"; lastViewEvent
+    timeSpentNs& = lastViewEvent.view.time_spent + 100000000 ' 100 ms after last known timestamp
+    timeSpentMs& = nanosToMillis(timeSpentNs&)
+    timestamp& = timeSpentMs& + lastViewEvent.date
+    print "estimated timestamp: "; timestamp&
+    crashEvent = {
+        _dd: {
+            format_version: 2
+            session: {
+                plan: 1
+            }
+        }
+        application: {
+            id: lastViewEvent.application.id
+        }
+        context: m.global.datadogContext
+        date: timestamp&
+        error: {
+            id: CreateObject("roDeviceInfo").GetRandomUUID()
+            is_crash: true
+            message: "Channel stopped unexpectedly"
+            source: "source"
+            source_type: agentSource()
+            stack: ""
+            type: m.top.lastExitOrTerminationReason
+        }
+        service: lastViewEvent.service
+        session: {
+            has_replay: false
+            id: lastViewEvent.session.id
+            type: "user"
+        }
+        source: agentSource()
+        type: "error"
+        usr: lastViewEvent.usr
+        version: lastViewEvent.version
+        view: {
+            id: lastViewEvent.view.id
+            url: lastViewEvent.view.url
+            name: lastViewEvent.view.name
+        }
+    }
+    ddLogInfo("RumCrashreporterTask, writing crash")
+    m.top.writer.writeEvent = FormatJson(crashEvent)
+    sleep(50)
+    lastViewEvent._dd.document_version = lastViewEvent._dd.document_version + 1
+    lastViewEvent.view.error = {
+        count: lastViewEvent.view.error.count + 1
+    }
+    lastViewEvent.view.crash = {
+        count: 1
+    }
+    lastViewEvent.view.time_spent = timeSpentNs&
+    ddLogInfo("RumCrashreporterTask, writing view update")
+    m.top.writer.writeEvent = FormatJson(lastViewEvent)
+end sub

--- a/dist/components/rum/RumCrashReporterTask.brs
+++ b/dist/components/rum/RumCrashReporterTask.brs
@@ -35,6 +35,7 @@ sub sendCrashReport()
     for each status in unexpectedExitStatus
         if (m.top.lastExitOrTerminationReason = status)
             keep = true
+            exit for
         end if
     end for
     if (not keep)
@@ -44,7 +45,7 @@ sub sendCrashReport()
     filenames = ListDir(folderPath)
     for each filename in filenames
         filePath = folderPath + "/" + filename
-        ddLogVerbose("RumCrashreporterTask, checking file: " + filename)
+        ddLogVerbose("RumCrashReporterTask, checking file: " + filename)
         if (filePath = currentSessionlastViewEventFilePath)
             ddLogVerbose("Ignoring current session file: " + filename)
         else if (filename.Left(10) = "_last_view")
@@ -56,7 +57,7 @@ sub sendCrashReport()
             DeleteFile(filePath)
         end if
     end for
-    ddLogVerbose("RumCrashreporterTask, all checks done")
+    ddLogVerbose("RumCrashReporterTask, all checks done")
 end sub
 
 ' ----------------------------------------------------------------
@@ -77,11 +78,9 @@ sub sendCrashReportFromViewEventFile(filepath as string)
         ddLogError(lastViewEventJson)
         return
     end if
-    print "LastView:"; lastViewEvent
-    timeSpentNs& = lastViewEvent.view.time_spent + 100000000 ' 100 ms after last known timestamp
+    timeSpentNs& = lastViewEvent.view.time_spent + millisToNanos(100) ' 100 ms after last known timestamp
     timeSpentMs& = nanosToMillis(timeSpentNs&)
     timestamp& = timeSpentMs& + lastViewEvent.date
-    print "estimated timestamp: "; timestamp&
     crashEvent = {
         _dd: {
             format_version: 2
@@ -119,7 +118,7 @@ sub sendCrashReportFromViewEventFile(filepath as string)
             name: lastViewEvent.view.name
         }
     }
-    ddLogInfo("RumCrashreporterTask, writing crash")
+    ddLogInfo("RumCrashReporterTask, writing crash")
     m.top.writer.writeEvent = FormatJson(crashEvent)
     sleep(50)
     lastViewEvent._dd.document_version = lastViewEvent._dd.document_version + 1
@@ -130,6 +129,6 @@ sub sendCrashReportFromViewEventFile(filepath as string)
         count: 1
     }
     lastViewEvent.view.time_spent = timeSpentNs&
-    ddLogInfo("RumCrashreporterTask, writing view update")
+    ddLogInfo("RumCrashReporterTask, writing view update")
     m.top.writer.writeEvent = FormatJson(lastViewEvent)
 end sub

--- a/dist/components/rum/RumCrashReporterTask.xml
+++ b/dist/components/rum/RumCrashReporterTask.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<component name="RumCrashReporterTask" extends="Task" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://devtools.web.roku.com/schema/RokuSceneGraph.xsd">
+    <interface>
+        <field id="lastExitOrTerminationReason" type="string" />
+        <field id="instanceId" type="string" />
+        <field id="writer" type="node" />
+    </interface>
+    <script type="text/brightscript" uri="pkg:/components/rum/RumCrashReporterTask.brs" />
+    <script type="text/brightscript" uri="pkg:/source/datadogSdk.brs" />
+    <script type="text/brightscript" uri="pkg:/source/fileUtils.brs" />
+    <script type="text/brightscript" uri="pkg:/source/internalLogger.brs" />
+    <script type="text/brightscript" uri="pkg:/source/timeUtils.brs" />
+    <script type="text/brightscript" uri="pkg:/source/rum/rumHelper.brs" />
+    <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
+</component>

--- a/dist/components/rum/RumTelemetryScope.xml
+++ b/dist/components/rum/RumTelemetryScope.xml
@@ -7,6 +7,7 @@
     <script type="text/brightscript" uri="pkg:/source/timeUtils.brs" />
     <script type="text/brightscript" uri="pkg:/source/rum/rumRawEvents.brs" />
     <script type="text/brightscript" uri="pkg:/source/rum/rumHelper.brs" />
+    <script type="text/brightscript" uri="pkg:/source/fileUtils.brs" />
     <script type="text/brightscript" uri="pkg:/source/internalLogger.brs" />
     <script type="text/brightscript" uri="pkg:/source/datadogSdk.brs" />
     <script type="text/brightscript" uri="pkg:/source/bslib.brs" />

--- a/dist/components/rum/RumViewScope.xml
+++ b/dist/components/rum/RumViewScope.xml
@@ -7,7 +7,9 @@
     </interface>
     <script type="text/brightscript" uri="pkg:/components/rum/RumViewScope.brs" />
     <script type="text/brightscript" uri="pkg:/source/timeUtils.brs" />
+    <script type="text/brightscript" uri="pkg:/source/rum/rumSessionState.brs" />
     <script type="text/brightscript" uri="pkg:/source/rum/rumRawEvents.brs" />
     <script type="text/brightscript" uri="pkg:/source/rum/rumHelper.brs" />
+    <script type="text/brightscript" uri="pkg:/source/fileUtils.brs" />
     <script type="text/brightscript" uri="pkg:/source/datadogSdk.brs" />
 </component>

--- a/dist/source/datadogSdk.brs
+++ b/dist/source/datadogSdk.brs
@@ -22,10 +22,6 @@ sub initialize(configuration as object)
                 return {}
             end if
         end function)(configuration)
-    print "Launch args:"
-    for each key in configuration.launchArgs
-        print key; " -> "; configuration.launchArgs[key]; " ["; type(key); "]"
-    end for
     ' Standard global fields
     m.global.addFields({
         datadogVerbosity: 0

--- a/dist/source/fileUtils.brs
+++ b/dist/source/fileUtils.brs
@@ -17,13 +17,32 @@ function trackFolderPath(trackType as string, version = 1 as integer) as string
 end function
 
 ' ----------------------------------------------------------------
+' Makes sure the parent folder for the given path exists (e.g. to
+' be able to write to the path)
+' @param path (string) the path to a file or folder
+' @return (string) true if the directory was created or already exists
+' ----------------------------------------------------------------
+function mkParentDirs(path as string) as boolean
+    ddLogVerbose("mkParentDirs(" + path + ")")
+    ' Early exit, path contains invalid chars
+    dirPath = CreateObject("roPath", path)
+    if (not dirPath.IsValid())
+        message = "Can't make parent directory, path is invalid: " + path
+        ddLogWarning(message)
+        return false
+    end if
+    folderData = dirPath.Split()
+    return mkDirs(folderData.parent)
+end function
+
+' ----------------------------------------------------------------
 ' Create a directory (and all intermediate directories), similar
 ' to the `mkdir -p` command in linux
 ' @param path (string) the path to a folder
 ' @return (boolean) true if the directory was created or already exists
 ' ----------------------------------------------------------------
-function mkdirs(path as string) as boolean
-    ddLogVerbose("mkdirs(" + path + ")")
+function mkDirs(path as string) as boolean
+    ddLogVerbose("mkDirs(" + path + ")")
     fileSystem = CreateObject("roFileSystem")
     ' Early exist, dir already exists
     if (fileSystem.Exists(path))
@@ -47,7 +66,7 @@ function mkdirs(path as string) as boolean
     folderData = dirPath.Split()
     ' Ensure parent exists
     if (folderData.parent <> "" and folderData.parent <> (folderData.phy + "/"))
-        if (not mkdirs(folderData.parent))
+        if (not mkDirs(folderData.parent))
             return false
         end if
     end if

--- a/dist/source/rum/rumHelper.brs
+++ b/dist/source/rum/rumHelper.brs
@@ -1,14 +1,31 @@
 ' Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 ' This product includes software developed at Datadog (https://www.datadoghq.com/).
 ' Copyright 2022-Today Datadog, Inc.
-
+'import "pkg:/source/fileUtils.bs"
 '*****************************************************************
 '* Utilities to inspect RUM events
 '*****************************************************************
+
+' ----------------------------------------------------------------
+' Verifies if the given resource object is valid
+' @param resource (object) the resource object
+' @return (boolean) whether the resource object is valid
+' ----------------------------------------------------------------
 function isValidResource(resource as object) as boolean
     status = resource.status
     if (status = "ok" or status = "" or status = invalid)
         return (resource.url <> invalid and resource.transferTime <> invalid)
     end if
     return false
+end function
+
+' ----------------------------------------------------------------
+' Computes the path the the copy of the last view event
+' @param instanceId (string) the current SDK instance id (renewed
+' at every initialization)
+' @return (string) the file path where the event should be stored
+' ----------------------------------------------------------------
+function lastViewEventFilePath(instanceId as string) as string
+    folderPath = trackFolderPath("rum")
+    return folderPath + "/_last_view_" + instanceId
 end function

--- a/dist/source/timeUtils.brs
+++ b/dist/source/timeUtils.brs
@@ -18,6 +18,17 @@ function getTimestamp() as longinteger
 end function
 
 ' ----------------------------------------------------------------
+' Converts a duration in nanoseconds (longinteger) into a duration in milliseconds (longinteger)
+' @param nanoseconds (longinteger) a duration in nanoseconds
+' @return (longinteger) the duration in milliseconds
+' ----------------------------------------------------------------
+function nanosToMillis(nanoseconds as longinteger) as longinteger
+    ratio& = 1000000
+    result& = nanoseconds / ratio&
+    return result&
+end function
+
+' ----------------------------------------------------------------
 ' Converts a duration in milliseconds (longinteger) into a duration in seconds (double)
 ' @param milliseconds (longinteger) a duration in milliseconds
 ' @return (double) the duration in seconds

--- a/library/components/core/MultiTrackUploaderTask.bs
+++ b/library/components/core/MultiTrackUploaderTask.bs
@@ -80,6 +80,11 @@ end sub
 ' @return (boolean) if the file is valid for upload
 ' ----------------------------------------------------------------
 function isFileValidForUpload(filename as string) as boolean
+    if (filename.Left(1) = "_")
+        ddLogVerbose("Ignoring file " + filename)
+        return false
+    end if
+
     fileTimestamp& = strToLong(filename)
     uploadTimestamp& = fileTimestamp& + 30000
     currentTimestamp& = getTimestamp()

--- a/library/components/core/MultiTrackUploaderTask.bs
+++ b/library/components/core/MultiTrackUploaderTask.bs
@@ -75,7 +75,8 @@ sub uploadAvailableFilesForTrack(trackInfo as object)
 end sub
 
 ' ----------------------------------------------------------------
-' Verify if the given file is uploadable
+' Verify if the given file is uploadable, meaning it's name is a timestamp,
+' and it's old enough that no writer will attempt appending data in it.
 ' @param path (string) the path of the file to upload
 ' @return (boolean) if the file is valid for upload
 ' ----------------------------------------------------------------

--- a/library/components/core/WriterTask.bs
+++ b/library/components/core/WriterTask.bs
@@ -80,7 +80,7 @@ function getWriteableFile(eventSize as integer) as string
     folderExists = m.fileSystem.Exists(folderPath)
     if (not folderExists)
         ddLogVerbose("Folder for track " + m.top.trackType + " doesn't exist")
-        mkdirs(folderPath)
+        mkDirs(folderPath)
     end if
 
     currentTimestamp& = getTimestamp()

--- a/library/components/rum/RumAgent.bs
+++ b/library/components/rum/RumAgent.bs
@@ -3,6 +3,7 @@
 ' Copyright 2022-Today Datadog, Inc.
 
 import "pkg:/source/rum/rumRawEvents.bs"
+import "pkg:/source/rum/rumHelper.bs"
 import "pkg:/source/datadogSdk.bs"
 import "pkg:/source/internalLogger.bs"
 
@@ -26,9 +27,10 @@ end sub
 ' ----------------------------------------------------------------
 sub rumAgentLoop()
     ddLogThread("RumAgent.rumAgentLoop()")
+    ensureSetup()
+    sendCrash(m.top.lastExitOrTerminationReason)
     while(true)
         msg = wait(m.top.keepAliveDelayMs, m.port)
-        ensureSetup()
         m.top.rumScope@.handleEvent(keepAliveEvent(), m.top.writer)
         msgType = type(msg)
         if (msgType <> "Invalid")
@@ -91,6 +93,20 @@ sub addResource(resource as object)
 end sub
 
 ' ----------------------------------------------------------------
+' Sends a crash report from a previous view
+' @param lastExitOrTerminationReason (object) the lastExitOrTerminationReason parameter
+' from the channel's RunUserInterface
+' ----------------------------------------------------------------
+sub sendCrash(lastExitOrTerminationReason as string)
+    ensureSetup()
+    crashReporter = CreateObject("roSGNode", "RumCrashReporterTask")
+    crashReporter.writer = m.top.writer
+    crashReporter.lastExitOrTerminationReason = lastExitOrTerminationReason
+    crashReporter.instanceId = m.instanceId
+    crashReporter.control = "RUN"
+end sub
+
+' ----------------------------------------------------------------
 ' Adds a telemetry config event
 ' @param configuration (object) the configuration information
 ' ----------------------------------------------------------------
@@ -136,17 +152,19 @@ end sub
 ' ----------------------------------------------------------------
 sub ensureRumScope()
     if (m.top.rumScope = invalid)
-        ddLogVerbose("Creating RumApplicationScope")
-        m.top.rumScope = CreateObject("roSGNode", "RumApplicationScope")
-
-        m.top.rumScope.applicationId = m.top.applicationId
-        m.top.rumScope.service = m.top.service
-        m.top.rumScope.sessionSampleRate = m.top.sessionSampleRate
-
+        m.instanceId = CreateObject("roDeviceInfo").GetRandomUUID()
+        ddLogWarning("RumViewScope.instanceId:" + m.instanceId)
         m.global.addFields({ datadogRumContext: {} })
         datadogRumContext = m.global.datadogRumContext
         datadogRumContext.applicationId = m.top.applicationId
+        datadogRumContext.instanceId = m.instanceId
         m.global.setField("datadogRumContext", datadogRumContext)
+
+        ddLogVerbose("Creating RumApplicationScope")
+        m.top.rumScope = CreateObject("roSGNode", "RumApplicationScope")
+        m.top.rumScope.applicationId = m.top.applicationId
+        m.top.rumScope.service = m.top.service
+        m.top.rumScope.sessionSampleRate = m.top.sessionSampleRate
     end if
 end sub
 

--- a/library/components/rum/RumAgent.xml
+++ b/library/components/rum/RumAgent.xml
@@ -18,6 +18,7 @@ Copyright 2022-Today Datadog, Inc.
         <field id="service" type="string" />
         <field id="keepAliveDelayMs" type="integer" value="15000" />
         <field id="sessionSampleRate" type="integer" value="100" />
+        <field id="lastExitOrTerminationReason" type="string" />
 
         <!-- Dependency Injection -->
         <field id="uploader" type="node" />
@@ -31,6 +32,7 @@ Copyright 2022-Today Datadog, Inc.
         <function name="addAction" />
         <function name="addError" />
         <function name="addResource" />
+        <function name="sendCrash" />
 
         <!-- Internal telemetry -->
         <function name="addConfigTelemetry" />

--- a/library/components/rum/RumCrashReporterTask.bs
+++ b/library/components/rum/RumCrashReporterTask.bs
@@ -1,0 +1,141 @@
+' Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+' This product includes software developed at Datadog (https://www.datadoghq.com/).
+' Copyright 2022-Today Datadog, Inc.
+
+import "pkg:/source/fileUtils.bs"
+
+' *****************************************************************
+' * RumCrashReporterTask : a node capable of writing data to a file on disk
+' *****************************************************************
+
+import "pkg:/source/rum/rumHelper.bs"
+
+' ----------------------------------------------------------------
+' Initialize the component
+' ----------------------------------------------------------------
+sub init()
+    ddLogThread("RumCrashReporterTask.init()")
+    m.port = createObject("roMessagePort")
+    m.top.functionName = "sendCrashReport"
+end sub
+
+' ----------------------------------------------------------------
+' Reads the last known view event and send the crash report
+' ----------------------------------------------------------------
+sub sendCrashReport()
+    ddLogThread("RumCrashReporterTask.sendCrashReport()")
+    currentSessionlastViewEventFilePath = lastViewEventFilePath(m.top.instanceId)
+
+    unexpectedExitStatus = [
+        "EXIT_BRIGHTSCRIPT_CRASH",
+        "EXIT_BRIGHTSCRIPT_TIMEOUT",
+        "EXIT_GRAPHICS_NOT_RELEASED",
+        "EXIT_SIGNAL_TIMEOUT",
+        "EXIT_OUT_OF_MEMORY",
+        "EXIT_MEM_LIMIT_EXCEEDED_FG",
+        "EXIT_MEM_LIMIT_EXCEEDED_BG"
+    ]
+    keep = false
+    for each status in unexpectedExitStatus
+        if (m.top.lastExitOrTerminationReason = status)
+            keep = true
+        end if
+    end for
+
+    if (not keep)
+        ddLogInfo("Last exit status " + m.top.lastExitOrTerminationReason + " is not a crash, ignoring")
+    end if
+
+    folderPath = trackFolderPath("rum")
+    filenames = ListDir(folderPath)
+    for each filename in filenames
+        filePath = folderPath + "/" + filename
+        ddLogVerbose("RumCrashreporterTask, checking file: " + filename)
+        if (filePath = currentSessionlastViewEventFilePath)
+            ddLogVerbose("Ignoring current session file: " + filename)
+        else if (filename.Left(10) = "_last_view")
+            if (keep)
+                ddLogVerbose("Found last view file " + filePath)
+                sendCrashReportFromViewEventFile(filePath)
+            end if
+            ddLogVerbose("Deleting file " + filePath)
+            DeleteFile(filePath)
+        end if
+    end for
+
+    ddLogVerbose("RumCrashreporterTask, all checks done")
+end sub
+
+' ----------------------------------------------------------------
+' Sends a crash report linked to the view stored in the given path
+' @param filepath (string) the path to the file holding the last known view event
+' ----------------------------------------------------------------
+sub sendCrashReportFromViewEventFile(filepath as string)
+
+    ddLogVerbose("Reading file " + filepath)
+    lastViewEventJson = ReadAsciiFile(filepath)
+    if (lastViewEventJson = "" or lastViewEventJson = invalid)
+        ddLogWarning("A crash was detected but the last known view is empty, ignoring")
+        return
+    end if
+
+    ddLogVerbose("Parsing event from " + filepath)
+    lastViewEvent = ParseJson(lastViewEventJson)
+    if (lastViewEvent = invalid)
+        ddLogError("A crash was detected but the last view event is invalid")
+        ddLogError(lastViewEventJson)
+        return
+    end if
+
+    print "LastView:"; lastViewEvent
+    timeSpentNs& = lastViewEvent.view.time_spent + 100000000 ' 100 ms after last known timestamp
+    timeSpentMs& = nanosToMillis(timeSpentNs&)
+    timestamp& = timeSpentMs& + lastViewEvent.date
+    print "estimated timestamp: "; timestamp&
+    crashEvent = {
+        _dd: {
+            format_version: 2,
+            session: { plan: 1 }
+        },
+        application: {
+            id: lastViewEvent.application.id
+        },
+        context: m.global.datadogContext,
+        date: timestamp&,
+        error: {
+            id: CreateObject("roDeviceInfo").GetRandomUUID(),
+            is_crash: true,
+            message: "Channel stopped unexpectedly",
+            source: "source",
+            source_type: agentSource(),
+            stack: "",
+            type: m.top.lastExitOrTerminationReason
+        },
+        service: lastViewEvent.service,
+        session: {
+            has_replay: false,
+            id: lastViewEvent.session.id,
+            type: "user"
+        },
+        source: agentSource(),
+        type: "error",
+        usr: lastViewEvent.usr,
+        version: lastViewEvent.version,
+        view: {
+            id: lastViewEvent.view.id,
+            url: lastViewEvent.view.url,
+            name: lastViewEvent.view.name
+        }
+    }
+
+    ddLogInfo("RumCrashreporterTask, writing crash")
+    m.top.writer.writeEvent = FormatJson(crashEvent)
+
+    sleep(50)
+    lastViewEvent._dd.document_version = lastViewEvent._dd.document_version + 1
+    lastViewEvent.view.error = { count: lastViewEvent.view.error.count + 1 }
+    lastViewEvent.view.crash = { count: 1 }
+    lastViewEvent.view.time_spent = timeSpentNs&
+    ddLogInfo("RumCrashreporterTask, writing view update")
+    m.top.writer.writeEvent = FormatJson(lastViewEvent)
+end sub

--- a/library/components/rum/RumCrashReporterTask.bs
+++ b/library/components/rum/RumCrashReporterTask.bs
@@ -39,6 +39,7 @@ sub sendCrashReport()
     for each status in unexpectedExitStatus
         if (m.top.lastExitOrTerminationReason = status)
             keep = true
+            exit for
         end if
     end for
 
@@ -50,7 +51,7 @@ sub sendCrashReport()
     filenames = ListDir(folderPath)
     for each filename in filenames
         filePath = folderPath + "/" + filename
-        ddLogVerbose("RumCrashreporterTask, checking file: " + filename)
+        ddLogVerbose("RumCrashReporterTask, checking file: " + filename)
         if (filePath = currentSessionlastViewEventFilePath)
             ddLogVerbose("Ignoring current session file: " + filename)
         else if (filename.Left(10) = "_last_view")
@@ -62,8 +63,7 @@ sub sendCrashReport()
             DeleteFile(filePath)
         end if
     end for
-
-    ddLogVerbose("RumCrashreporterTask, all checks done")
+    ddLogVerbose("RumCrashReporterTask, all checks done")
 end sub
 
 ' ----------------------------------------------------------------
@@ -87,11 +87,9 @@ sub sendCrashReportFromViewEventFile(filepath as string)
         return
     end if
 
-    print "LastView:"; lastViewEvent
-    timeSpentNs& = lastViewEvent.view.time_spent + 100000000 ' 100 ms after last known timestamp
+    timeSpentNs& = lastViewEvent.view.time_spent + millisToNanos(100) ' 100 ms after last known timestamp
     timeSpentMs& = nanosToMillis(timeSpentNs&)
     timestamp& = timeSpentMs& + lastViewEvent.date
-    print "estimated timestamp: "; timestamp&
     crashEvent = {
         _dd: {
             format_version: 2,
@@ -128,7 +126,7 @@ sub sendCrashReportFromViewEventFile(filepath as string)
         }
     }
 
-    ddLogInfo("RumCrashreporterTask, writing crash")
+    ddLogInfo("RumCrashReporterTask, writing crash")
     m.top.writer.writeEvent = FormatJson(crashEvent)
 
     sleep(50)
@@ -136,6 +134,6 @@ sub sendCrashReportFromViewEventFile(filepath as string)
     lastViewEvent.view.error = { count: lastViewEvent.view.error.count + 1 }
     lastViewEvent.view.crash = { count: 1 }
     lastViewEvent.view.time_spent = timeSpentNs&
-    ddLogInfo("RumCrashreporterTask, writing view update")
+    ddLogInfo("RumCrashReporterTask, writing view update")
     m.top.writer.writeEvent = FormatJson(lastViewEvent)
 end sub

--- a/library/components/rum/RumCrashReporterTask.xml
+++ b/library/components/rum/RumCrashReporterTask.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+This product includes software developed at Datadog (https://www.datadoghq.com/).
+Copyright 2022-Today Datadog, Inc.
+-->
+<component name="RumCrashReporterTask" extends="Task" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://devtools.web.roku.com/schema/RokuSceneGraph.xsd">
+
+    <script type="text/brightscript" uri="pkg:/components/rum/RumCrashReporterTask.bs" />
+    <script type="text/brightscript" uri="pkg:/source/datadogSdk.bs" />
+    <script type="text/brightscript" uri="pkg:/source/fileUtils.bs" />
+    <script type="text/brightscript" uri="pkg:/source/internalLogger.bs" />
+    <script type="text/brightscript" uri="pkg:/source/timeUtils.bs" />
+
+    <interface>
+        <field id="lastExitOrTerminationReason" type="string" />
+        <field id="instanceId" type="string" />
+        <field id="writer" type="node" />
+    </interface>
+
+</component>

--- a/library/components/rum/RumViewScope.bs
+++ b/library/components/rum/RumViewScope.bs
@@ -5,8 +5,9 @@
 import "pkg:/source/datadogSdk.bs"
 import "pkg:/source/internalLogger.bs"
 import "pkg:/source/timeUtils.bs"
-import "pkg:/source/rum/rumRawEvents.bs"
 import "pkg:/source/rum/rumHelper.bs"
+import "pkg:/source/rum/rumRawEvents.bs"
+import "pkg:/source/rum/rumSessionState.bs"
 
 ' ****************************************************************
 ' * RumViewScope: handles the View level
@@ -27,6 +28,7 @@ sub init()
     m.resourceCount = 0
     datadogRumContext = m.global.datadogRumContext
     datadogRumContext.viewId = m.viewId
+    m.instanceId = datadogRumContext.instanceId ?? ""
     m.global.setField("datadogRumContext", datadogRumContext)
 end sub
 
@@ -414,7 +416,7 @@ end sub
 ' ----------------------------------------------------------------
 sub sendViewUpdate(writer as object)
     timestamp& = getTimestamp()
-    ddLogVerbose("Sending view update")
+    ddLogThread("Sending view update")
 
     context = getRumContext(invalid)
 
@@ -453,5 +455,21 @@ sub sendViewUpdate(writer as object)
         }
     }
 
-    writer.writeEvent = FormatJson(viewEvent)
+    jsonEvent = FormatJson(viewEvent)
+    writer.writeEvent = jsonEvent
+
+    if (m.instanceId <> invalid and m.instanceId <> "")
+        path = lastViewEventFilePath(m.instanceId)
+        DeleteFile(path)
+        if (context.sessionState = RumSessionState.tracked)
+            ddLogVerbose("Keeping track of the last known view into " + path)
+            viewEvent._dd.lastEvent = true
+            jsonEvent = FormatJson(viewEvent)
+            WriteAsciiFile(path, jsonEvent)
+        else
+            ddLogInfo("Session not tracked, clear last known view")
+        end if
+    else
+        ddLogWarning("Invalid or empty instance id... ignoring for now")
+    end if
 end sub

--- a/library/source/datadogSdk.bs
+++ b/library/source/datadogSdk.bs
@@ -16,10 +16,6 @@
 sub initialize(configuration as object)
 
     launchArgs = configuration.launchArgs ?? {}
-    print "Launch args:"
-    for each key in configuration.launchArgs
-        print key; " -> "; configuration.launchArgs[key]; " ["; type(key); "]"
-    end for
 
     ' Standard global fields
     m.global.addFields({

--- a/library/source/fileUtils.bs
+++ b/library/source/fileUtils.bs
@@ -19,13 +19,34 @@ function trackFolderPath(trackType as string, version = 1 as integer) as string
 end function
 
 ' ----------------------------------------------------------------
+' Makes sure the parent folder for the given path exists (e.g. to
+' be able to write to the path)
+' @param path (string) the path to a file or folder
+' @return (string) true if the directory was created or already exists
+' ----------------------------------------------------------------
+function mkParentDirs(path as string) as boolean
+    ddLogVerbose("mkParentDirs(" + path + ")")
+
+    ' Early exit, path contains invalid chars
+    dirPath = CreateObject("roPath", path)
+    if (not dirPath.IsValid())
+        message = "Can't make parent directory, path is invalid: " + path
+        ddLogWarning(message)
+        return false
+    end if
+
+    folderData = dirPath.Split()
+    return mkDirs(folderData.parent)
+end function
+
+' ----------------------------------------------------------------
 ' Create a directory (and all intermediate directories), similar
 ' to the `mkdir -p` command in linux
 ' @param path (string) the path to a folder
 ' @return (boolean) true if the directory was created or already exists
 ' ----------------------------------------------------------------
-function mkdirs(path as string) as boolean
-    ddLogVerbose("mkdirs(" + path + ")")
+function mkDirs(path as string) as boolean
+    ddLogVerbose("mkDirs(" + path + ")")
 
     fileSystem = CreateObject("roFileSystem")
 
@@ -50,7 +71,7 @@ function mkdirs(path as string) as boolean
 
     ' Ensure parent exists
     if (folderData.parent <> "" and folderData.parent <> (folderData.phy + "/"))
-        if (not mkdirs(folderData.parent))
+        if (not mkDirs(folderData.parent))
             return false
         end if
     end if

--- a/library/source/rum/rumHelper.bs
+++ b/library/source/rum/rumHelper.bs
@@ -2,14 +2,32 @@
 ' This product includes software developed at Datadog (https://www.datadoghq.com/).
 ' Copyright 2022-Today Datadog, Inc.
 
+import "pkg:/source/fileUtils.bs"
+
 '*****************************************************************
 '* Utilities to inspect RUM events
 '*****************************************************************
 
+' ----------------------------------------------------------------
+' Verifies if the given resource object is valid
+' @param resource (object) the resource object
+' @return (boolean) whether the resource object is valid
+' ----------------------------------------------------------------
 function isValidResource(resource as object) as boolean
     status = resource.status
     if (status = "ok" or status = "" or status = invalid)
         return (resource.url <> invalid and resource.transferTime <> invalid)
     end if
     return false
+end function
+
+' ----------------------------------------------------------------
+' Computes the path the the copy of the last view event
+' @param instanceId (string) the current SDK instance id (renewed
+' at every initialization)
+' @return (string) the file path where the event should be stored
+' ----------------------------------------------------------------
+function lastViewEventFilePath(instanceId as string) as string
+    folderPath = trackFolderPath("rum")
+    return folderPath + "/_last_view_" + instanceId
 end function

--- a/library/source/timeUtils.bs
+++ b/library/source/timeUtils.bs
@@ -19,6 +19,17 @@ function getTimestamp() as longinteger
 end function
 
 ' ----------------------------------------------------------------
+' Converts a duration in nanoseconds (longinteger) into a duration in milliseconds (longinteger)
+' @param nanoseconds (longinteger) a duration in nanoseconds
+' @return (longinteger) the duration in milliseconds
+' ----------------------------------------------------------------
+function nanosToMillis(nanoseconds as longinteger) as longinteger
+    ratio& = 1000000
+    result& = nanoseconds / ratio&
+    return result&
+end function
+
+' ----------------------------------------------------------------
 ' Converts a duration in milliseconds (longinteger) into a duration in seconds (double)
 ' @param milliseconds (longinteger) a duration in milliseconds
 ' @return (double) the duration in seconds

--- a/test/components/TestRunner.bs
+++ b/test/components/TestRunner.bs
@@ -12,6 +12,7 @@ import "pkg:/source/testFramework/UTF.brs"
 import "pkg:/source/asserts/Asserts.bs"
 
 import "pkg:/source/tests/Test__fileUtils.bs"
+import "pkg:/source/tests/Test__timeUtils.bs"
 import "pkg:/source/tests/Test__datadog.bs"
 import "pkg:/source/tests/core/Test__MultitrackUploaderTask.bs"
 import "pkg:/source/tests/core/Test__WriterTask.bs"
@@ -21,7 +22,9 @@ import "pkg:/source/tests/rum/Test__RumAgent.bs"
 import "pkg:/source/tests/rum/Test__RumApplicationScope.bs"
 import "pkg:/source/tests/rum/Test__RumSessionScope.bs"
 import "pkg:/source/tests/rum/Test__RumViewScope.bs"
+import "pkg:/source/tests/rum/Test__RumViewScope.bs"
 import "pkg:/source/tests/rum/Test__RumTelemetryScope.bs"
+import "pkg:/source/tests/rum/Test__RumCrashReporterTask.bs"
 
 import "pkg:/source/roku_modules/datadogroku/datadogSdk.brs"
 import "pkg:/source/roku_modules/datadogroku/fileUtils.brs"
@@ -48,6 +51,7 @@ sub runTests()
     Runner.SetFunctions([
         TestSuite__Datadog,
         TestSuite__FileUtils,
+        TestSuite__TimeUtils,
         TestSuite__MultiTrackUploaderTask
         TestSuite__WriterTask,
         TestSuite__RumAgent,
@@ -56,6 +60,7 @@ sub runTests()
         TestSuite__RumActionScope,
         TestSuite__RumViewScope,
         TestSuite__RumTelemetryScope,
+        TestSuite__RumCrashReporterTask,
         TestSuite__LogsAgent
     ])
 

--- a/test/source/asserts/Asserts.bs
+++ b/test/source/asserts/Asserts.bs
@@ -243,6 +243,45 @@ class BaseAssert
     end function
 
     ' ----------------------------------------------------------------
+    ' @param expected (dynamic) the expected value to be close to the actual
+    ' @param offset (dynamic) the allowed offset between the actual and expected values
+    ' @param msg (string) the error message to use
+    ' @return (BaseAssert) this for chaining purposes
+    ' ----------------------------------------------------------------
+    function isCloseTo(expected as dynamic, offset = Constants.EPSILON as dynamic, msg = "" as string) as BaseAssert
+        if (not TF_Utils__IsNumber(m.actual))
+            throw {
+                number: m.errorCode,
+                message: "Expected " + TF_Utils__AsString(m.actual) + " to be a number (integer, longinteger, float or double) but was " + type(m.actual)
+            }
+        else if (not TF_Utils__IsNumber(expected))
+            throw {
+                number: m.errorCode,
+                message: "Expected " + TF_Utils__AsString(expected) + " to be a number (integer, longinteger, float or double) but was " + type(expected)
+            }
+        else if (not TF_Utils__IsNumber(offset))
+            throw {
+                number: m.errorCode,
+                message: "Expected " + TF_Utils__AsString(offset) + " to be a number (integer, longinteger, float or double) but was " + type(offset)
+            }
+        end if
+
+        diff = Abs(m.actual - expected)
+        if (diff > offset)
+            if (msg = "")
+                msg = "Expected " + TF_Utils__AsString(m.actual) + " to be close to " + TF_Utils__AsString(expected)
+            end if
+
+            throw {
+                number: m.errorCode,
+                message: msg
+            }
+        end if
+
+        return m
+    end function
+
+    ' ----------------------------------------------------------------
     ' @param msg (string) the error message to use
     ' @return (BaseAssert) this for chaining purposes
     ' ----------------------------------------------------------------

--- a/test/source/tests/Test__fileUtils.bs
+++ b/test/source/tests/Test__fileUtils.bs
@@ -14,9 +14,17 @@ function TestSuite__FileUtils() as object
     this.addTest("WhenMkDirsExisting_ThenDoNothing", FileUtilsTest__WhenMkDirsExisting_ThenDoNothing)
     this.addTest("WhenMkDirs_ThenCreateParentDirs", FileUtilsTest__WhenMkDirs_ThenCreateParentDirs)
     this.addTest("WhenMkDirsInvalidPath_ThenDoNothing", FileUtilsTest__WhenMkDirsInvalidPath_ThenDoNothing)
+
+    this.addTest("WhenMkParentDirs_ThenCreateDir", FileUtilsTest__WhenMkParentDirs_ThenCreateDir)
+    this.addTest("WhenMkParentDirsExisting_ThenDoNothing", FileUtilsTest__WhenMkParentDirsExisting_ThenDoNothing)
+    this.addTest("WhenMkParentDirs_ThenCreateParentDirs", FileUtilsTest__WhenMkParentDirs_ThenCreateParentDirs)
+    this.addTest("WhenMkParentDirsInvalidPath_ThenDoNothing", FileUtilsTest__WhenMkParentDirsInvalidPath_ThenDoNothing)
+
     this.addTest("WhenTrackFolderPath_ThenComputePath", FileUtilsTest__WhenTrackFolderPath_ThenComputePath)
+
     this.addTest("WhenAppendAsciiFile_ThenAppendsToExistingFile", FileUtilsTest__WhenAppendAsciiFile_ThenAppendsToExistingFile)
     this.addTest("WhenAppendAsciiFile_ThenAppendsToEmptyFile", FileUtilsTest__WhenAppendAsciiFile_ThenAppendsToEmptyFile)
+
     this.addTest("WhenStrToLong_ThenReturnsLong", FileUtilsTest__WhenStrToLong_ThenReturnsLong)
     this.addTest("WhenStrToLongOnString_ThenReturnsLong", FileUtilsTest__WhenStrToLongOnString_ThenReturnsLong)
 
@@ -24,7 +32,7 @@ function TestSuite__FileUtils() as object
 end function
 
 '----------------------------------------------------------------
-' Checks that mkdirs creates the required directory
+' Checks that mkDirs creates the required directory
 '----------------------------------------------------------------
 function FileUtilsTest__WhenMkDirs_ThenCreateDir() as string
     ' Given
@@ -35,7 +43,7 @@ function FileUtilsTest__WhenMkDirs_ThenCreateDir() as string
     end if
 
     ' When
-    result = datadogroku_mkdirs(path)
+    result = datadogroku_mkDirs(path)
 
     ' Then
     Assert.that(result).isTrue("Expected result to be true")
@@ -44,7 +52,7 @@ function FileUtilsTest__WhenMkDirs_ThenCreateDir() as string
 end function
 
 '----------------------------------------------------------------
-' Checks that mkdirs does nothing if folder already exists
+' Checks that mkDirs does nothing if folder already exists
 '----------------------------------------------------------------
 function FileUtilsTest__WhenMkDirsExisting_ThenDoNothing() as string
     ' Given
@@ -55,8 +63,8 @@ function FileUtilsTest__WhenMkDirsExisting_ThenDoNothing() as string
     end if
 
     ' When
-    result = datadogroku_mkdirs(path)
-    result2 = datadogroku_mkdirs(path)
+    result = datadogroku_mkDirs(path)
+    result2 = datadogroku_mkDirs(path)
 
     ' Then
     Assert.that(result).isTrue("Expected result to be true")
@@ -66,7 +74,7 @@ function FileUtilsTest__WhenMkDirsExisting_ThenDoNothing() as string
 end function
 
 '----------------------------------------------------------------
-' Checks that mkdirs creates all intermediate directories
+' Checks that mkDirs creates all intermediate directories
 '----------------------------------------------------------------
 function FileUtilsTest__WhenMkDirs_ThenCreateParentDirs() as string
     ' Given
@@ -81,7 +89,7 @@ function FileUtilsTest__WhenMkDirs_ThenCreateParentDirs() as string
     end if
 
     ' When
-    result = datadogroku_mkdirs(path)
+    result = datadogroku_mkDirs(path)
 
     ' Then
     Assert.that(result).isTrue("Expected result to be true")
@@ -90,7 +98,7 @@ function FileUtilsTest__WhenMkDirs_ThenCreateParentDirs() as string
 end function
 
 '----------------------------------------------------------------
-' Checks that mkdirs fails silently when an invalid path is provided
+' Checks that mkDirs fails silently when an invalid path is provided
 ' cf: https://developer.roku.com/en-gb/docs/developer-program/getting-started/architecture/file-system.md
 '----------------------------------------------------------------
 function FileUtilsTest__WhenMkDirsInvalidPath_ThenDoNothing() as string
@@ -103,11 +111,107 @@ function FileUtilsTest__WhenMkDirsInvalidPath_ThenDoNothing() as string
     end if
 
     ' When
-    result = datadogroku_mkdirs(path)
+    result = datadogroku_mkDirs(path)
 
     ' Then
     Assert.that(result).isFalse("Expected result to be false")
     Assert.that(fileSystem.Exists(path)).isFalse("Random folder at " + path + " shouldn't exist")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Checks that mkParentDirs creates the required directory
+'----------------------------------------------------------------
+function FileUtilsTest__WhenMkParentDirs_ThenCreateDir() as string
+    ' Given
+    fileSystem = CreateObject("roFileSystem")
+    path = IG_GetOneOf(["cachefs", "tmp"]) + ":/" + IG_GetString(16)
+    filePath = path + "/" + IG_GetString(16)
+    if (fileSystem.Exists(filePath))
+        return "Random folder at " + filePath + " shouldn't exist"
+    end if
+
+    ' When
+    result = datadogroku_mkParentDirs(filePath)
+
+    ' Then
+    Assert.that(result).isTrue("Expected result to be true")
+    Assert.that(fileSystem.Exists(path)).isTrue("Random folder at " + path + " should exist")
+    Assert.that(fileSystem.Exists(filePath)).isFalse("Random folder/file at " + filePath + " shouldn't exist")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Checks that mkparentdirs does nothing if folder already exists
+'----------------------------------------------------------------
+function FileUtilsTest__WhenMkParentDirsExisting_ThenDoNothing() as string
+    ' Given
+    fileSystem = CreateObject("roFileSystem")
+    path = IG_GetOneOf(["cachefs", "tmp"]) + ":/" + IG_GetString(16)
+    filePath = path + "/" + IG_GetString(16)
+    if (fileSystem.Exists(path))
+        return "Random folder at " + path + " shouldn't exist"
+    end if
+
+    ' When
+    result = datadogroku_mkParentDirs(filePath)
+    result2 = datadogroku_mkparentdirs(filePath)
+
+    ' Then
+    Assert.that(result).isTrue("Expected result to be true")
+    Assert.that(result2).isTrue("Expected result2 to be true")
+    Assert.that(fileSystem.Exists(path)).isTrue("Random folder at " + path + " should exist")
+    Assert.that(fileSystem.Exists(filePath)).isFalse("Random folder/file at " + filePath + " shouldn't exist")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Checks that mkParentDirs creates all intermediate directories
+'----------------------------------------------------------------
+function FileUtilsTest__WhenMkParentDirs_ThenCreateParentDirs() as string
+    ' Given
+    fileSystem = CreateObject("roFileSystem")
+    folderNames = IG_GetArray(["string", "string", "string", "string"])
+    path = IG_GetOneOf(["cachefs", "tmp"]) + ":"
+    for each folderName in folderNames
+        path = path + "/" + folderName
+    end for
+    filePath = path + "/" + IG_GetString(16)
+    if (fileSystem.Exists(path))
+        return "Random folder at " + path + " shouldn't exist"
+    end if
+
+    ' When
+    result = datadogroku_mkParentDirs(filePath)
+
+    ' Then
+    Assert.that(result).isTrue("Expected result to be true")
+    Assert.that(fileSystem.Exists(path)).isTrue("Random folder at " + path + " should exist")
+    Assert.that(fileSystem.Exists(filePath)).isFalse("Random folder/file at " + filePath + " shouldn't exist")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Checks that mkParentDirs fails silently when an invalid path is provided
+' cf: https://developer.roku.com/en-gb/docs/developer-program/getting-started/architecture/file-system.md
+'----------------------------------------------------------------
+function FileUtilsTest__WhenMkParentDirsInvalidPath_ThenDoNothing() as string
+    ' Given
+    fileSystem = CreateObject("roFileSystem")
+    invalidChar = IG_GetOneOf(["<", ">", """", ":", "|", "?", "*"])
+    path = IG_GetOneOf(["foo", "bar"]) + ":/" + IG_GetString(8) + invalidChar + IG_GetString(8)
+    filePath = path + "/" + IG_GetString(16)
+    if (fileSystem.Exists(path))
+        return "Random folder at " + path + " shouldn't exist"
+    end if
+
+    ' When
+    result = datadogroku_mkParentDirs(filePath)
+
+    ' Then
+    Assert.that(result).isFalse("Expected result to be false")
+    Assert.that(fileSystem.Exists(path)).isFalse("Random folder at " + path + " shouldn't exist")
+    Assert.that(fileSystem.Exists(filePath)).isFalse("Random folder/file at " + filePath + " shouldn't exist")
     return ""
 end function
 

--- a/test/source/tests/Test__timeUtils.bs
+++ b/test/source/tests/Test__timeUtils.bs
@@ -1,0 +1,168 @@
+' Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+' This product includes software developed at Datadog (https://www.datadoghq.com/).
+' Copyright 2022-Today Datadog, Inc.
+
+'----------------------------------------------------------------
+' Main setup function.
+' @return A configured TestSuite object.
+'----------------------------------------------------------------
+function TestSuite__TimeUtils() as object
+    this = BaseTestSuite()
+    this.Name = "TimeUtils"
+
+    this.addTest("WhenGetTimestamp_ThenReturnsTimestampInMilliseconds", TimeUtilsTest__WhenGetTimestamp_ThenReturnsTimestampInMilliseconds)
+
+    this.addTest("WhenNanosToMillis_ThenConvertsToMillis", TimeUtilsTest__WhenNanosToMillis_ThenConvertsToMillis)
+    this.addTest("WhenMillisToNanos_ThenConvertsToNanos", TimeUtilsTest__WhenMillisToNanos_ThenConvertsToNanos)
+    this.addTest("WhenMillisToSecs_ThenConvertsToSeconds", TimeUtilsTest__WhenMillisToSecs_ThenConvertsToSeconds)
+    this.addTest("WhenSecsToNanos_ThenConvertsToNanos", TimeUtilsTest__WhenSecsToNanos_ThenConvertsToNanos)
+    this.addTest("WhenSecsToMillis_ThenConvertsToMillis", TimeUtilsTest__WhenSecsToMillis_ThenConvertsToMillis)
+
+    return this
+end function
+
+'----------------------------------------------------------------
+'
+'----------------------------------------------------------------
+function TimeUtilsTest__WhenGetTimestamp_ThenReturnsTimestampInMilliseconds() as string
+    ' Given
+    ' hardcoded values to get a valid range
+    timestampMS_1jan2023 = 1672527600000
+    timestampMS_1jan2024 = 1704063600000
+
+    ' When
+    result = datadogroku_getTimestamp()
+
+    ' Then
+    Assert.that(result).isInRange(timestampMS_1jan2023, timestampMS_1jan2024)
+    return ""
+end function
+
+'----------------------------------------------------------------
+'
+'----------------------------------------------------------------
+function TimeUtilsTest__WhenNanosToMillis_ThenConvertsToMillis() as string
+    ' Given
+    hardcoded = [
+        { ms: 4815, ns: 4815162342 },
+        { ms: 42, ns: 42164851 },
+        { ms: 15, ns: 15764985 },
+        { ms: 1, ns: 1000000 },
+        { ms: 0, ns: 756491 },
+        { ms: 0, ns: 104862 },
+        { ms: 0, ns: 1 },
+        { ms: 0, ns: 0 },
+    ]
+
+    for each testcase in hardcoded
+        ' When
+        result = datadogroku_nanosToMillis(testcase.ns)
+
+        ' Then
+        Assert.that(result).isEqualTo(testcase.ms, "Failed to convert " + testcase.ns.toStr() + "ns to " + testcase.ms.toStr() + "ms (was " + result.toStr() + "ms)")
+    end for
+
+    return ""
+end function
+
+'----------------------------------------------------------------
+'
+'----------------------------------------------------------------
+function TimeUtilsTest__WhenMillisToNanos_ThenConvertsToNanos() as string
+    ' Given
+    hardcoded = [
+        { ms: 4815, ns: 4815000000 },
+        { ms: 42, ns: 42000000 },
+        { ms: 15, ns: 15000000 },
+        { ms: 1, ns: 1000000 },
+        { ms: 0, ns: 0 },
+    ]
+
+    for each testcase in hardcoded
+        ' When
+        result = datadogroku_millisToNanos(testcase.ms)
+
+        ' Then
+        Assert.that(result).isEqualTo(testcase.ns, "Failed to convert " + testcase.ms.toStr() + "ms to " + testcase.ns.toStr() + "ns (was " + result.toStr() + "ns)")
+    end for
+
+    return ""
+end function
+
+'----------------------------------------------------------------
+'
+'----------------------------------------------------------------
+function TimeUtilsTest__WhenMillisToSecs_ThenConvertsToSeconds() as string
+    ' Given
+    hardcoded = [
+        { ms: 48151623, s: 48151.623 },
+        { ms: 1337, s: 1.337 },
+        { ms: 42, s: 0.042 },
+        { ms: 15, s: 0.015 },
+        { ms: 1, s: 0.001 },
+        { ms: 0, s: 0 },
+    ]
+    offset = 0.01 ' 10 ms threshold for floating point errors
+
+    for each testcase in hardcoded
+        ' When
+        result = datadogroku_millisToSec(testcase.ms)
+
+        ' Then
+        Assert.that(result).isCloseTo(testcase.s, offset, "Failed to convert " + testcase.ms.toStr() + "ms to " + testcase.s.toStr() + "s (was " + result.toStr() + "s)")
+    end for
+
+    return ""
+end function
+
+'----------------------------------------------------------------
+'
+'----------------------------------------------------------------
+function TimeUtilsTest__WhenSecsToNanos_ThenConvertsToNanos() as string
+    ' Given
+    hardcoded = [
+        { s: 4.815162342, ns: 4815162342 },
+        { s: 0.1337, ns: 133700000 },
+        { s: 0.042, ns: 42000000 },
+        { s: 0.015, ns: 15000000 },
+        { s: 0.001, ns: 1000000 },
+        { s: 0, ns: 0 },
+    ]
+    offset = 2000000 ' 2 ms threshold because of floating point error
+
+    for each testcase in hardcoded
+        ' When
+        result = datadogroku_secToNanos(testcase.s)
+
+        ' Then
+        Assert.that(result).isCloseTo(testcase.ns, offset, "Failed to convert " + testcase.s.toStr() + "s to " + testcase.ns.toStr() + "ns (was " + result.toStr() + "ns)")
+    end for
+
+    return ""
+end function
+
+'----------------------------------------------------------------
+'
+'----------------------------------------------------------------
+function TimeUtilsTest__WhenSecsToMillis_ThenConvertsToMillis() as string
+    ' Given
+    hardcoded = [
+        { ms: 48151623, s: 48151.623 },
+        { ms: 1337, s: 1.337 },
+        { ms: 42, s: 0.042 },
+        { ms: 15, s: 0.015 },
+        { ms: 1, s: 0.001 },
+        { ms: 0, s: 0 },
+    ]
+    offset = 2 ' 2 ms threshold because of floating point error
+
+    for each testcase in hardcoded
+        ' When
+        result = datadogroku_secToMillis(testcase.s)
+
+        ' Then
+        Assert.that(result).isCloseTo(testcase.ms, offset, "Failed to convert " + testcase.s.toStr() + "s to " + testcase.ms.toStr() + "ms (was " + result.toStr() + "ms)")
+    end for
+
+    return ""
+end function

--- a/test/source/tests/core/Test__MultitrackUploaderTask.bs
+++ b/test/source/tests/core/Test__MultitrackUploaderTask.bs
@@ -24,6 +24,7 @@ function TestSuite__MultiTrackUploaderTask() as object
     this.addTest("WhenInit_UploadsExistingFile_5xx", MultiTrackUploaderTaskTest__WhenInit_UploadsExistingFile_5xx, MultiTrackUploaderTaskTest__SetUp, MultiTrackUploaderTaskTest__TearDown)
 
     this.addTest("WhenInit_IgnoreRecentFile", MultiTrackUploaderTaskTest__WhenInit_IgnoreRecentFile, MultiTrackUploaderTaskTest__SetUp, MultiTrackUploaderTaskTest__TearDown)
+    this.addTest("WhenInit_IgnoreLastEventFile", MultiTrackUploaderTaskTest__WhenInit_IgnoreLastEventFile, MultiTrackUploaderTaskTest__SetUp, MultiTrackUploaderTaskTest__TearDown)
     this.addTest("WhenInit_UploadFilesFromMultipleTracks", MultiTrackUploaderTaskTest__WhenInit_UploadFilesFromMultipleTracks, MultiTrackUploaderTaskTest__SetUp, MultiTrackUploaderTaskTest__TearDown)
 
     this.testUploader = __testUploader
@@ -183,7 +184,7 @@ function MultiTrackUploaderTaskTest__WhenInit_UploadsExistingFile_5xx() as strin
 end function
 
 '----------------------------------------------------------------
-' Given: an uploader and a non-uploadable file
+' Given: an uploader and a non-uploadable file (too recent)
 '  When: waiting for the loop to run
 '  Then: the file is not uploaded and kept
 '----------------------------------------------------------------
@@ -193,7 +194,29 @@ function MultiTrackUploaderTaskTest__WhenInit_IgnoreRecentFile() as string
     currentTimeStamp& = datadogroku_getTimestamp()
     filePath = folderPath + "/" + currentTimeStamp&.toStr()
     m.mockNetworkClient@.stubCall("postFromFile", {}, 202)
-    datadogroku_mkdirs(folderPath)
+    datadogroku_mkDirs(folderPath)
+    WriteAsciiFile(filePath, IG_GetString(128))
+
+    ' When
+    sleep(100)
+
+    ' Then
+    Assert.that(CreateObject("roFileSystem").Exists(filePath)).isTrue("Expected file " + filePath + " to still be present")
+    return m.mockNetworkClient@.assertNoInteractions()
+end function
+
+'----------------------------------------------------------------
+' Given: an uploader and a non-uploadable file (filename doesn't match)
+'  When: waiting for the loop to run
+'  Then: the file is not uploaded and kept
+'----------------------------------------------------------------
+function MultiTrackUploaderTaskTest__WhenInit_IgnoreLastEventFile() as string
+    ' Given
+    folderPath = datadogroku_trackFolderPath(m.fakeTrackType)
+    fakeId = IG_GetString(16)
+    filePath = folderPath + "/_last_view_" + fakeId
+    m.mockNetworkClient@.stubCall("postFromFile", {}, 202)
+    datadogroku_mkDirs(folderPath)
     WriteAsciiFile(filePath, IG_GetString(128))
 
     ' When
@@ -235,8 +258,8 @@ function MultiTrackUploaderTaskTest__WhenInit_UploadFilesFromMultipleTracks() as
     expectedCallArgs1 = { filePath: filePath1, headers: expectedHeaders1, payloadPrefix: m.fakePrefix, payloadPostfix: m.fakePostfix }
     expectedCallArgs2 = { url: fakeUrl2, filePath: filePath2, headers: expectedHeaders2, payloadPrefix: fakePrefix2, payloadPostfix: fakePostfix2 }
     m.mockNetworkClient@.stubCall("postFromFile", {}, 202)
-    datadogroku_mkdirs(folderPath1)
-    datadogroku_mkdirs(folderPath2)
+    datadogroku_mkDirs(folderPath1)
+    datadogroku_mkDirs(folderPath2)
     WriteAsciiFile(filePath1, IG_GetString(128))
     WriteAsciiFile(filePath2, IG_GetString(128))
 
@@ -267,7 +290,7 @@ function __testUploader(statusCode as integer, keepFile as boolean) as string
     expectedHeaders = __buildExpectedHeaders(m.fakeClientToken, m.fakeContentType)
     expectedCallArgs = { filePath: filePath, headers: expectedHeaders, payloadPrefix: m.fakePrefix, payloadPostfix: m.fakePostfix }
     m.mockNetworkClient@.stubCall("postFromFile", expectedCallArgs, statusCode)
-    datadogroku_mkdirs(folderPath)
+    datadogroku_mkDirs(folderPath)
     WriteAsciiFile(filePath, IG_GetString(128))
     datadogroku_ddLogInfo("Wrote data at " + filePath)
 

--- a/test/source/tests/core/Test__WriterTask.bs
+++ b/test/source/tests/core/Test__WriterTask.bs
@@ -30,7 +30,7 @@ sub WriterTaskTest__SetUp()
     m.testSuite.fakeSeparator = IG_GetString(2)
 
     m.testSuite.folderPath = datadogroku_trackFolderPath(fakeTrackType)
-    datadogroku_mkdirs(m.testSuite.folderPath)
+    datadogroku_mkDirs(m.testSuite.folderPath)
 
     ' Tested Node
     m.testSuite.testedTask = CreateObject("roSGNode", "datadogroku_WriterTask")

--- a/test/source/tests/rum/Test__RumCrashReporterTask.bs
+++ b/test/source/tests/rum/Test__RumCrashReporterTask.bs
@@ -1,0 +1,272 @@
+' Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+' This product includes software developed at Datadog (https://www.datadoghq.com/).
+' Copyright 2022-Today Datadog, Inc.
+
+import "pkg:/source/roku_modules/datadogroku/rum/rumHelper.brs"
+import "pkg:/source/roku_modules/datadogroku/fileUtils.brs"
+
+'----------------------------------------------------------------
+' Main setup function.
+' @return (object) a configured TestSuite object.
+'----------------------------------------------------------------
+function TestSuite__RumCrashReporterTask() as object
+    this = BaseTestSuite()
+    this.Name = "RumCrashReporterTask"
+
+    this.addTest("WhenReasonIsValid_ThenWriteErrorAndViewEvents", RumCrashReporterTaskTest__WhenReasonIsValid_ThenWriteErrorAndViewEvents, RumCrashReporterTaskTest__SetUp, RumCrashReporterTaskTest__TearDown)
+    this.addTest("WhenLastViewIsCurrentSession_ThenDoNothing", RumCrashReporterTaskTest__WhenLastViewIsCurrentSession_ThenDoNothing, RumCrashReporterTaskTest__SetUp, RumCrashReporterTaskTest__TearDown)
+    this.addTest("WhenExitreasonInvalid_ThenDoNothing", RumCrashReporterTaskTest__WhenExitreasonInvalid_ThenDoNothing, RumCrashReporterTaskTest__SetUp, RumCrashReporterTaskTest__TearDown)
+
+    return this
+end function
+
+sub RumCrashReporterTaskTest__SetUp()
+    ' Mocks
+    m.testSuite.mockWriter = CreateObject("roSGNode", "MockWriterTask")
+
+    ' Fake data
+    m.testSuite.fakeInstanceId = IG_GetString(32)
+    m.testSuite.fakeGlobalUserInfo = {
+        id: IG_GetString(16),
+        name: IG_GetString(16),
+        email: IG_GetString(16) + "@" + IG_GetString(16) + ".com"
+    }
+    m.testSuite.fakeGlobalContext = {}
+    for i = 1 to 5
+        m.testSuite.fakeGlobalContext[IG_GetString(16) + i.toStr()] = IG_GetOneOf([IG_GetString(12), IG_GetInteger(), IG_GetFloat(), IG_GetBoolean()])
+        m.testSuite.fakeGlobalUserInfo[IG_GetString(16) + i.toStr()] = IG_GetOneOf([IG_GetString(12), IG_GetInteger(), IG_GetFloat(), IG_GetBoolean()])
+    end for
+
+    ' Tested Task
+    m.testSuite.testedTask = CreateObject("roSGNode", "datadogroku_RumCrashReporterTask")
+    m.testSuite.testedTask.writer = m.testSuite.mockWriter
+    m.testSuite.testedTask.instanceId = m.testSuite.fakeInstanceId
+
+    ' Filesystem
+    folder = datadogroku_trackFolderPath("rum")
+    datadogroku_mkDirs(folder)
+end sub
+
+sub RumCrashReporterTaskTest__TearDown()
+    m.testSuite.Delete("mockWriter")
+    m.testSuite.Delete("testedTask")
+end sub
+
+'----------------------------------------------------------------
+' Given: a RumCrashReporterTask
+'  When: last view exists, and exit reason is relevant
+'  Then: writes an error and view events
+'----------------------------------------------------------------
+function RumCrashReporterTaskTest__WhenReasonIsValid_ThenWriteErrorAndViewEvents() as string
+    ' Given
+    fakeExitStatus = IG_GetOneOf([
+        "EXIT_BRIGHTSCRIPT_CRASH",
+        "EXIT_BRIGHTSCRIPT_TIMEOUT",
+        "EXIT_GRAPHICS_NOT_RELEASED",
+        "EXIT_SIGNAL_TIMEOUT",
+        "EXIT_OUT_OF_MEMORY",
+        "EXIT_MEM_LIMIT_EXCEEDED_FG",
+        "EXIT_MEM_LIMIT_EXCEEDED_BG"
+    ])
+    fakePreviousViewEvent = {
+        _dd: {
+            document_version: IG_GetInteger()
+        },
+        application: {
+            id: IG_GetString(16)
+        },
+        context: m.global.datadogContext,
+        date: IG_GetLongInteger(),
+        service: m.fakeGlobalContext,
+        session: {
+            has_replay: false,
+            id: IG_GetString(16),
+            type: "user"
+        },
+        source: IG_GetString(16),
+        type: "view",
+        usr: m.fakeGlobalUserInfo,
+        version: IG_GetString(16),
+        view: {
+            id: IG_GetString(16),
+            url: IG_GetString(16),
+            name: IG_GetString(16),
+            time_spent: IG_GetInteger(),
+            action: { count: IG_GetInteger() },
+            error: { count: IG_GetInteger() },
+            resource: { count: IG_GetInteger() }
+        }
+    }
+    previousInstanceId = IG_GetString(32)
+    lastViewFilePath = datadogroku_lastViewEventFilePath(previousInstanceId)
+    WriteAsciiFile(lastViewFilePath, FormatJson(fakePreviousViewEvent))
+    m.testedTask.lastExitOrTerminationReason = fakeExitStatus
+
+    ' When
+    errorTimestamp& = datadogroku_getTimestamp()
+    m.testedTask.control = "RUN"
+    sleep(100)
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    Assert.that(updates).hasSize(2)
+    errorEvent = ParseJson(updates[0])
+    Assert.that(errorEvent).isNotInvalid()
+    Assert.that(errorEvent.application.id).isEqualTo(fakePreviousViewEvent.application.id)
+    Assert.that(errorEvent.date).isEqualTo(fakePreviousViewEvent.date + 100)
+    Assert.that(errorEvent.service).isEqualTo(fakePreviousViewEvent.service)
+    Assert.that(errorEvent.session.has_replay).isEqualTo(false)
+    Assert.that(errorEvent.session.id).isEqualTo(fakePreviousViewEvent.session.id)
+    Assert.that(errorEvent.session.type).isEqualTo("user")
+    Assert.that(errorEvent.source).isEqualTo("roku")
+    Assert.that(errorEvent.type).isEqualTo("error")
+    Assert.that(errorEvent.version).isEqualTo(fakePreviousViewEvent.version)
+    Assert.that(errorEvent.view.id).isEqualTo(fakePreviousViewEvent.view.id)
+    Assert.that(errorEvent.view.name).isEqualTo(fakePreviousViewEvent.view.name)
+    Assert.that(errorEvent.view.url).isEqualTo(fakePreviousViewEvent.view.url)
+    Assert.that(errorEvent.error.id).isNotEmpty()
+    Assert.that(errorEvent.error.message).isEqualTo("Channel stopped unexpectedly")
+    Assert.that(errorEvent.error.source).isEqualTo("source")
+    Assert.that(errorEvent.error.source_type).isEqualTo("roku")
+    Assert.that(errorEvent.error.stack).isEqualTo("")
+    Assert.that(errorEvent.error.is_crash).isEqualTo(true)
+    Assert.that(errorEvent.error.type).isEqualTo(fakeExitStatus)
+
+    viewEvent = ParseJson(updates[1])
+    Assert.that(viewEvent).isNotInvalid()
+    Assert.that(viewEvent._dd.document_version).isEqualTo(fakePreviousViewEvent._dd.document_version + 1)
+    Assert.that(viewEvent.application.id).isEqualTo(fakePreviousViewEvent.application.id)
+    Assert.that(viewEvent.date).isEqualTo(fakePreviousViewEvent.date)
+    Assert.that(viewEvent.service).isEqualTo(fakePreviousViewEvent.service)
+    Assert.that(viewEvent.session.has_replay).isEqualTo(false)
+    Assert.that(viewEvent.session.id).isEqualTo(fakePreviousViewEvent.session.id)
+    Assert.that(viewEvent.session.type).isEqualTo("user")
+    Assert.that(viewEvent.source).isEqualTo(fakePreviousViewEvent.source)
+    Assert.that(viewEvent.type).isEqualTo("view")
+    Assert.that(viewEvent.version).isEqualTo(fakePreviousViewEvent.version)
+    Assert.that(viewEvent.view.id).isEqualTo(fakePreviousViewEvent.view.id)
+    Assert.that(viewEvent.view.name).isEqualTo(fakePreviousViewEvent.view.name)
+    Assert.that(viewEvent.view.time_spent).isEqualTo(fakePreviousViewEvent.view.time_spent + 100000000)
+    Assert.that(viewEvent.view.url).isEqualTo(fakePreviousViewEvent.view.url)
+    Assert.that(viewEvent.view.action.count).isEqualTo(fakePreviousViewEvent.view.action.count)
+    Assert.that(viewEvent.view.error.count).isEqualTo(fakePreviousViewEvent.view.error.count + 1)
+    Assert.that(viewEvent.view.crash.count).isEqualTo(1)
+    Assert.that(viewEvent.view.resource.count).isEqualTo(fakePreviousViewEvent.view.resource.count)
+
+    Assert_that(CreateObject("roFileSystem").Exists(lastViewFilePath)).isFalse("Expected file " + lastViewFilePath + " to be deleted")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a RumCrashReporterTask
+'  When: last view exists for current instance
+'  Then: ignore and does nothing
+'----------------------------------------------------------------
+function RumCrashReporterTaskTest__WhenLastViewIsCurrentSession_ThenDoNothing() as string
+    ' Given
+    fakeExitStatus = IG_GetOneOf([
+        "EXIT_BRIGHTSCRIPT_CRASH",
+        "EXIT_BRIGHTSCRIPT_TIMEOUT",
+        "EXIT_GRAPHICS_NOT_RELEASED",
+        "EXIT_SIGNAL_TIMEOUT",
+        "EXIT_OUT_OF_MEMORY",
+        "EXIT_MEM_LIMIT_EXCEEDED_FG",
+        "EXIT_MEM_LIMIT_EXCEEDED_BG"
+    ])
+    fakePreviousViewEvent = {
+        _dd: {
+            document_version: IG_GetInteger()
+        },
+        application: {
+            id: IG_GetString(16)
+        },
+        context: m.global.datadogContext,
+        date: IG_GetLongInteger(),
+        service: m.fakeGlobalContext,
+        session: {
+            has_replay: false,
+            id: IG_GetString(16),
+            type: "user"
+        },
+        source: IG_GetString(16),
+        type: "view",
+        usr: m.fakeGlobalUserInfo,
+        version: IG_GetString(16),
+        view: {
+            id: IG_GetString(16),
+            url: IG_GetString(16),
+            name: IG_GetString(16),
+            time_spent: IG_GetInteger(),
+            action: { count: IG_GetInteger() },
+            error: { count: IG_GetInteger() },
+            resource: { count: IG_GetInteger() }
+        }
+    }
+    lastViewFilePath = datadogroku_lastViewEventFilePath(m.fakeInstanceId)
+    WriteAsciiFile(lastViewFilePath, FormatJson(fakePreviousViewEvent))
+    m.testedTask.lastExitOrTerminationReason = fakeExitStatus
+
+    ' When
+    errorTimestamp& = datadogroku_getTimestamp()
+    m.testedTask.control = "RUN"
+    sleep(100)
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    Assert.that(updates).hasSize(0)
+    Assert_that(CreateObject("roFileSystem").Exists(lastViewFilePath)).isTrue("Expected file " + lastViewFilePath + " to be kept")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a RumCrashReporterTask
+'  When: last view exists for current instance
+'  Then: ignore and does nothing
+'----------------------------------------------------------------
+function RumCrashReporterTaskTest__WhenExitreasonInvalid_ThenDoNothing() as string
+    ' Given
+    fakePreviousViewEvent = {
+        _dd: {
+            document_version: IG_GetInteger()
+        },
+        application: {
+            id: IG_GetString(16)
+        },
+        context: m.global.datadogContext,
+        date: IG_GetLongInteger(),
+        service: m.fakeGlobalContext,
+        session: {
+            has_replay: false,
+            id: IG_GetString(16),
+            type: "user"
+        },
+        source: IG_GetString(16),
+        type: "view",
+        usr: m.fakeGlobalUserInfo,
+        version: IG_GetString(16),
+        view: {
+            id: IG_GetString(16),
+            url: IG_GetString(16),
+            name: IG_GetString(16),
+            time_spent: IG_GetInteger(),
+            action: { count: IG_GetInteger() },
+            error: { count: IG_GetInteger() },
+            resource: { count: IG_GetInteger() }
+        }
+    }
+    previousInstanceId = IG_GetString(32)
+    lastViewFilePath = datadogroku_lastViewEventFilePath(previousInstanceId)
+    WriteAsciiFile(lastViewFilePath, FormatJson(fakePreviousViewEvent))
+    m.testedTask.lastExitOrTerminationReason = IG_GetString(16)
+
+    ' When
+    errorTimestamp& = datadogroku_getTimestamp()
+    m.testedTask.control = "RUN"
+    sleep(100)
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    Assert.that(updates).hasSize(0)
+    Assert_that(CreateObject("roFileSystem").Exists(lastViewFilePath)).isFalse("Expected file " + lastViewFilePath + " to be deleted")
+    return ""
+end function

--- a/test/source/tests/rum/Test__RumViewScope.bs
+++ b/test/source/tests/rum/Test__RumViewScope.bs
@@ -2,6 +2,8 @@
 ' This product includes software developed at Datadog (https://www.datadoghq.com/).
 ' Copyright 2022-Today Datadog, Inc.
 
+import "pkg:/source/roku_modules/datadogroku/rum/rumHelper.brs"
+
 '----------------------------------------------------------------
 ' Main setup function.
 ' @return (object) a configured TestSuite object.
@@ -22,6 +24,8 @@ function TestSuite__RumViewScope() as object
     this.addTest("WhenHandleStopViewEventTwice_ThenWriteViewEvent", RumViewScopeTest__WhenHandleStopViewEventTwice_ThenWriteViewEvent, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
     this.addTest("WhenHandleStartViewEvent_ThenWriteViewEvent", RumViewScopeTest__WhenHandleStartViewEvent_ThenWriteViewEvent, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
     this.addTest("WhenStopUnknownView_ThenDoNothing", RumViewScopeTest__WhenStopUnknownView_ThenDoNothing, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
+    this.addTest("WhenHanldeViewUpdate_ThenKeepLastKnownViewEvent", RumViewScopeTest__WhenHandleViewUpdate_ThenKeepLastKnownViewEvent, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
+    this.addTest("WhenHandleViewUpdateNotTracked_ThenDiscardLastKnownViewEvent", RumViewScopeTest__WhenHandleViewUpdateNotTracked_ThenDiscardLastKnownViewEvent, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
 
     this.addTest("WhenHandleAddErrorEvent_ThenWriteViewEvent", RumViewScopeTest__WhenHandleAddErrorEvent_ThenWriteViewEvent, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
     this.addTest("WhenHandleAddErrorEventWithContext_ThenWriteViewEvent", RumViewScopeTest__WhenHandleAddErrorEventWithContext_ThenWriteViewEvent, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
@@ -62,6 +66,7 @@ sub RumViewScopeTest__SetUp()
     m.testSuite.mockActionScope = CreateObject("roSGNode", "MockRumScope")
 
     ' Fake data
+    m.testSuite.fakeInstanceId = IG_GetString(32)
     m.testSuite.fakeViewName = IG_GetString(16)
     m.testSuite.fakeViewUrl = "https://" + IG_GetString(32)
     m.testSuite.fakeActionId = IG_GetString(32)
@@ -78,6 +83,7 @@ sub RumViewScopeTest__SetUp()
         m.testSuite.fakeGlobalUserInfo[IG_GetString(16) + i.toStr()] = IG_GetOneOf([IG_GetString(12), IG_GetInteger(), IG_GetFloat(), IG_GetBoolean()])
     end for
     m.testSuite.global.addFields({ datadogContext: {}, datadogUserInfo: {}, datadogRumContext: {} })
+    m.testSuite.global.setField("datadogRumContext", { instanceId: m.testSuite.fakeInstanceId })
 
     ' Tested Task
     m.testSuite.startTimestamp& = datadogroku_getTimestamp()
@@ -443,6 +449,88 @@ function RumViewScopeTest__WhenStopUnknownView_ThenDoNothing() as string
     ' Then
     updates = m.mockWriter@.getFieldUpdates("writeEvent")
     Assert.that(updates).hasSize(0)
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a RumViewScope
+'  When: handling an event (stopView)
+'  Then: writes a last known view event
+'----------------------------------------------------------------
+function RumViewScopeTest__WhenHandleViewUpdate_ThenKeepLastKnownViewEvent() as string
+    ' Given
+    fakeApplicationId = IG_GetString(32)
+    fakeApplicationVersion = IG_GetString(32)
+    fakeService = IG_GetString(32)
+    fakeSessionId = IG_GetString(32)
+    fakeInstanceId = IG_GetString(32)
+    fakeParentContext = {
+        applicationId: fakeApplicationId,
+        service: fakeService,
+        sessionId: fakeSessionId,
+        applicationVersion: fakeApplicationVersion,
+        sessionState: "tracked"
+    }
+    m.mockParentScope@.stubCall("getRumContext", {}, fakeParentContext)
+    fakeEvent = { mock: "event", eventType: "stopView", viewName: m.fakeViewName, viewUrl: m.fakeViewUrl }
+
+    ' When
+    m.testedScope@.handleEvent(fakeEvent, m.mockWriter)
+
+    ' Then
+    lastKnownFilePath = datadogroku_lastViewEventFilePath(m.fakeInstanceId)
+    Assert_that(CreateObject("roFileSystem").Exists(lastKnownFilePath)).isTrue("Expected file " + lastKnownFilePath + " to still be present")
+
+    viewEvent = ParseJson(ReadAsciiFile(lastKnownFilePath))
+    Assert.that(viewEvent).isNotInvalid()
+    Assert.that(viewEvent._dd.document_version).isEqualTo(1)
+    Assert.that(viewEvent.application.id).isEqualTo(fakeApplicationId)
+    Assert.that(viewEvent.date).isInRange(m.startTimestamp&, m.startTimestamp& + 5)
+    Assert.that(viewEvent.service).isEqualTo(fakeService)
+    Assert.that(viewEvent.session.has_replay).isEqualTo(false)
+    Assert.that(viewEvent.session.id).isNotEmpty()
+    Assert.that(viewEvent.session.type).isEqualTo("user")
+    Assert.that(viewEvent.source).isEqualTo("roku")
+    Assert.that(viewEvent.type).isEqualTo("view")
+    Assert.that(viewEvent.version).isEqualTo(fakeApplicationVersion)
+    Assert.that(viewEvent.view.id).isNotEmpty()
+    Assert.that(viewEvent.view.name).isEqualTo(m.fakeViewName)
+    Assert.that(viewEvent.view.time_spent).isInRange(1000000, 10000000)
+    Assert.that(viewEvent.view.url).isEqualTo(m.fakeViewUrl)
+    Assert.that(viewEvent.view.action.count).isEqualTo(0)
+    Assert.that(viewEvent.view.error.count).isEqualTo(0)
+    Assert.that(viewEvent.view.resource.count).isEqualTo(0)
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a RumViewScope in a non tracked session
+'  When: handling an event (stopView)
+'  Then: discard the last known view event
+'----------------------------------------------------------------
+function RumViewScopeTest__WhenHandleViewUpdateNotTracked_ThenDiscardLastKnownViewEvent() as string
+    ' Given
+    fakeApplicationId = IG_GetString(32)
+    fakeApplicationVersion = IG_GetString(32)
+    fakeService = IG_GetString(32)
+    fakeSessionId = IG_GetString(32)
+    fakeInstanceId = IG_GetString(32)
+    fakeParentContext = {
+        applicationId: fakeApplicationId,
+        service: fakeService,
+        sessionId: fakeSessionId,
+        applicationVersion: fakeApplicationVersion,
+        sessionState: "not_tracked"
+    }
+    m.mockParentScope@.stubCall("getRumContext", {}, fakeParentContext)
+    fakeEvent = { mock: "event", eventType: "stopView", viewName: m.fakeViewName, viewUrl: m.fakeViewUrl }
+
+    ' When
+    m.testedScope@.handleEvent(fakeEvent, m.mockWriter)
+
+    ' Then
+    lastKnownFilePath = datadogroku_lastViewEventFilePath(m.fakeInstanceId)
+    Assert_that(CreateObject("roFileSystem").Exists(lastKnownFilePath)).isFalse("Expected file " + lastKnownFilePath + " to be deleted")
     return ""
 end function
 


### PR DESCRIPTION
### What does this PR do?

The mecanism to track crashes is similar to what we do on iOS: 
- On startup, a channel receives a lestExitOrTerminationReason flag, stating how the last run of the channel ended. 
- Everytime a RUM View is updated, a backup copy is kept on disk
- When the SDK is initialized with this flag provided, and a last view event is available in the backup file, a RUM Error and a RUM View update are sent to DD

### Additional Notes

The SDK uses an `instanceId`, which is unique each time the SDK is initialized, to distinguish the _last view backup_ file from the current session from the one from a previous session, and attach the crash to the relevant view. 
