### PR TITLE
Improve logs meta data

### DIFF
--- a/dist/components/logs/LogsAgent.brs
+++ b/dist/components/logs/LogsAgent.brs
@@ -143,6 +143,10 @@ sub sendLog(status as object, message as string, attributes as object)
             version: m.top.osVersion
             version_major: m.top.osVersionMajor
         }
+        logger: {
+            thread_name: m.top.threadInfo().currentThread.name
+            version: sdkVersion()
+        }
     }
     for each key in attributes
         logEvent[key] = attributes[key]

--- a/dist/source/datadogSdk.brs
+++ b/dist/source/datadogSdk.brs
@@ -107,7 +107,7 @@ sub initialize(configuration as object, global as object)
         })
         global.datadogLogsAgent.site = configuration.site
         global.datadogLogsAgent.clientToken = configuration.clientToken
-        global.datadogLogsAgent.service = configuration.service
+        global.datadogLogsAgent.service = service
         global.datadogLogsAgent.env = configuration.env
         global.datadogLogsAgent.uploader = global.datadogUploader
         global.datadogLogsAgent.deviceName = deviceName

--- a/library/components/logs/LogsAgent.bs
+++ b/library/components/logs/LogsAgent.bs
@@ -134,16 +134,20 @@ sub sendLog(status as LogStatus, message as string, attributes as object)
         status: status,
         service: m.top.service,
         usr: m.global.datadogUserInfo,
-        device : {
+        device: {
             type: "tv",
             name: m.top.deviceName,
             model: m.top.deviceModel,
             brand: "Roku"
         },
         os: {
-            name : "Roku",
-            version : m.top.osVersion,
-            version_major : m.top.osVersionMajor
+            name: "Roku",
+            version: m.top.osVersion,
+            version_major: m.top.osVersionMajor
+        },
+        logger: {
+            thread_name: m.top.threadInfo().currentThread.name,
+            version: sdkVersion()
         }
     }
     for each key in attributes

--- a/library/source/datadogSdk.bs
+++ b/library/source/datadogSdk.bs
@@ -71,7 +71,7 @@ sub initialize(configuration as object, global as object)
         global.addFields({ datadogLogsAgent: CreateObject("roSGNode", "LogsAgent") })
         global.datadogLogsAgent.site = configuration.site
         global.datadogLogsAgent.clientToken = configuration.clientToken
-        global.datadogLogsAgent.service = configuration.service
+        global.datadogLogsAgent.service = service
         global.datadogLogsAgent.env = configuration.env
         global.datadogLogsAgent.uploader = global.datadogUploader
         global.datadogLogsAgent.deviceName = deviceName

--- a/test/source/tests/logs/Test__LogsAgent.bs
+++ b/test/source/tests/logs/Test__LogsAgent.bs
@@ -74,11 +74,11 @@ sub LogsAgentTest__SetUp()
     m.testSuite.mockWriter = CreateObject("roSGNode", "MockWriterTask")
 
     ' Fake data
-    m.testSuite.fakeDeviceModel = IG_GetString(16) 
+    m.testSuite.fakeDeviceModel = IG_GetString(16)
     m.testSuite.fakeDeviceName = IG_GetString(16)
     m.testSuite.fakeOsVersion = IG_GetString(16)
     m.testSuite.fakeOsVersionMajor = IG_GetString(16)
-    m.testSuite.fakeSite = IG_GetString(3) 
+    m.testSuite.fakeSite = IG_GetString(3)
     m.testSuite.fakeClientToken = "pub" + IG_GetString(32)
     m.testSuite.fakeService = IG_GetString(32)
     m.testSuite.fakeEnv = IG_GetString(8)
@@ -203,6 +203,8 @@ function LogsAgentTest__WhenLogOk_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     return ""
 end function
 
@@ -240,6 +242,8 @@ function LogsAgentTest__WhenLogOkWithCustomAttributes_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     for each key in fakeAttributes
         Assert.that(logEvent[key]).isEqualTo(fakeAttributes[key])
     end for
@@ -281,6 +285,8 @@ function LogsAgentTest__WhenLogOkWithGlobalAttributes_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     for each key in m.fakeGlobalContext
         Assert.that(logEvent[key]).isEqualTo(m.fakeGlobalContext[key])
     end for
@@ -322,6 +328,8 @@ function LogsAgentTest__WhenLogOkWithUserInfo_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     Assert.that(logEvent.usr).isEqualTo(m.fakeGlobalUserInfo)
     return ""
 end function
@@ -361,6 +369,8 @@ function LogsAgentTest__WhenLogOkWithRumContext_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     Assert.that(logEvent.application_id).isEqualTo(m.fakeRumContext.applicationId)
     Assert.that(logEvent.session_id).isEqualTo(m.fakeRumContext.sessionId)
     Assert.that(logEvent.view.id).isEqualTo(m.fakeRumContext.viewId)
@@ -399,6 +409,8 @@ function LogsAgentTest__WhenLogDebug_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     return ""
 end function
 
@@ -436,6 +448,8 @@ function LogsAgentTest__WhenLogDebugWithCustomAttributes_ThenWriteLog() as strin
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     for each key in fakeAttributes
         Assert.that(logEvent[key]).isEqualTo(fakeAttributes[key])
     end for
@@ -477,6 +491,8 @@ function LogsAgentTest__WhenLogDebugWithGlobalAttributes_ThenWriteLog() as strin
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     for each key in m.fakeGlobalContext
         Assert.that(logEvent[key]).isEqualTo(m.fakeGlobalContext[key])
     end for
@@ -518,6 +534,8 @@ function LogsAgentTest__WhenLogDebugWithUserInfo_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     Assert.that(logEvent.usr).isEqualTo(m.fakeGlobalUserInfo)
     return ""
 end function
@@ -562,6 +580,8 @@ function LogsAgentTest__WhenLogDebugWithRumContext_ThenWriteLog() as string
     Assert.that(logEvent.session_id).isEqualTo(m.fakeRumContext.sessionId)
     Assert.that(logEvent.view.id).isEqualTo(m.fakeRumContext.viewId)
     Assert.that(logEvent.user_action.id).isEqualTo(m.fakeRumContext.actionId)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     return ""
 end function
 
@@ -596,6 +616,8 @@ function LogsAgentTest__WhenLogInfo_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     return ""
 end function
 
@@ -633,6 +655,8 @@ function LogsAgentTest__WhenLogInfoWithCustomAttributes_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     for each key in fakeAttributes
         Assert.that(logEvent[key]).isEqualTo(fakeAttributes[key])
     end for
@@ -675,6 +699,8 @@ function LogsAgentTest__WhenLogInfoWithGlobalAttributes_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     for each key in m.fakeGlobalContext
         Assert.that(logEvent[key]).isEqualTo(m.fakeGlobalContext[key])
     end for
@@ -716,6 +742,8 @@ function LogsAgentTest__WhenLogInfoWithUserInfo_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     Assert.that(logEvent.usr).isEqualTo(m.fakeGlobalUserInfo)
     return ""
 end function
@@ -755,6 +783,8 @@ function LogsAgentTest__WhenLogInfoWithRumContext_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     Assert.that(logEvent.application_id).isEqualTo(m.fakeRumContext.applicationId)
     Assert.that(logEvent.session_id).isEqualTo(m.fakeRumContext.sessionId)
     Assert.that(logEvent.view.id).isEqualTo(m.fakeRumContext.viewId)
@@ -793,6 +823,8 @@ function LogsAgentTest__WhenLogNotice_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     return ""
 end function
 
@@ -830,6 +862,8 @@ function LogsAgentTest__WhenLogNoticeWithCustomAttributes_ThenWriteLog() as stri
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     for each key in fakeAttributes
         Assert.that(logEvent[key]).isEqualTo(fakeAttributes[key])
     end for
@@ -871,6 +905,8 @@ function LogsAgentTest__WhenLogNoticeWithGlobalAttributes_ThenWriteLog() as stri
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     for each key in m.fakeGlobalContext
         Assert.that(logEvent[key]).isEqualTo(m.fakeGlobalContext[key])
     end for
@@ -912,6 +948,8 @@ function LogsAgentTest__WhenLogNoticeWithUserInfo_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     Assert.that(logEvent.usr).isEqualTo(m.fakeGlobalUserInfo)
     return ""
 end function
@@ -951,6 +989,8 @@ function LogsAgentTest__WhenLogNoticeWithRumContext_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     Assert.that(logEvent.application_id).isEqualTo(m.fakeRumContext.applicationId)
     Assert.that(logEvent.session_id).isEqualTo(m.fakeRumContext.sessionId)
     Assert.that(logEvent.view.id).isEqualTo(m.fakeRumContext.viewId)
@@ -989,6 +1029,8 @@ function LogsAgentTest__WhenLogWarn_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     return ""
 end function
 
@@ -1026,6 +1068,8 @@ function LogsAgentTest__WhenLogWarnWithCustomAttributes_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     for each key in fakeAttributes
         Assert.that(logEvent[key]).isEqualTo(fakeAttributes[key])
     end for
@@ -1067,6 +1111,8 @@ function LogsAgentTest__WhenLogWarnWithGlobalAttributes_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     for each key in m.fakeGlobalContext
         Assert.that(logEvent[key]).isEqualTo(m.fakeGlobalContext[key])
     end for
@@ -1108,6 +1154,8 @@ function LogsAgentTest__WhenLogWarnWithUserInfo_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     Assert.that(logEvent.usr).isEqualTo(m.fakeGlobalUserInfo)
     return ""
 end function
@@ -1147,6 +1195,8 @@ function LogsAgentTest__WhenLogWarnWithRumContext_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     Assert.that(logEvent.application_id).isEqualTo(m.fakeRumContext.applicationId)
     Assert.that(logEvent.session_id).isEqualTo(m.fakeRumContext.sessionId)
     Assert.that(logEvent.view.id).isEqualTo(m.fakeRumContext.viewId)
@@ -1185,6 +1235,8 @@ function LogsAgentTest__WhenLogError_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     return ""
 end function
 
@@ -1222,6 +1274,8 @@ function LogsAgentTest__WhenLogErrorWithCustomAttributes_ThenWriteLog() as strin
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     for each key in fakeAttributes
         Assert.that(logEvent[key]).isEqualTo(fakeAttributes[key])
     end for
@@ -1263,6 +1317,8 @@ function LogsAgentTest__WhenLogErrorWithGlobalAttributes_ThenWriteLog() as strin
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     for each key in m.fakeGlobalContext
         Assert.that(logEvent[key]).isEqualTo(m.fakeGlobalContext[key])
     end for
@@ -1304,6 +1360,8 @@ function LogsAgentTest__WhenLogErrorWithUserInfo_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     Assert.that(logEvent.usr).isEqualTo(m.fakeGlobalUserInfo)
     return ""
 end function
@@ -1343,6 +1401,8 @@ function LogsAgentTest__WhenLogErrorWithRumContext_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     Assert.that(logEvent.application_id).isEqualTo(m.fakeRumContext.applicationId)
     Assert.that(logEvent.session_id).isEqualTo(m.fakeRumContext.sessionId)
     Assert.that(logEvent.view.id).isEqualTo(m.fakeRumContext.viewId)
@@ -1381,6 +1441,8 @@ function LogsAgentTest__WhenLogCritical_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     return ""
 end function
 
@@ -1418,6 +1480,8 @@ function LogsAgentTest__WhenLogCriticalWithCustomAttributes_ThenWriteLog() as st
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     for each key in fakeAttributes
         Assert.that(logEvent[key]).isEqualTo(fakeAttributes[key])
     end for
@@ -1459,6 +1523,8 @@ function LogsAgentTest__WhenLogCriticalWithGlobalAttributes_ThenWriteLog() as st
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     for each key in m.fakeGlobalContext
         Assert.that(logEvent[key]).isEqualTo(m.fakeGlobalContext[key])
     end for
@@ -1500,6 +1566,8 @@ function LogsAgentTest__WhenLogCriticalWithUserInfo_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     Assert.that(logEvent.usr).isEqualTo(m.fakeGlobalUserInfo)
     return ""
 end function
@@ -1539,6 +1607,8 @@ function LogsAgentTest__WhenLogCriticalWithRumContext_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     Assert.that(logEvent.application_id).isEqualTo(m.fakeRumContext.applicationId)
     Assert.that(logEvent.session_id).isEqualTo(m.fakeRumContext.sessionId)
     Assert.that(logEvent.view.id).isEqualTo(m.fakeRumContext.viewId)
@@ -1577,6 +1647,8 @@ function LogsAgentTest__WhenLogAlert_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     return ""
 end function
 
@@ -1614,6 +1686,8 @@ function LogsAgentTest__WhenLogAlertWithCustomAttributes_ThenWriteLog() as strin
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     for each key in fakeAttributes
         Assert.that(logEvent[key]).isEqualTo(fakeAttributes[key])
     end for
@@ -1655,6 +1729,8 @@ function LogsAgentTest__WhenLogAlertWithGlobalAttributes_ThenWriteLog() as strin
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     for each key in m.fakeGlobalContext
         Assert.that(logEvent[key]).isEqualTo(m.fakeGlobalContext[key])
     end for
@@ -1696,6 +1772,8 @@ function LogsAgentTest__WhenLogAlertWithUserInfo_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     Assert.that(logEvent.usr).isEqualTo(m.fakeGlobalUserInfo)
     return ""
 end function
@@ -1735,6 +1813,8 @@ function LogsAgentTest__WhenLogAlertWithRumContext_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     Assert.that(logEvent.application_id).isEqualTo(m.fakeRumContext.applicationId)
     Assert.that(logEvent.session_id).isEqualTo(m.fakeRumContext.sessionId)
     Assert.that(logEvent.view.id).isEqualTo(m.fakeRumContext.viewId)
@@ -1773,6 +1853,8 @@ function LogsAgentTest__WhenLogEmergency_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     return ""
 end function
 
@@ -1811,6 +1893,8 @@ function LogsAgentTest__WhenLogEmergencyWithCustomAttributes_ThenWriteLog() as s
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     for each key in fakeAttributes
         Assert.that(logEvent[key]).isEqualTo(fakeAttributes[key])
     end for
@@ -1852,6 +1936,8 @@ function LogsAgentTest__WhenLogEmergencyWithGlobalAttributes_ThenWriteLog() as s
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     for each key in m.fakeGlobalContext
         Assert.that(logEvent[key]).isEqualTo(m.fakeGlobalContext[key])
     end for
@@ -1893,6 +1979,8 @@ function LogsAgentTest__WhenLogEmergencyWithUserInfo_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     Assert.that(logEvent.usr).isEqualTo(m.fakeGlobalUserInfo)
     return ""
 end function
@@ -1932,6 +2020,8 @@ function LogsAgentTest__WhenLogEmergencyWithRumContext_ThenWriteLog() as string
     Assert.that(logEvent.os.name).isEqualTo("Roku")
     Assert.that(logEvent.os.version).isEqualTo(m.fakeOsVersion)
     Assert.that(logEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
+    Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     Assert.that(logEvent.application_id).isEqualTo(m.fakeRumContext.applicationId)
     Assert.that(logEvent.session_id).isEqualTo(m.fakeRumContext.sessionId)
     Assert.that(logEvent.view.id).isEqualTo(m.fakeRumContext.viewId)


### PR DESCRIPTION
### What does this PR do?

Improve the logs metadata when sent from Roku : 
- logger thread name
- logger version

Also uses the default service name when not overriden

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

