### PR TITLE
RUMM-3018 fix crash in WriterTask

### DIFF
--- a/dist/components/core/WriterTask.brs
+++ b/dist/components/core/WriterTask.brs
@@ -84,7 +84,14 @@ function getWriteableFile(eventSize as integer) as string
         uploadTimestamp& = fileTimestamp& + 25000
         if ((uploadTimestamp& > currentTimestamp&))
             lastFilePath = folderPath + "/" + lastFilename
-            lastFileSize = m.fileSystem.Stat(lastFilePath).size
+            lastFileSize = (function(lastFilePath, m)
+                    __bsConsequent = m.fileSystem.Stat(lastFilePath).size
+                    if __bsConsequent <> invalid then
+                        return __bsConsequent
+                    else
+                        return m.top.maxBatchSize
+                    end if
+                end function)(lastFilePath, m)
             if (lastFileSize + m.top.payloadSeparator.Len() + eventSize < m.top.maxBatchSize)
                 return folderPath + "/" + lastFilename
             end if

--- a/library/components/core/WriterTask.bs
+++ b/library/components/core/WriterTask.bs
@@ -92,7 +92,7 @@ function getWriteableFile(eventSize as integer) as string
         uploadTimestamp& = fileTimestamp& + 25000
         if ((uploadTimestamp& > currentTimestamp&))
             lastFilePath = folderPath + "/" + lastFilename
-            lastFileSize = m.fileSystem.Stat(lastFilePath).size
+            lastFileSize = m.fileSystem.Stat(lastFilePath).size ?? m.top.maxBatchSize
             if (lastFileSize + m.top.payloadSeparator.Len() + eventSize < m.top.maxBatchSize)
                 return folderPath + "/" + lastFilename
             end if

--- a/test/source/tests/core/Test__WriterTask.bs
+++ b/test/source/tests/core/Test__WriterTask.bs
@@ -14,8 +14,11 @@ function TestSuite__WriterTask() as object
     this.addTest("WhenEvent_ThenAppendEmptyFile", WriterTaskTest__WhenEvent_ThenAppendEmptyFile, WriterTaskTest__SetUp, WriterTaskTest__TearDown)
     this.addTest("WhenEvent_ThenAppendNonEmptyFile", WriterTaskTest__WhenEvent_ThenAppendNonEmptyFile, WriterTaskTest__SetUp, WriterTaskTest__TearDown)
     this.addTest("WhenMultipleEvents_ThenAppendFile", WriterTaskTest__WhenMultipleEvents_ThenAppendFile, WriterTaskTest__SetUp, WriterTaskTest__TearDown)
+
     this.addTest("WhenFileTooLarge_ThenWriteInNewFile", WriterTaskTest__WhenFileTooLarge_ThenWriteInNewFile, WriterTaskTest__SetUp, WriterTaskTest__TearDown)
     this.addTest("WhenFileTooOld_ThenWriteInNewFile", WriterTaskTest__WhenFileTooOld_ThenWriteInNewFile, WriterTaskTest__SetUp, WriterTaskTest__TearDown)
+    this.addTest("WhenFolderExists_ThenWriteInNewFile", WriterTaskTest__WhenFolderExists_ThenWriteInNewFile, WriterTaskTest__SetUp, WriterTaskTest__TearDown)
+
     this.addTest("WhenEmptyEvent_ThenDoNothing", WriterTaskTest__WhenEmptyEvent_ThenDoNothing, WriterTaskTest__SetUp, WriterTaskTest__TearDown)
     this.addTest("WhenEmptyEventWithPreviousFile_ThenDoNothing", WriterTaskTest__WhenEmptyEventWithPreviousFile_ThenDoNothing, WriterTaskTest__SetUp, WriterTaskTest__TearDown)
 
@@ -209,6 +212,34 @@ function WriterTaskTest__WhenFileTooOld_ThenWriteInNewFile() as string
     timestamp& = datadogroku_getTimestamp() - 30000
     filePath = m.folderPath + "/" + timestamp&.toStr()
     WriteAsciiFile(filePath, previousData)
+
+    ' When
+    m.testedTask.writeEvent = fakeEvent
+    sleep(15)
+
+    ' Then
+    filenames = ListDir(m.folderPath)
+    Assert.that(filenames).hasSize(2)
+    content = ReadAsciiFile(m.folderPath + "/" + filenames[0])
+    Assert.that(filenames).contains(timestamp&.toStr())
+    Assert.that(content).isEqualTo(fakeEvent)
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a writer node, an existing folder that matches the file names
+'  When: sending an event (as string)
+'  Then: the file is appended in a new file
+'----------------------------------------------------------------
+function WriterTaskTest__WhenFolderExists_ThenWriteInNewFile() as string
+    ' Given
+    filenames = ListDir(m.folderPath)
+    Assume.that(filenames).isEmpty()
+    previousData = IG_GetString(128)
+    fakeEvent = IG_GetString(128)
+    timestamp& = datadogroku_getTimestamp() - 1000
+    filePath = m.folderPath + "/" + timestamp&.toStr()
+    datadogroku_mkDirs(filePath)
 
     ' When
     m.testedTask.writeEvent = fakeEvent

--- a/test/source/tests/rum/Test__RumAgent.bs
+++ b/test/source/tests/rum/Test__RumAgent.bs
@@ -284,7 +284,7 @@ function RumAgentTest__WhenDoNothing_ThenInitDependencies() as string
         payloadPrefix: "",
         payloadPostfix: "",
         contentType: "text/plain;charset=UTF-8",
-        queryParams: {}
+        queryParams: { ddsource: "roku", ddtags: "sdk_version:1.0.0-dev" }
     })
     return ""
 end function


### PR DESCRIPTION
### What does this PR do?

In some case it seems the filesystem returns invalid when querying a file's size. 
Not sure why it happens, but we're using a folder to mimic this behaviour in the test and ensure we don't crash the host app. 
