### PR TITLE
RUM-2756 update trace to use 128 bit id instead of 64

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,9 +9,9 @@ include:
 
 variables:
   REPO: 'dd-sdk-roku'
-  CI_IMAGE_VERSION: "4"
+  CI_IMAGE_VERSION: "5"
   BUILD_STABLE_REGISTRY: '486234852809.dkr.ecr.us-east-1.amazonaws.com'
-  CI_IMAGE: '$BUILD_STABLE_REGISTRY/ci/$REPO:$CI_IMAGE_VERSION'
+  CI_IMAGE: 'registry.ddbuild.io/ci/$REPO:$CI_IMAGE_VERSION'
   GIT_REPOSITORY: 'git@github.com:DataDog/dd-sdk-roku.git'
   MAIN_BRANCH: 'main'
   GIT_DEPTH: 5

--- a/Dockerfile.gitlab
+++ b/Dockerfile.gitlab
@@ -1,4 +1,4 @@
-FROM registry.ddbuild.io/images/mirror/node:16.16.0-bullseye-slim
+FROM registry.ddbuild.io/images/mirror/ubuntu:24.04
 
 ####################################################################################################
 # DEBIAN SETUP
@@ -35,21 +35,22 @@ RUN set -x \
    && apt-get -y upgrade \
    && apt-get -y install --no-install-recommends \
    python3 \
-   python3-distutils \
    python3-apt \
+   python3-pip \
+   pipx \
    && apt-get -y clean \
    && rm -rf /var/lib/apt/lists/*
 
 #  Install pip for aws
-RUN set -x \
-   && curl -OL https://bootstrap.pypa.io/get-pip.py \
-   && python3 get-pip.py \
-   && rm get-pip.py
+# RUN set -x \
+#    && curl -OL https://bootstrap.pypa.io/get-pip.py \
+#    && python3 get-pip.py \
+#    && rm get-pip.py
 
 RUN python3 --version
 
 #  Install aws CLI
-RUN set -x && pip install awscli
+RUN set -x && pipx install awscli
 
 ####################################################################################################
 # JAVA
@@ -59,13 +60,24 @@ RUN set -x \
    && apt-get update \
    && apt-get -y upgrade \
    && apt-get -y install --no-install-recommends \
-   openjdk-17-jdk \
+   openjdk-21-jdk \
    && apt-get -y clean \
    && rm -rf /var/lib/apt/lists/*
+RUN java --version
 
 ####################################################################################################
 # NPM
 ####################################################################################################
+
+# Install Node
+RUN set -x \
+   && apt-get update \
+   && apt-get -y upgrade \
+   && apt-get -y install --no-install-recommends \
+   nodejs \
+   npm \
+   && apt-get -y clean \
+   && rm -rf /var/lib/apt/lists/*
 
 # Check Node and NPM version
 RUN node --version
@@ -95,7 +107,7 @@ RUN curl -L https://github.com/get-woke/woke/releases/download/v${WOKE_VERSION}/
 ####################################################################################################
 
 ENV ROKU_SCA_URL "http://devtools.web.roku.com/static-channel-analysis/sca-cmd.zip"
-ENV ROKU_SCA_SHA256 "e287aeb52c5a5d419975779b77bfe3177f323f7aae5be1f12c53596e56219b97"
+ENV ROKU_SCA_SHA256 "b4affb79c7924c5dfc10c9f9358d32e5fa279386711c328c067e3819d5278ff8"
 RUN curl -L $ROKU_SCA_URL -o sca-cmd.zip \
    && echo "${ROKU_SCA_SHA256} sca-cmd.zip" | sha256sum -c  \
    && unzip sca-cmd.zip \

--- a/Dockerfile.gitlab
+++ b/Dockerfile.gitlab
@@ -95,7 +95,7 @@ RUN curl -L https://github.com/get-woke/woke/releases/download/v${WOKE_VERSION}/
 ####################################################################################################
 
 ENV ROKU_SCA_URL "http://devtools.web.roku.com/static-channel-analysis/sca-cmd.zip"
-ENV ROKU_SCA_SHA256 "41a033f9cbe81507cb0a8d67181dfa57331718b65a800c8a14736c6e6f9ab2d5"
+ENV ROKU_SCA_SHA256 "e287aeb52c5a5d419975779b77bfe3177f323f7aae5be1f12c53596e56219b97"
 RUN curl -L $ROKU_SCA_URL -o sca-cmd.zip \
    && echo "${ROKU_SCA_SHA256} sca-cmd.zip" | sha256sum -c  \
    && unzip sca-cmd.zip \

--- a/dist/source/wrapper/DdUrlTransfer.brs
+++ b/dist/source/wrapper/DdUrlTransfer.brs
@@ -632,29 +632,34 @@ function __DdUrlTransfer_builder()
     instance._addSampledInHeaders = sub(headerType as object)
         m._deleteTracingHeaders()
         if (headerType = "datadog")
-            ' Datadog uses traces in base 10 and not hex
-            m.traceId = generateUniqueId(10)
-            m.spanId = generateUniqueId(10)
-            m.AddHeader("x-datadog-trace-id", m.traceId)
+            ' Datadog uses a complex system for compatibility purposes
+            ddId = generateUniqueIdDd()
+            m.traceId = ddId[0]
+            m.spanId = generateUniqueId64(10)
+            m.AddHeader("x-datadog-trace-id", ddId[1])
+            m.AddHeader("x-datadog-tags", "_dd.p.tid=" + ddId[2])
             m.AddHeader("x-datadog-parent-id", m.spanId)
             m.AddHeader("x-datadog-sampling-priority", "1")
             m.AddHeader("x-datadog-origin", "rum")
         else if (headerType = "b3")
-            m.traceId = generateUniqueId(16)
-            m.spanId = generateUniqueId(16)
-            b3 = padLeft(m.traceId, 32, "0") + "-" + padLeft(m.spanId, 16, "0") + "-1"
+            m.traceId = generateUniqueId128(16)
+            m.spanId = generateUniqueId64(16)
+            hexTraceId = padLeft(m.traceId, 32, "0")
+            hexSpanId = padLeft(m.spanId, 16, "0")
+            b3 = hexTraceId + "-" + hexSpanId + "-1"
             m.AddHeader("b3", b3)
         else if (headerType = "b3multi")
-            m.traceId = generateUniqueId(16)
-            m.spanId = generateUniqueId(16)
+            m.traceId = generateUniqueId128(16)
+            m.spanId = generateUniqueId64(16)
             m.AddHeader("X-B3-TraceId", m.traceId)
             m.AddHeader("X-B3-SpanId", m.spanId)
             m.AddHeader("X-B3-Sampled", "1")
         else if (headerType = "tracecontext")
-            m.traceId = generateUniqueId(16)
-            m.spanId = generateUniqueId(16)
+            m.traceId = generateUniqueId128(16)
+            m.spanId = generateUniqueId64(16)
+            hexTraceId = padLeft(m.traceId, 32, "0")
             hexSpanId = padLeft(m.spanId, 16, "0")
-            traceparent = "00-" + padLeft(m.traceId, 32, "0") + "-" + hexSpanId + "-01"
+            traceparent = "00-" + hexTraceId + "-" + hexSpanId + "-01"
             m.AddHeader("traceparent", traceparent)
             usrId = m.global.datadogUserInfo.id
             if (usrId <> invalid)
@@ -769,24 +774,69 @@ function getTracedHeaderType(url as string, tracingHeaderTypes as object) as dyn
 end function
 
 ' ----------------------------------------------------------------
-' Generates a unique identifier compatible with Datadog's APM trace and span IDs
+' Generates a unique identifier as a 64 bits random number
+' @param radix (integer) the radix to use when representing the id as a string
 ' @return (string) the generated Unique id
 ' ----------------------------------------------------------------
-function generateUniqueId(radix = 10 as integer) as string
+function generateUniqueId64(radix = 10 as integer) as string
     maxInt = 4294967295
-    low& = Rnd(maxInt) - 1
-    high& = Rnd(maxInt) - 1
+    return printIdToString(0, 0, Rnd(maxInt) - 1, Rnd(maxInt) - 1, radix)
+end function
+
+' ----------------------------------------------------------------
+' Generates a unique identifier as a 128 bits random number
+' @param radix (integer) the radix to use when representing the id as a string
+' @return (string) the generated Unique id
+' ----------------------------------------------------------------
+function generateUniqueId128(radix = 10 as integer) as string
+    maxInt = 4294967295
+    return printIdToString(Rnd(maxInt) - 1, Rnd(maxInt) - 1, Rnd(maxInt) - 1, Rnd(maxInt) - 1, radix)
+end function
+
+' ----------------------------------------------------------------
+' Generates a unique identifier as a 128 bits random number, fit for Datadog's specification
+' @return (array) the array with the generated id as a list of strings:
+'     - the full 128 bit id in hexadecimal
+'     - the low 64 bit part of the id in decimal (compatible with Datadog's legacy x-datadog-trace-id header)
+'     - the high 64 bit part of the id in id in hexadecimal
+' ----------------------------------------------------------------
+function generateUniqueIdDd() as object
+    maxInt = 4294967295
+    high0& = Rnd(maxInt) - 1
+    high1& = Rnd(maxInt) - 1
+    low0& = Rnd(maxInt) - 1
+    low1& = Rnd(maxInt) - 1
+    fullId = printIdToString(high0&, high1&, low0&, low1&, 16)
+    lowId = printIdToString(0, 0, low0&, low1&, 10)
+    highId = printIdToString(0, 0, high0&, high1&, 16)
+    return [
+        fullId
+        lowId
+        highId
+    ]
+end function
+
+function printIdToString(li0& as longinteger, li1& as longinteger, li2& as longinteger, li3& as longinteger, radix = 10 as integer) as string
+    a& = li0&
+    b& = li1&
+    c& = li2&
+    d& = li3&
     id = ""
-    while (high& > 0 or low& > 0)
-        ' Create an intermediate value with the same modulo as the combined high and low value
+    while (a& > 0 or b& > 0 or c& > 0 or d& > 0)
+        ' Create intermediate values with the same modulo as the combined high and low value
         ' but requiring 36 bits max (32 for the low value + 4 for the high part)
-        modH = high& mod radix
-        temp& = (modH << 32) + low&
-        digit = temp& mod radix
-        ' update the high value
-        high& = (high& - modH) / radix ' we reuse the modH to avoid the need of a floor op
-        ' the low value reuses the previous temp value to account for the "missing mod" in the high update
-        low& = (temp& - digit) / radix ' we reuse the digit to avoid the need of a floor op
+        ' transitively for each bucket
+        modA& = a& mod radix
+        tempB& = (modA& << 32) + b&
+        modTempB& = tempB& mod radix
+        tempC& = (modTempB& << 32) + c&
+        modTempC& = tempC& mod radix
+        tempD& = (modTempC& << 32) + d&
+        digit = tempD& mod radix
+        a& = (a& - modA&) / radix
+        b& = (tempB& - modTempB&) / radix
+        c& = (tempC& - modTempC&) / radix
+        d& = (tempD& - digit) / radix
         ' update the string from right to left
         if (digit < 10)
             id = digit.toStr() + id

--- a/library/source/wrapper/DdUrlTransfer.bs
+++ b/library/source/wrapper/DdUrlTransfer.bs
@@ -674,29 +674,34 @@ class DdUrlTransfer
     sub _addSampledInHeaders(headerType as TracingHeaderType)
         m._deleteTracingHeaders()
         if (headerType = TracingHeaderType.datadog)
-            ' Datadog uses traces in base 10 and not hex
-            m.traceId = generateUniqueId(10)
-            m.spanId = generateUniqueId(10)
-            m.AddHeader("x-datadog-trace-id", m.traceId)
+            ' Datadog uses a complex system for compatibility purposes
+            ddId = generateUniqueIdDd()
+            m.traceId = ddId[0]
+            m.spanId = generateUniqueId64(10)
+            m.AddHeader("x-datadog-trace-id", ddId[1])
+            m.AddHeader("x-datadog-tags", "_dd.p.tid=" + ddId[2])
             m.AddHeader("x-datadog-parent-id", m.spanId)
             m.AddHeader("x-datadog-sampling-priority", "1")
             m.AddHeader("x-datadog-origin", "rum")
         else if (headerType = TracingHeaderType.b3)
-            m.traceId = generateUniqueId(16)
-            m.spanId = generateUniqueId(16)
-            b3 = padLeft(m.traceId, 32, "0") + "-" + padLeft(m.spanId, 16, "0") + "-1"
+            m.traceId = generateUniqueId128(16)
+            m.spanId = generateUniqueId64(16)
+            hexTraceId = padLeft(m.traceId, 32, "0")
+            hexSpanId = padLeft(m.spanId, 16, "0")
+            b3 = hexTraceId + "-" + hexSpanId + "-1"
             m.AddHeader("b3", b3)
         else if (headerType = TracingHeaderType.b3multi)
-            m.traceId = generateUniqueId(16)
-            m.spanId = generateUniqueId(16)
+            m.traceId = generateUniqueId128(16)
+            m.spanId = generateUniqueId64(16)
             m.AddHeader("X-B3-TraceId", m.traceId)
             m.AddHeader("X-B3-SpanId", m.spanId)
             m.AddHeader("X-B3-Sampled", "1")
         else if (headerType = TracingHeaderType.tracecontext)
-            m.traceId = generateUniqueId(16)
-            m.spanId = generateUniqueId(16)
+            m.traceId = generateUniqueId128(16)
+            m.spanId = generateUniqueId64(16)
+            hexTraceId = padLeft(m.traceId, 32, "0")
             hexSpanId = padLeft(m.spanId, 16, "0")
-            traceparent = "00-" + padLeft(m.traceId, 32, "0") + "-" + hexSpanId + "-01"
+            traceparent = "00-" + hexTraceId + "-" + hexSpanId + "-01"
             m.AddHeader("traceparent", traceparent)
             usrId = m.global.datadogUserInfo.id
             if (usrId <> invalid)
@@ -811,26 +816,71 @@ function getTracedHeaderType(url as string, tracingHeaderTypes as object) as dyn
 end function
 
 ' ----------------------------------------------------------------
-' Generates a unique identifier compatible with Datadog's APM trace and span IDs
+' Generates a unique identifier as a 64 bits random number
+' @param radix (integer) the radix to use when representing the id as a string
 ' @return (string) the generated Unique id
 ' ----------------------------------------------------------------
-function generateUniqueId(radix = 10 as integer) as string
+function generateUniqueId64(radix = 10 as integer) as string
     maxInt = 4294967295
-    low& = Rnd(maxInt) - 1
-    high& = Rnd(maxInt) - 1
+    return printIdToString(0, 0, Rnd(maxInt) - 1, Rnd(maxInt) - 1, radix)
+end function
+
+
+' ----------------------------------------------------------------
+' Generates a unique identifier as a 128 bits random number
+' @param radix (integer) the radix to use when representing the id as a string
+' @return (string) the generated Unique id
+' ----------------------------------------------------------------
+function generateUniqueId128(radix = 10 as integer) as string
+    maxInt = 4294967295
+    return printIdToString(Rnd(maxInt) - 1, Rnd(maxInt) - 1, Rnd(maxInt) - 1, Rnd(maxInt) - 1, radix)
+end function
+
+' ----------------------------------------------------------------
+' Generates a unique identifier as a 128 bits random number, fit for Datadog's specification
+' @return (array) the array with the generated id as a list of strings:
+'     - the full 128 bit id in hexadecimal
+'     - the low 64 bit part of the id in decimal (compatible with Datadog's legacy x-datadog-trace-id header)
+'     - the high 64 bit part of the id in id in hexadecimal
+' ----------------------------------------------------------------
+function generateUniqueIdDd() as object
+    maxInt = 4294967295
+    high0& = Rnd(maxInt) - 1
+    high1& = Rnd(maxInt) - 1
+    low0& = Rnd(maxInt) - 1
+    low1& = Rnd(maxInt) - 1
+
+    fullId = printIdToString(high0&, high1&, low0&, low1&, 16)
+    lowId = printIdToString(0, 0, low0&, low1&, 10)
+    highId = printIdToString(0, 0, high0&, high1&, 16)
+
+    return [fullId, lowId, highId]
+end function
+
+function printIdToString(li0& as longinteger, li1& as longinteger, li2& as longinteger, li3& as longinteger, radix = 10 as integer) as string
+    a& = li0&
+    b& = li1&
+    c& = li2&
+    d& = li3&
     id = ""
 
-    while (high& > 0 or low& > 0)
-        ' Create an intermediate value with the same modulo as the combined high and low value
+    while (a& > 0 or b& > 0 or c& > 0 or d& > 0)
+        ' Create intermediate values with the same modulo as the combined high and low value
         ' but requiring 36 bits max (32 for the low value + 4 for the high part)
-        modH = high& mod radix
-        temp& = (modH << 32) + low&
-        digit = temp& mod radix
+        ' transitively for each bucket
+        modA& = a& mod radix
+        tempB& = (modA& << 32) + b&
+        modTempB& = tempB& mod radix
+        tempC& = (modTempB& << 32) + c&
+        modTempC& = tempC& mod radix
+        tempD& = (modTempC& << 32) + d&
 
-        ' update the high value
-        high& = (high& - modH) / radix ' we reuse the modH to avoid the need of a floor op
-        ' the low value reuses the previous temp value to account for the "missing mod" in the high update
-        low& = (temp& - digit) / radix ' we reuse the digit to avoid the need of a floor op
+        digit = tempD& mod radix
+
+        a& = (a& - modA&) / radix
+        b& = (tempB& - modTempB&) / radix
+        c& = (tempC& - modTempC&) / radix
+        d& = (tempD& - digit) / radix
 
         ' update the string from right to left
         if (digit < 10)

--- a/test/source/asserts/Asserts.bs
+++ b/test/source/asserts/Asserts.bs
@@ -405,8 +405,37 @@ class BaseAssert
 
         throw {
             number: m.errorCode,
-            message: "Expected " + m.actual + " to have substring " + expected + ")"
+            message: "Expected " + m.actual + " to have substring " + expected
         }
+    end function
+
+    ' ----------------------------------------------------------------
+    ' @param expected (dynamic) the expected regex to use for matching
+    ' @param flag (string) the flag for regex matching (i for case insensitive, …)
+    ' @param msg (string) the error message to use
+    ' @return (BaseAssert) this for chaining purposes
+    ' ----------------------------------------------------------------
+    function matches(expected as dynamic, flags = "" as string, msg = "" as string) as BaseAssert
+        if ((expected = invalid) or (not TF_Utils__IsString(expected)))
+            throw {
+                number: m.errorCode,
+                message: "Expected " + TF_Utils__AsString(expected) + " to be a string but was " + type(expected)
+            }
+        else if (not TF_Utils__IsString(m.actual))
+            throw {
+                number: m.errorCode,
+                message: "Expected " + TF_Utils__AsString(m.actual) + " to be a string but was " + type(m.actual)
+            }
+        end if
+
+        regex = CreateObject("roRegex", expected, flags)
+        if (not regex.IsMatch(m.actual))
+            throw {
+                number: m.errorCode,
+                message: "Expected " + m.actual + " to match regex /" + expected + "/"
+            }
+        end if
+        return m
     end function
 
     ' ----------------------------------------------------------------

--- a/test/source/tests/Test__DdUrlTransfer.bs
+++ b/test/source/tests/Test__DdUrlTransfer.bs
@@ -21,6 +21,13 @@ function TestSuite__DdUrlTransfer() as object
     this.addTest("WhenPadLeftWithLargeString_ThenReturnOriginalString", DdUrlTransferTest__WhenPadLeftWithLargeString_ThenReturnOriginalString)
     this.addTest("WhenPadLeftWithSmallString_ThenReturnOriginalString", DdUrlTransferTest__WhenPadLeftWithSmallString_ThenReturnOriginalString)
 
+    this.addTest("WhenGenerateUniqueId64_ThenGenerateIdDecimal", DdUrlTransferTest__WhenGenerateUniqueId64_ThenGenerateIdDecimal)
+    this.addTest("WhenGenerateUniqueId64_ThenGenerateIdHexadecimal", DdUrlTransferTest__WhenGenerateUniqueId64_ThenGenerateIdHexadecimal)
+    this.addTest("WhenGenerateUniqueId128_ThenGenerateIdDecimal", DdUrlTransferTest__WhenGenerateUniqueId128_ThenGenerateIdDecimal)
+    this.addTest("WhenGenerateUniqueId128_ThenGenerateIdHexadecimal", DdUrlTransferTest__WhenGenerateUniqueId128_ThenGenerateIdHexadecimal)
+    this.addTest("WhenGenerateUniqueIdDd_ThenGenerateAllId", DdUrlTransferTest__WhenGenerateUniqueIdDd_ThenGenerateAllId)
+    this.addTest("WhenPrintIdToString_ThenGenerateStringId", DdUrlTransferTest__WhenPrintIdToString_ThenGenerateStringId)
+
     return this
 end function
 
@@ -201,5 +208,120 @@ function DdUrlTransferTest__WhenPadLeftWithSmallString_ThenReturnOriginalString(
 
     ' Then
     Assert.that(result).hasSize(length).hasSubstring(pad + input)
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given:
+'  When: call the generateUniqueId64 method
+'  Then: returns a 64 bits unique id
+'----------------------------------------------------------------
+function DdUrlTransferTest__WhenGenerateUniqueId64_ThenGenerateIdDecimal() as string
+    ' Given
+
+    ' When
+    id = datadogroku_generateUniqueId64()
+
+    ' Then
+    ' 64 bit ids will never have more than 20 chars in decimal representation
+    Assert.that(Len(id)).isInRange(1, 20)
+    Assert.that(id).matches("^[0-9]+$")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given:
+'  When: call the generateUniqueId64 method
+'  Then: returns a 64 bits unique id
+'----------------------------------------------------------------
+function DdUrlTransferTest__WhenGenerateUniqueId64_ThenGenerateIdHexadecimal() as string
+    ' Given
+
+    ' When
+    id = datadogroku_generateUniqueId64(16)
+
+    ' Then
+    ' 64 bit ids will never have more than 16 chars in hexadecimal representation
+    Assert.that(Len(id)).isInRange(1, 16)
+    Assert.that(id).matches("^[0-9a-f]+$", "i")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given:
+'  When: call the generateUniqueId64 method
+'  Then: returns a 64 bits unique id
+'----------------------------------------------------------------
+function DdUrlTransferTest__WhenGenerateUniqueId128_ThenGenerateIdDecimal() as string
+    ' Given
+
+    ' When
+    id = datadogroku_generateUniqueId128()
+
+    ' Then
+    ' 64 bit ids will never have more than 39 chars in decimal representation
+    Assert.that(Len(id)).isInRange(1, 39)
+    Assert.that(id).matches("^[0-9]+$")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given:
+'  When: call the generateUniqueId64 method
+'  Then: returns a 64 bits unique id
+'----------------------------------------------------------------
+function DdUrlTransferTest__WhenGenerateUniqueId128_ThenGenerateIdHexadecimal() as string
+    ' Given
+
+    ' When
+    id = datadogroku_generateUniqueId128(16)
+
+    ' Then
+    ' 64 bit ids will never have more than 32 chars in hexadecimal representation
+    Assert.that(Len(id)).isInRange(1, 32)
+    Assert.that(id).matches("^[0-9a-f]+$", "i")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given:
+'  When: call the printIdToString method
+'  Then: returns a 64 bits unique id
+'----------------------------------------------------------------
+function DdUrlTransferTest__WhenGenerateUniqueIdDd_ThenGenerateAllId() as string
+    ' Given
+
+    ' When
+    id = datadogroku_generateUniqueIdDd()
+
+    ' Then
+    Assert.that(id).hasSize(3)
+    ' the full id always starts with the high id as both are hexadecimal representations
+    Assert.that(id[0]).matches("^" + id[2] + "[0-9a-f]{16}$", "i")
+    Assert.that(id[1]).matches("^[0-9]+$", "i")
+    Assert.that(id[2]).matches("^[0-9a-f]+$", "i")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given:
+'  When: call the printIdToString method
+'  Then: returns a 64 bits unique id
+'----------------------------------------------------------------
+function DdUrlTransferTest__WhenPrintIdToString_ThenGenerateStringId() as string
+    ' some special cases / Decimal
+    decRadix = 10
+    Assert.that(datadogroku_printIdToString(0, 0, 0, 42, decRadix)).isEqualTo("42")
+    Assert.that(datadogroku_printIdToString(0, 0, 16, 0, decRadix)).isEqualTo("68719476736")
+    Assert.that(datadogroku_printIdToString(0, 815, 0, 0, decRadix)).isEqualTo("15034096420073284567040")
+    Assert.that(datadogroku_printIdToString(23, 0, 13, 0, decRadix)).isEqualTo("1822247737828079764707345432576")
+
+    ' some special cases / Hexadecimal
+    hexRadix = 16
+    Assert.that(datadogroku_printIdToString(0, 0, 0, 42, hexRadix)).isEqualTo("2a")
+    Assert.that(datadogroku_printIdToString(0, 0, 16, 0, hexRadix)).isEqualTo("1000000000")
+    Assert.that(datadogroku_printIdToString(0, 815, 0, 0, hexRadix)).isEqualTo("32f0000000000000000")
+    Assert.that(datadogroku_printIdToString(23, 0, 0, 0, hexRadix)).isEqualTo("17000000000000000000000000")
+
     return ""
 end function

--- a/test/source/tests/core/Test__WriterTask.bs
+++ b/test/source/tests/core/Test__WriterTask.bs
@@ -145,7 +145,6 @@ function WriterTaskTest__WhenMultipleEvents_ThenAppendFile() as string
     ' Given
     filenames = ListDir(m.folderPath)
     Assume.that(filenames).isEmpty()
-    fakeEventCount = 5
     fakeEvents = []
     expectedString = ""
     for i = 1 to 5 :


### PR DESCRIPTION
### What does this PR do?

This uses a 128 bit trace id for all supported trace header formats, to align with the rest of Datadog APM services and RUM SDKs.