### PR TITLE
RUMM-3129 let the RUM track send the env

### DIFF
--- a/dist/components/rum/RumAgent.brs
+++ b/dist/components/rum/RumAgent.brs
@@ -211,7 +211,7 @@ sub ensureUploader()
         contentType: "text/plain;charset=UTF-8"
         queryParams: {
             ddsource: agentSource()
-            ddtags: "sdk_version:" + sdkVersion()
+            ddtags: "sdk_version:" + sdkVersion() + ",env:" + m.top.env
         }
     }
     uploader.tracks = tracks

--- a/dist/components/rum/RumAgent.xml
+++ b/dist/components/rum/RumAgent.xml
@@ -2,6 +2,7 @@
 <component name="RumAgent" extends="Task" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://devtools.web.roku.com/schema/RokuSceneGraph.xsd">
     <interface>
         <field id="site" type="string" value="us1" />
+        <field id="env" type="string" value="" />
         <field id="clientToken" type="string" />
         <field id="applicationId" type="string" />
         <field id="service" type="string" />

--- a/dist/source/datadogSdk.brs
+++ b/dist/source/datadogSdk.brs
@@ -72,6 +72,7 @@ sub initialize(configuration as object, global as object)
             datadogRumAgent: CreateObject("roSGNode", "RumAgent")
         })
         global.datadogRumAgent.site = configuration.site
+        global.datadogRumAgent.env = configuration.env
         global.datadogRumAgent.clientToken = configuration.clientToken
         global.datadogRumAgent.applicationId = configuration.applicationId
         global.datadogRumAgent.service = service

--- a/library/components/rum/RumAgent.bs
+++ b/library/components/rum/RumAgent.bs
@@ -204,7 +204,7 @@ sub ensureUploader()
         payloadPrefix: "",
         payloadPostfix: "",
         contentType: "text/plain;charset=UTF-8",
-        queryParams: { ddsource: agentSource(), ddtags: "sdk_version:" + sdkVersion() }
+        queryParams: { ddsource: agentSource(), ddtags: "sdk_version:" + sdkVersion() + ",env:" + m.top.env }
     }
     uploader.tracks = tracks
     uploader.clientToken = m.top.clientToken

--- a/library/components/rum/RumAgent.xml
+++ b/library/components/rum/RumAgent.xml
@@ -13,6 +13,7 @@ Copyright 2022-Today Datadog, Inc.
 
     <interface>
         <field id="site" type="string" value="us1" />
+        <field id="env" type="string" value="" />
         <field id="clientToken" type="string" />
         <field id="applicationId" type="string" />
         <field id="service" type="string" />

--- a/library/source/datadogSdk.bs
+++ b/library/source/datadogSdk.bs
@@ -51,6 +51,7 @@ sub initialize(configuration as object, global as object)
         ddLogInfo("No RUM agent, creating one")
         global.addFields({ datadogRumAgent: CreateObject("roSGNode", "RumAgent") })
         global.datadogRumAgent.site = configuration.site
+        global.datadogRumAgent.env = configuration.env ?? ""
         global.datadogRumAgent.clientToken = configuration.clientToken
         global.datadogRumAgent.applicationId = configuration.applicationId
         global.datadogRumAgent.service = service

--- a/test/source/tests/rum/Test__RumAgent.bs
+++ b/test/source/tests/rum/Test__RumAgent.bs
@@ -39,6 +39,7 @@ sub RumAgentTest__SetUp()
     m.testSuite.fakeDeviceName = IG_GetString(16)
     m.testSuite.fakeOsVersion = IG_GetString(16)
     m.testSuite.fakeOsVersionMajor = IG_GetString(16)
+    m.testSuite.fakeEnv = IG_GetString(10)
     m.testSuite.fakeSite = IG_GetString(3)
     m.testSuite.fakeClientToken = "pub" + IG_GetString(32)
     m.testSuite.fakeApplicationId = IG_GetString(32)
@@ -54,6 +55,7 @@ sub RumAgentTest__SetUp()
     m.testSuite.testedNode.telemetryScope = m.testSuite.mockTelemetryScope
     m.testSuite.testedNode.keepAliveDelayMs = m.testSuite.fakeKeepAliveDelayMs
     m.testSuite.testedNode.site = m.testSuite.fakeSite
+    m.testSuite.testedNode.env = m.testSuite.fakeEnv
     m.testSuite.testedNode.clientToken = m.testSuite.fakeClientToken
     m.testSuite.testedNode.applicationId = m.testSuite.fakeApplicationId
     m.testSuite.testedNode.service = m.testSuite.fakeService
@@ -278,6 +280,7 @@ function RumAgentTest__WhenDoNothing_ThenInitDependencies() as string
     m.testedNode.rumScope = invalid
     site = IG_GetOneOf(["us1", "us3", "us5", "eu1"])
     m.testedNode.site = site
+    m.testedNode.env = m.fakeEnv
     expectedUrl = datadogroku_getIntakeUrl(site, "rum")
     expectedTrackName = "rum_" + m.testedNode.threadInfo().node.address
 
@@ -311,7 +314,7 @@ function RumAgentTest__WhenDoNothing_ThenInitDependencies() as string
         payloadPrefix: "",
         payloadPostfix: "",
         contentType: "text/plain;charset=UTF-8",
-        queryParams: { ddsource: "roku", ddtags: "sdk_version:1.0.0-dev" }
+        queryParams: { ddsource: "roku", ddtags: "sdk_version:" + datadogroku_sdkVersion() + ",env:" + m.fakeEnv }
     })
     return ""
 end function


### PR DESCRIPTION
### What does this PR do?

Add the `env` in the upload tags to let RUM events use it.