### PR TITLE
Add workflow: Changelog update to Confluence

### DIFF
--- a/.github/workflows/changelog-to-confluence.yaml
+++ b/.github/workflows/changelog-to-confluence.yaml
@@ -1,0 +1,31 @@
+name: Publish Changelog to Confluence
+on:
+    push:
+        branches:
+            - develop
+        paths:
+            - 'CHANGELOG.md'
+permissions:
+    contents: read
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+
+            - name: Prepare Only Changelog
+              run: |
+                  mkdir -p publish_folder
+                  cp CHANGELOG.md publish_folder/roku-sdk-changelog.md
+                  echo "Publishing only CHANGELOG.md"
+
+            - name: Publish Markdown to Confluence
+              uses: markdown-confluence/publish-action@7767a0a7f438bb1497ee7ffd7d3d685b81dfe700 # v5
+              with:
+                  confluenceBaseUrl: ${{ secrets.DATADOG_CONFLUENCE_BASE_URL }}
+                  confluenceParentId: ${{ secrets.CONFLUENCE_PARENT_ID }}
+                  atlassianUserName: ${{ secrets.CONFLUENCE_ROBOT_RUM_EMAIL }}
+                  atlassianApiToken: ${{ secrets.CONFLUENCE_ROBOT_RUM_API_KEY }}
+                  contentRoot: '.'
+                  folderToPublish: 'publish_folder'


### PR DESCRIPTION
### What does this PR do?

- Add workflow to update changelog file to confluence

### Motivation

- Streamline the SDK's changelog to confluence, to easier access and retrieve, as well, the leverage of this information for the EEKS.

### Additional Notes

#### Next steps
- Add Github Secret to project `CONFLUENCE_PARENT_ID` : `5207459116` 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

