### PR TITLE
RUM-2880 Prevent performance impact for internal logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Next release: 1.1.0
+
+* [IMPROVEMENT] Improve performance regarding internal logging (#78)
+
+
 # 1.0.0 / 2023-12-18
 
 ### Changes

--- a/dist/source/internalLogger.brs
+++ b/dist/source/internalLogger.brs
@@ -166,11 +166,21 @@ function decToHex(number as integer) as string
     end if
 end function
 
+function __isDev() as boolean
+    return CreateObject("roAppInfo").isDev()
+end function
+
 ' ----------------------------------------------------------------
 ' Checks whether the given log level is allowed in the current app
 ' @param level (LogLevel) the level of the log (1: error; 2: warning; )
 ' ----------------------------------------------------------------
 function __isLogLevelAllowed(level as object) as boolean
+    if (__isDev() = false)
+        return false
+    end if
+    if (m.datadogVerbosity <> invalid)
+        return level <= m.datadogVerbosity
+    end if
     if (m.global <> invalid)
         verbosity = (function(m)
                 __bsConsequent = m.global.datadogVerbosity
@@ -180,6 +190,7 @@ function __isLogLevelAllowed(level as object) as boolean
                     return 0
                 end if
             end function)(m)
+        m.datadogVerbosity = verbosity
         return level <= verbosity
     end if
     return false

--- a/library/source/internalLogger.bs
+++ b/library/source/internalLogger.bs
@@ -154,13 +154,26 @@ function decToHex(number as integer) as string
     end if
 end function
 
+function __isDev() as boolean
+    return CreateObject("roAppInfo").isDev()
+end function
+
 ' ----------------------------------------------------------------
 ' Checks whether the given log level is allowed in the current app
 ' @param level (LogLevel) the level of the log (1: error; 2: warning; )
 ' ----------------------------------------------------------------
 function __isLogLevelAllowed(level as LogLevel) as boolean
+    if (__isDev() = false)
+        return false
+    end if
+
+    if (m.datadogVerbosity <> invalid)
+        return level <= m.datadogVerbosity
+    end if
+
     if (m.global <> invalid)
         verbosity = m.global.datadogVerbosity ?? 0
+        m.datadogVerbosity = verbosity
         return level <= verbosity
     end if
     return false


### PR DESCRIPTION
### What does this PR do?

Fix #78 

Following suggestions by @slheavner , we prevented too many rendez vous with the main thread in our internal logger by:

- disabling internal logs altogether when not in development mode
- memoizing the verbosity in the current thread to avoid too many lookups
