### PR TITLE
RUM-8215 Allow sending custom error with type

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ Whenever you perform an operation that might throw an exception, you can forward
     end try
 ```
 
+You can also track errors manually without using a `try-catch` block, as follows:
+
+```brightscript
+   customError = {
+        type: "Error42",
+        message: "An unexpected situation occured"
+    }
+    m.global.datadogRumAgent.callfunc("addError", customError)
+```
+
 #### Track RUM Resources
 
 ##### `roUrlTransfer`

--- a/dist/components/rum/RumViewScope.brs
+++ b/dist/components/rum/RumViewScope.brs
@@ -130,10 +130,12 @@ end sub
 ' @param writer (object) the writer node (see WriterTask component)
 ' ----------------------------------------------------------------
 sub addError(exception as object, context as object, writer as object)
-    if (exception.number = invalid)
-        errorType = "unknown"
-    else
+    if (exception.type <> invalid)
+        errorType = exception.type
+    else if (exception.number <> invalid)
         errorType = "&h" + decToHex(exception.number)
+    else
+        errorType = "unknown"
     end if
     if (exception.message <> invalid)
         errorMsg = exception.message

--- a/library/components/rum/RumViewScope.bs
+++ b/library/components/rum/RumViewScope.bs
@@ -122,10 +122,12 @@ end sub
 ' @param writer (object) the writer node (see WriterTask component)
 ' ----------------------------------------------------------------
 sub addError(exception as object, context as object, writer as object)
-    if (exception.number = invalid)
-        errorType = "unknown"
-    else
+    if (exception.type <> invalid)
+        errorType = exception.type
+    else if (exception.number <> invalid)
         errorType = "&h" + decToHex(exception.number)
+    else
+        errorType = "unknown"
     end if
     if (exception.message <> invalid)
         errorMsg = exception.message

--- a/sample/components/screens/DebugScreen.bs
+++ b/sample/components/screens/DebugScreen.bs
@@ -17,6 +17,7 @@ sub init()
         "Add Click Action",
         "Add Custom Action",
         "Add Error",
+        "Add Custom Error",
         "Add Resource",
         "Add custom Resource",
         "Send Logs",
@@ -70,18 +71,20 @@ sub onItemSelected()
     else if (itemSelected = 4)
         sendError()
     else if (itemSelected = 5)
-        sendResource()
+        sendCustomError()
     else if (itemSelected = 6)
-        sendCustomResource()
+        sendResource()
     else if (itemSelected = 7)
-        sendLogs()
+        sendCustomResource()
     else if (itemSelected = 8)
-        sendErrorTelemetry()
+        sendLogs()
     else if (itemSelected = 9)
         sendErrorTelemetry()
     else if (itemSelected = 10)
-        sendDebugTelemetry()
+        sendErrorTelemetry()
     else if (itemSelected = 11)
+        sendDebugTelemetry()
+    else if (itemSelected = 12)
         sendCrash()
     end if
 end sub
@@ -107,6 +110,15 @@ sub sendError()
         datadogroku_ddLogError("Caught something", error)
         m.global.datadogRumAgent@.addError(error, { custom_add_error: Rnd(100) })
     end try
+end sub
+
+sub sendCustomError()
+    customError = {
+        type: "Error42",
+        message: "An unexpected situation occured"
+    }
+    datadogroku_ddLogError("Caught something", customError)
+    m.global.datadogRumAgent@.addError(customError, { custom_add_error: Rnd(100) })
 end sub
 
 sub sendClickAction()

--- a/test/source/tests/Test__timeUtils.bs
+++ b/test/source/tests/Test__timeUtils.bs
@@ -27,14 +27,14 @@ end function
 function TimeUtilsTest__WhenGetTimestamp_ThenReturnsTimestampInMilliseconds() as string
     ' Given
     ' hardcoded values to get a valid range
-    timestampMS_1jan2024 = 1704063600000
     timestampMS_1jan2025 = 1735686000000
+    timestampMS_1jan2026 = 1767225600000
 
     ' When
     result = datadogroku_getTimestamp()
 
     ' Then
-    Assert.that(result).isInRange(timestampMS_1jan2024, timestampMS_1jan2025)
+    Assert.that(result).isInRange(timestampMS_1jan2025, timestampMS_1jan2026)
     return ""
 end function
 

--- a/test/source/tests/rum/Test__RumViewScope.bs
+++ b/test/source/tests/rum/Test__RumViewScope.bs
@@ -30,6 +30,7 @@ function TestSuite__RumViewScope() as object
     this.addTest("WhenHandleViewUpdateNotTracked_ThenDiscardLastKnownViewEvent", RumViewScopeTest__WhenHandleViewUpdateNotTracked_ThenDiscardLastKnownViewEvent, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
 
     this.addTest("WhenHandleAddErrorEvent_ThenWriteViewEvent", RumViewScopeTest__WhenHandleAddErrorEvent_ThenWriteViewEvent, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
+    this.addTest("WhenHandleAddErrorEventWithCustomType_ThenWriteViewEvent", RumViewScopeTest__WhenHandleAddErrorEventWithCustomType_ThenWriteViewEvent, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
     this.addTest("WhenHandleAddErrorEventWithGlobalContext_ThenWriteViewEvent", RumViewScopeTest__WhenHandleAddErrorEventWithGlobalContext_ThenWriteViewEvent, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
     this.addTest("WhenHandleAddErrorEventWithLocalContext_ThenWriteViewEvent", RumViewScopeTest__WhenHandleAddErrorEventWithLocalContext_ThenWriteViewEvent, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
     this.addTest("WhenHandleAddErrorEventWithUserInfo_ThenWriteViewEvent", RumViewScopeTest__WhenHandleAddErrorEventWithUserInfo_ThenWriteViewEvent, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
@@ -875,6 +876,74 @@ function RumViewScopeTest__WhenHandleAddErrorEvent_ThenWriteViewEvent() as strin
     Assert.that(errorEvent.error.stack).isEqualTo(datadogroku_backtraceToString(fakeBacktrace))
     Assert.that(errorEvent.error.is_crash).isEqualTo(false)
     Assert.that(errorEvent.error.type).isEqualTo("&h" + datadogroku_decToHex(fakeErrorNumber))
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a RumViewScope
+'  When: handling an event (addError) with a custom type
+'  Then: write an error event
+'----------------------------------------------------------------
+function RumViewScopeTest__WhenHandleAddErrorEventWithCustomType_ThenWriteViewEvent() as string
+    ' Given
+    fakeApplicationId = IG_GetString(32)
+    fakeApplicationVersion = IG_GetString(32)
+    fakeService = IG_GetString(32)
+    fakeSessionId = IG_GetString(32)
+    fakeParentContext = {
+        applicationId: fakeApplicationId,
+        service: fakeService,
+        sessionId: fakeSessionId,
+        applicationVersion: fakeApplicationVersion,
+        deviceName: m.fakeDeviceName,
+        deviceModel: m.fakeDeviceModel,
+        osVersion: m.fakeOsVersion,
+        osVersionMajor: m.fakeOsVersionMajor
+    }
+    m.mockParentScope@.stubCall("getRumContext", {}, fakeParentContext)
+    fakeMessage = IG_GetString(128)
+    fakeErrorNumber = IG_GetInteger(256)
+    fakeErrorType = IG_GetString(32)
+    fakeBacktrace = IG_GetBacktrace()
+    fakeException = { number: fakeErrorNumber, message: fakeMessage, backtrace: fakeBacktrace, type: fakeErrorType }
+    fakeEvent = { mock: "event", eventType: "addError", exception: fakeException }
+
+    ' When
+    errorTimestamp& = datadogroku_getTimestamp()
+    m.testedScope@.handleEvent(fakeEvent, m.mockWriter)
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    Assert.that(updates).hasSize(1)
+    errorEvent = ParseJson(updates[0])
+    Assert.that(errorEvent).isNotInvalid()
+    Assert.that(errorEvent.application.id).isEqualTo(fakeApplicationId)
+    Assert.that(errorEvent.action.id).isEqualTo(invalid)
+    Assert.that(errorEvent.date).isInRange(errorTimestamp&, errorTimestamp& + 5)
+    Assert.that(errorEvent.device.type).isEqualTo("tv")
+    Assert.that(errorEvent.device.name).isEqualTo(m.fakeDeviceName)
+    Assert.that(errorEvent.device.model).isEqualTo(m.fakeDeviceModel)
+    Assert.that(errorEvent.device.brand).isEqualTo("Roku")
+    Assert.that(errorEvent.os.name).isEqualTo("Roku")
+    Assert.that(errorEvent.os.version).isEqualTo(m.fakeOsVersion)
+    Assert.that(errorEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+    Assert.that(errorEvent.service).isEqualTo(fakeService)
+    Assert.that(errorEvent.session.has_replay).isEqualTo(false)
+    Assert.that(errorEvent.session.id).isNotEmpty()
+    Assert.that(errorEvent.session.type).isEqualTo("user")
+    Assert.that(errorEvent.source).isEqualTo("roku")
+    Assert.that(errorEvent.type).isEqualTo("error")
+    Assert.that(errorEvent.version).isEqualTo(fakeApplicationVersion)
+    Assert.that(errorEvent.view.id).isNotEmpty()
+    Assert.that(errorEvent.view.name).isEqualTo(m.fakeViewName)
+    Assert.that(errorEvent.view.url).isEqualTo(m.fakeViewUrl)
+    Assert.that(errorEvent.error.id).isNotEmpty()
+    Assert.that(errorEvent.error.message).isEqualTo(fakeMessage)
+    Assert.that(errorEvent.error.source).isEqualTo("source")
+    Assert.that(errorEvent.error.source_type).isEqualTo("roku")
+    Assert.that(errorEvent.error.stack).isEqualTo(datadogroku_backtraceToString(fakeBacktrace))
+    Assert.that(errorEvent.error.is_crash).isEqualTo(false)
+    Assert.that(errorEvent.error.type).isEqualTo(fakeErrorType)
     return ""
 end function
 


### PR DESCRIPTION
### What does this PR do?

Adds the opportunity to send a custom error, with example.

### Motivation

When sending a custom error, the `error.type` would always default to `"unknown"`. This allows customers to use a custom type.

