### PR TITLE
RUMM-3412 Fix wrong headers in intake request

### DIFF
--- a/dist/components/core/NetworkClient.brs
+++ b/dist/components/core/NetworkClient.brs
@@ -30,8 +30,6 @@ function postFromFile(url as string, filePath as string, headers as object, payl
     m.urlTransfer.SetUrl(url)
     m.urlTransfer.SetRequest("POST")
     m.urlTransfer.SetCertificatesFile("common:/certs/ca-bundle.crt") ' required for SSL
-    for each header in headers
-        m.urlTransfer.AddHeader(header, headers[header])
-    end for
+    m.urlTransfer.SetHeaders(headers)
     return m.urlTransfer.PostFromString(payload)
 end function

--- a/dist/components/core/NetworkClient.brs
+++ b/dist/components/core/NetworkClient.brs
@@ -29,7 +29,11 @@ function postFromFile(url as string, filePath as string, headers as object, payl
     payload = payloadPrefix + ReadAsciiFile(filePath) + payloadPostfix
     m.urlTransfer.SetUrl(url)
     m.urlTransfer.SetRequest("POST")
-    m.urlTransfer.SetCertificatesFile("common:/certs/ca-bundle.crt") ' required for SSL
-    m.urlTransfer.SetHeaders(headers)
+    if (not m.urlTransfer.SetCertificatesFile("common:/certs/ca-bundle.crt")) ' required for SSL
+        ddLogWarning("Error setting the common certificates file to the intake request; if the issue persists, please contact the support.")
+    endif
+    if (not m.urlTransfer.SetHeaders(headers))
+        ddLogWarning("Error setting headers to the intake request; if the issue persists, please contact the support.")
+    endif
     return m.urlTransfer.PostFromString(payload)
 end function

--- a/dist/components/rum/RumActionScope.brs
+++ b/dist/components/rum/RumActionScope.brs
@@ -150,6 +150,7 @@ sub sendAction(writer as object)
             name: context.viewName
         }
     }
+    ddLogInfo("Tracking " + m.top.actionType + " action '" + m.top.target + "' in view " + context.viewName + " (" + context.viewId + ")")
     writer.writeEvent = FormatJson(actionEvent)
 end sub
 ' ****************************************************************

--- a/dist/components/rum/RumViewScope.brs
+++ b/dist/components/rum/RumViewScope.brs
@@ -198,6 +198,7 @@ sub sendError(message as string, errorType as string, backtrace as dynamic, writ
             name: m.top.viewName
         }
     }
+    ddLogInfo("Tracking error '" + message + "' in view " + m.top.viewName + " (" + m.viewId + ")")
     m.errorCount++
     writer.writeEvent = FormatJson(errorEvent)
 end sub
@@ -295,6 +296,7 @@ sub sendCustomAction(target as string, writer as object)
             name: m.top.viewName
         }
     }
+    ddLogInfo("Tracking custom action '" + target + "' in view " + m.top.viewName + " (" + m.viewId + ")")
     writer.writeEvent = FormatJson(actionEvent)
 end sub
 
@@ -380,6 +382,23 @@ sub sendResource(resource as object, writer as object)
             name: m.top.viewName
         }
     }
+    method = (function(resource)
+            __bsConsequent = resource.method
+            if __bsConsequent <> invalid then
+                return __bsConsequent
+            else
+                return "?"
+            end if
+        end function)(resource)
+    statusCode = (function(resource)
+            __bsConsequent = resource.httpCode
+            if __bsConsequent <> invalid then
+                return __bsConsequent
+            else
+                return 0
+            end if
+        end function)(resource)
+    ddLogInfo("Tracking resource " + method + ":" + resource.url + " -> " + statusCode.toStr() + " in view " + m.top.viewName + " (" + m.viewId + ")")
     m.resourceCount++
     writer.writeEvent = FormatJson(resourceEvent)
 end sub
@@ -455,6 +474,7 @@ sub sendResourceError(status as string, url as dynamic, method as dynamic, write
             name: m.top.viewName
         }
     }
+    ddLogInfo("Tracking resource error " + method + ":" + url + "' in view " + m.top.viewName + " (" + m.viewId + ")")
     writer.writeEvent = FormatJson(errorEvent)
 end sub
 
@@ -518,6 +538,7 @@ sub sendViewUpdate(writer as object)
             }
         }
     }
+    ddLogInfo("Tracking view update for view " + m.top.viewName + " (" + m.viewId + ")")
     jsonEvent = FormatJson(viewEvent)
     writer.writeEvent = jsonEvent
     if (m.instanceId <> invalid and m.instanceId <> "")

--- a/dist/source/fileUtils.brs
+++ b/dist/source/fileUtils.brs
@@ -94,7 +94,7 @@ end function
 ' @return (string) whether the file was successfully appended
 ' ----------------------------------------------------------------
 function AppendAsciiFile(filepath as string, text as string) as boolean
-    ddLogInfo("Appending bytes to " + filepath)
+    ddLogVerbose("Appending bytes to " + filepath)
     byteArray = CreateObject("roByteArray")
     byteArray.FromAsciiString(text)
     return byteArray.AppendFile(filepath)

--- a/library/components/core/NetworkClient.bs
+++ b/library/components/core/NetworkClient.bs
@@ -31,9 +31,14 @@ function postFromFile(url as string, filePath as string, headers as object, payl
 
     m.urlTransfer.SetUrl(url)
     m.urlTransfer.SetRequest("POST")
-    m.urlTransfer.SetCertificatesFile("common:/certs/ca-bundle.crt") ' required for SSL
+    
+    if (not m.urlTransfer.SetCertificatesFile("common:/certs/ca-bundle.crt")) ' required for SSL
+        ddLogWarning("Error setting the common certificates file to the intake request; if the issue persists, please contact the support.")
+    endif
 
-    m.urlTransfer.SetHeaders(headers)
+    if (not m.urlTransfer.SetHeaders(headers))
+        ddLogWarning("Error setting headers to the intake request; if the issue persists, please contact the support.")
+    endif
 
     return m.urlTransfer.PostFromString(payload)
 end function

--- a/library/components/core/NetworkClient.bs
+++ b/library/components/core/NetworkClient.bs
@@ -33,9 +33,7 @@ function postFromFile(url as string, filePath as string, headers as object, payl
     m.urlTransfer.SetRequest("POST")
     m.urlTransfer.SetCertificatesFile("common:/certs/ca-bundle.crt") ' required for SSL
 
-    for each header in headers
-        m.urlTransfer.AddHeader(header, headers[header])
-    end for
+    m.urlTransfer.SetHeaders(headers)
 
     return m.urlTransfer.PostFromString(payload)
 end function

--- a/library/components/rum/RumActionScope.bs
+++ b/library/components/rum/RumActionScope.bs
@@ -154,6 +154,7 @@ sub sendAction(writer as object)
         }
     }
 
+    ddLogInfo("Tracking " + m.top.actionType + " action '" + m.top.target + "' in view " + context.viewName + " (" + context.viewId + ")")
     writer.writeEvent = FormatJson(actionEvent)
 end sub
 

--- a/library/components/rum/RumViewScope.bs
+++ b/library/components/rum/RumViewScope.bs
@@ -199,6 +199,7 @@ sub sendError(message as string, errorType as string, backtrace as dynamic, writ
         }
     }
 
+    ddLogInfo("Tracking error '" + message + "' in view " + m.top.viewName + " (" + m.viewId + ")")
     m.errorCount++
     writer.writeEvent = FormatJson(errorEvent)
 end sub
@@ -296,6 +297,7 @@ sub sendCustomAction(target as string, writer as object)
         }
     }
 
+    ddLogInfo("Tracking custom action '" + target + "' in view " + m.top.viewName + " (" + m.viewId + ")")
     writer.writeEvent = FormatJson(actionEvent)
 end sub
 
@@ -375,6 +377,9 @@ sub sendResource(resource as object, writer as object)
         }
     }
 
+    method = resource.method ?? "?"
+    statusCode = resource.httpCode ?? 0
+    ddLogInfo("Tracking resource " + method + ":" + resource.url + " -> " + statusCode.toStr() + " in view " + m.top.viewName + " (" + m.viewId + ")")
     m.resourceCount++
     writer.writeEvent = FormatJson(resourceEvent)
 end sub
@@ -451,6 +456,7 @@ sub sendResourceError(status as string, url as dynamic, method as dynamic, write
         }
     }
 
+    ddLogInfo("Tracking resource error " + method + ":" + url + "' in view " + m.top.viewName + " (" + m.viewId + ")")
     writer.writeEvent = FormatJson(errorEvent)
 end sub
 
@@ -510,6 +516,7 @@ sub sendViewUpdate(writer as object)
         }
     }
 
+    ddLogInfo("Tracking view update for view " + m.top.viewName + " (" + m.viewId + ")")
     jsonEvent = FormatJson(viewEvent)
     writer.writeEvent = jsonEvent
 

--- a/library/source/fileUtils.bs
+++ b/library/source/fileUtils.bs
@@ -97,7 +97,7 @@ end function
 ' @return (string) whether the file was successfully appended
 ' ----------------------------------------------------------------
 function AppendAsciiFile(filepath as string, text as string) as boolean
-    ddLogInfo("Appending bytes to " + filepath)
+    ddLogVerbose("Appending bytes to " + filepath)
     byteArray = CreateObject("roByteArray")
     byteArray.FromAsciiString(text)
     return byteArray.AppendFile(filepath)

--- a/test/source/tests/rum/Test__RumActionScope.bs
+++ b/test/source/tests/rum/Test__RumActionScope.bs
@@ -54,6 +54,12 @@ sub RumActionScopeTest__SetUp()
         name: IG_GetString(16),
         email: IG_GetString(16) + "@" + IG_GetString(16) + ".com"
     }
+    m.testSuite.fakeParentContext = {
+        applicationId: IG_GetString(32),
+        sessionId: IG_GetString(32),
+        viewId: IG_GetString(32),
+        viewName: IG_GetString(32)
+    }
     m.testSuite.fakeGlobalContext = {}
     for i = 1 to 5
         m.testSuite.fakeGlobalContext[IG_GetString(16) + i.toStr()] = IG_GetOneOf([IG_GetString(12), IG_GetInteger(), IG_GetFloat(), IG_GetBoolean()])
@@ -148,6 +154,7 @@ end function
 function RumActionScopeTest__WhenStoppedIsActive_ThenReturnsFalse() as string
     ' Given
     fakeEvent = { mock: "event", eventType: "any" }
+    m.mockParentScope@.stubCall("getRumContext", { _ph: invalid }, m.fakeParentContext)
 
     ' When
     sleep(150)


### PR DESCRIPTION
### What does this PR do?

The `AddHeader` doesn't overwrite an existing header with the same name. This means that for example the `DD-EVP-ORIGIN` would eventually have a value `roku,roku,roku,roku,roku,roku,roku,roku,roku,roku,roku,roku,roku,roku,roku,roku,roku,…`, which would go over the maximum size of a header.

### Motivation

Fix an issue where some events in a session would stop being sent. 
