### PR TITLE
RUM-8230: Reduce Global attributes rendezvous in initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ package-lock.json
 # Visual Studio Code
 .vscode
 
+# Windsurf
+.windsurf
+
 # Mac OS
 .DS_Store
 

--- a/dist/source/datadogSdk.brs
+++ b/dist/source/datadogSdk.brs
@@ -68,21 +68,19 @@ sub initialize(configuration as object, global as object)
     if (global.datadogUploader = invalid)
         ddLogInfo("No uploader, creating one")
         uploader = CreateObject("roSGNode", "MultiTrackUploaderTask")
+        uploader.clientToken = configuration.clientToken
         global.addFields({
             datadogUploader: uploader
         })
-        global.datadogUploader.clientToken = configuration.clientToken
     end if
     if (configuration.applicationId = invalid or configuration.applicationId = "")
         ddLogWarning("Trying to initialize the Datadog SDK without a RUM Application Id, please check your configuration.")
         return
     else if (global.datadogRumAgent = invalid)
         ddLogInfo("No RUM agent, creating one")
-        global.addFields({
-            datadogRumAgent: CreateObject("roSGNode", "RumAgent")
-        })
-        global.datadogRumAgent.site = configuration.site
-        global.datadogRumAgent.env = (function(configuration)
+        rumAgent = CreateObject("roSGNode", "RumAgent")
+        rumAgent.site = configuration.site
+        rumAgent.env = (function(configuration)
                 __bsConsequent = configuration.env
                 if __bsConsequent <> invalid then
                     return __bsConsequent
@@ -90,12 +88,12 @@ sub initialize(configuration as object, global as object)
                     return ""
                 end if
             end function)(configuration)
-        global.datadogRumAgent.clientToken = configuration.clientToken
-        global.datadogRumAgent.applicationId = configuration.applicationId
-        global.datadogRumAgent.service = service
-        global.datadogRumAgent.version = version
-        global.datadogRumAgent.uploader = global.datadogUploader
-        global.datadogRumAgent.sessionSampleRate = (function(configuration)
+        rumAgent.clientToken = configuration.clientToken
+        rumAgent.applicationId = configuration.applicationId
+        rumAgent.service = service
+        rumAgent.version = version
+        rumAgent.uploader = global.datadogUploader
+        rumAgent.sessionSampleRate = (function(configuration)
                 __bsConsequent = configuration.sessionSampleRate
                 if __bsConsequent <> invalid then
                     return __bsConsequent
@@ -103,27 +101,31 @@ sub initialize(configuration as object, global as object)
                     return 100
                 end if
             end function)(configuration)
-        global.datadogRumAgent.lastExitOrTerminationReason = launchArgs.lastExitOrTerminationReason
-        global.datadogRumAgent.configuration = configuration
-        global.datadogRumAgent.deviceName = deviceName
-        global.datadogRumAgent.deviceModel = deviceModel
-        global.datadogRumAgent.osVersion = deviceOsVersionFull
-        global.datadogRumAgent.osVersionMajor = deviceOsVersion.major
+        rumAgent.lastExitOrTerminationReason = launchArgs.lastExitOrTerminationReason
+        rumAgent.configuration = configuration
+        rumAgent.deviceName = deviceName
+        rumAgent.deviceModel = deviceModel
+        rumAgent.osVersion = deviceOsVersionFull
+        rumAgent.osVersionMajor = deviceOsVersion.major
+        global.addFields({
+            datadogRumAgent: rumAgent
+        })
     end if
     if (global.datadogLogsAgent = invalid)
         ddLogInfo("No Logs agent, creating one")
+        agent = CreateObject("roSGNode", "LogsAgent")
+        agent.site = configuration.site
+        agent.clientToken = configuration.clientToken
+        agent.service = service
+        agent.env = configuration.env
+        agent.uploader = global.datadogUploader
+        agent.deviceName = deviceName
+        agent.deviceModel = deviceModel
+        agent.osVersion = deviceOsVersionFull
+        agent.osVersionMajor = deviceOsVersion.major
         global.addFields({
-            datadogLogsAgent: CreateObject("roSGNode", "LogsAgent")
+            datadogLogsAgent: agent
         })
-        global.datadogLogsAgent.site = configuration.site
-        global.datadogLogsAgent.clientToken = configuration.clientToken
-        global.datadogLogsAgent.service = service
-        global.datadogLogsAgent.env = configuration.env
-        global.datadogLogsAgent.uploader = global.datadogUploader
-        global.datadogLogsAgent.deviceName = deviceName
-        global.datadogLogsAgent.deviceModel = deviceModel
-        global.datadogLogsAgent.osVersion = deviceOsVersionFull
-        global.datadogLogsAgent.osVersionMajor = deviceOsVersion.major
     end if
     global.addFields({
         datadogTraceAgent: {

--- a/library/source/datadogSdk.bs
+++ b/library/source/datadogSdk.bs
@@ -50,8 +50,8 @@ sub initialize(configuration as object, global as object)
     if (global.datadogUploader = invalid)
         ddLogInfo("No uploader, creating one")
         uploader = CreateObject("roSGNode", "MultiTrackUploaderTask")
+        uploader.clientToken = configuration.clientToken
         global.addFields({ datadogUploader: uploader })
-        global.datadogUploader.clientToken = configuration.clientToken
     end if
 
     if (configuration.applicationId = invalid or configuration.applicationId = "")
@@ -59,35 +59,39 @@ sub initialize(configuration as object, global as object)
         return
     else if (global.datadogRumAgent = invalid)
         ddLogInfo("No RUM agent, creating one")
-        global.addFields({ datadogRumAgent: CreateObject("roSGNode", "RumAgent") })
-        global.datadogRumAgent.site = configuration.site
-        global.datadogRumAgent.env = configuration.env ?? ""
-        global.datadogRumAgent.clientToken = configuration.clientToken
-        global.datadogRumAgent.applicationId = configuration.applicationId
-        global.datadogRumAgent.service = service
-        global.datadogRumAgent.version = version
-        global.datadogRumAgent.uploader = global.datadogUploader
-        global.datadogRumAgent.sessionSampleRate = configuration.sessionSampleRate ?? 100
-        global.datadogRumAgent.lastExitOrTerminationReason = launchArgs.lastExitOrTerminationReason
-        global.datadogRumAgent.configuration = configuration
-        global.datadogRumAgent.deviceName = deviceName
-        global.datadogRumAgent.deviceModel = deviceModel
-        global.datadogRumAgent.osVersion = deviceOsVersionFull
-        global.datadogRumAgent.osVersionMajor = deviceOsVersion.major
+        rumAgent = CreateObject("roSGNode", "RumAgent")
+        rumAgent.site = configuration.site
+        rumAgent.env = configuration.env ?? ""
+        rumAgent.clientToken = configuration.clientToken
+        rumAgent.applicationId = configuration.applicationId
+        rumAgent.service = service
+        rumAgent.version = version
+        rumAgent.uploader = global.datadogUploader
+        rumAgent.sessionSampleRate = configuration.sessionSampleRate ?? 100
+        rumAgent.lastExitOrTerminationReason = launchArgs.lastExitOrTerminationReason
+        rumAgent.configuration = configuration
+        rumAgent.deviceName = deviceName
+        rumAgent.deviceModel = deviceModel
+        rumAgent.osVersion = deviceOsVersionFull
+        rumAgent.osVersionMajor = deviceOsVersion.major
+        
+        global.addFields({ datadogRumAgent: rumAgent })
     end if
 
     if (global.datadogLogsAgent = invalid)
         ddLogInfo("No Logs agent, creating one")
-        global.addFields({ datadogLogsAgent: CreateObject("roSGNode", "LogsAgent") })
-        global.datadogLogsAgent.site = configuration.site
-        global.datadogLogsAgent.clientToken = configuration.clientToken
-        global.datadogLogsAgent.service = service
-        global.datadogLogsAgent.env = configuration.env
-        global.datadogLogsAgent.uploader = global.datadogUploader
-        global.datadogLogsAgent.deviceName = deviceName
-        global.datadogLogsAgent.deviceModel = deviceModel
-        global.datadogLogsAgent.osVersion = deviceOsVersionFull
-        global.datadogLogsAgent.osVersionMajor = deviceOsVersion.major
+        
+        agent = CreateObject("roSGNode", "LogsAgent")
+        agent.site = configuration.site
+        agent.clientToken = configuration.clientToken
+        agent.service = service
+        agent.env = configuration.env
+        agent.uploader = global.datadogUploader
+        agent.deviceName = deviceName
+        agent.deviceModel = deviceModel
+        agent.osVersion = deviceOsVersionFull
+        agent.osVersionMajor = deviceOsVersion.major
+        global.addFields({ datadogLogsAgent: agent })
     end if
 
     global.addFields({

--- a/test/source/tests/Test__DdUrlTransfer.bs
+++ b/test/source/tests/Test__DdUrlTransfer.bs
@@ -444,6 +444,7 @@ function DdUrlTransferTest__WhenSampledIn_ThenHaveSampleInHeaders() as string
     }
     ddUrlTransfer = datadogroku_DdUrlTransfer(fakeGlobal)
     ddUrlTransfer.SetUrl("https://datadog.com")
+    ddUrlTransfer.SetTraceSampleRate(100)
     ddUrlTransfer._traceRequest()
     result = ddUrlTransfer.GetHeader("baggage")
     Assert.that(result[0]).isEqualTo("session.id=" + fakeSessionId)

--- a/test/source/tests/Test__datadog.bs
+++ b/test/source/tests/Test__datadog.bs
@@ -20,6 +20,10 @@ function TestSuite__Datadog() as object
     this.addTest("WhenGetEndpointAP1_ThenCreateEndpoint", DatadogTest__WhenGetEndpointAP1_ThenCreateEndpoint)
     this.addTest("WhenGetEndpointAP2_ThenCreateEndpoint", DatadogTest__WhenGetEndpointAP2_ThenCreateEndpoint)
 
+    this.addTest("WhenInitialize_ThenRumAgentConfigurationIsSetInGlobal", DatadogTest__WhenInitialize_ThenRumAgentConfigurationIsSetInGlobal)
+    this.addTest("WhenInitialize_ThenLogsAgentConfigurationIsSetInGlobal", DatadogTest__WhenInitialize_ThenLogsAgentConfigurationIsSetInGlobal)
+    this.addTest("WhenInitialize_ThenUploaderIsSetInGlobal", DatadogTest__WhenInitialize_ThenUploaderIsSetInGlobal) 
+
     this.addTest("WhenGetEndpointStaging_ThenCreateEndpoint", DatadogTest__WhenGetEndpointStaging_ThenCreateEndpoint)
 
     this.addTest("WhenGetEndpointRumUnknown_ThenCreateEndpoint", DatadogTest__WhenGetEndpointRumUnknown_ThenCreateEndpoint)
@@ -191,3 +195,123 @@ function DatadogTest__WhenGetEndpointRumUnknown_ThenCreateEndpoint() as string
     Assert.that(endpoint).isEqualTo("")
     return ""
 end function
+
+'----------------------------------------------------------------
+' Given: a valid configuration
+'  When: initializing the SDK
+'  Then: the configuration is properly set in the global object
+'----------------------------------------------------------------
+function DatadogTest__WhenInitialize_ThenRumAgentConfigurationIsSetInGlobal() as string
+    
+    ' Given
+    randomClientToken = IG_GetString(16)
+    randomAppId = IG_GetString(16)
+    randomSite = "us1" 
+    randomEnv = IG_GetString(16)
+    randomSessionRate = IG_GetInteger()
+    randomService = IG_GetString(16)
+    randomVersion = IG_GetString(8) + "." + IG_GetString(8) + "." + IG_GetString(8)
+    randomTraceRate = IG_GetInteger()
+    randomHost = IG_GetString(16)
+    randomHeader = IG_GetString(16)
+    
+    configuration = {
+        clientToken: randomClientToken,
+        applicationId: randomAppId,
+        site: randomSite,
+        env: randomEnv,
+        sessionSampleRate: randomSessionRate,
+        service: randomService,
+        version: randomVersion,
+        traceSampleRate: randomTraceRate,
+        tracingHeaderTypes: [{
+            host: randomHost,
+            header: randomHeader
+        }]
+    }
+    
+    ' When
+    fakeGlobal = CreateObject("roSGNode", "ContentNode")
+    
+    datadogroku_initialize(configuration, fakeGlobal)   
+    
+    ' Then
+    actualDatadogRumAgent = fakeGlobal.getField("datadogRumAgent")
+
+    Assert.that(actualDatadogRumAgent.site).isEqualTo(randomSite)
+    Assert.that(actualDatadogRumAgent.env).isEqualTo(randomEnv)
+    Assert.that(actualDatadogRumAgent.clientToken).isEqualTo(randomClientToken)
+    Assert.that(actualDatadogRumAgent.applicationId).isEqualTo(randomAppId)
+    Assert.that(actualDatadogRumAgent.service).isEqualTo(randomService)
+    Assert.that(actualDatadogRumAgent.version).isEqualTo(randomVersion)
+    Assert.that(actualDatadogRumAgent.sessionSampleRate).isEqualTo(randomSessionRate)
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Test: When Initialize - Then Logs Agent Configuration Is Set In Global
+'----------------------------------------------------------------
+function DatadogTest__WhenInitialize_ThenLogsAgentConfigurationIsSetInGlobal() as string
+    ' Given
+    randomClientToken = IG_GetString(16)
+    randomAppId = IG_GetString(16)
+    randomSite = "us1" 
+    randomEnv = IG_GetString(16)
+    randomService = IG_GetString(16)
+    randomOsVersion = IG_GetString(8)
+    randomOsVersionMajor = IG_GetInteger()
+    
+    configuration = {
+        clientToken: randomClientToken,
+        applicationId: randomAppId,
+        site: randomSite,
+        env: randomEnv,
+        service: randomService
+    }
+    
+    ' When
+    fakeGlobal = CreateObject("roSGNode", "ContentNode")
+    
+    datadogroku_initialize(configuration, fakeGlobal)   
+    
+    ' Then
+    actualLogsAgent = fakeGlobal.getField("datadogLogsAgent")
+
+    Assert.that(actualLogsAgent.site).isEqualTo(randomSite)
+    Assert.that(actualLogsAgent.clientToken).isEqualTo(randomClientToken)
+    Assert.that(actualLogsAgent.service).isEqualTo(randomService)
+    Assert.that(actualLogsAgent.env).isEqualTo(randomEnv)
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Test: When Initialize - Then Uploader Is Set In Global
+'----------------------------------------------------------------
+function DatadogTest__WhenInitialize_ThenUploaderIsSetInGlobal() as string
+    ' Given
+    randomClientToken = IG_GetString(16)
+    randomAppId = IG_GetString(16)
+    randomSite = "us1" 
+    randomEnv = IG_GetString(16)
+    randomService = IG_GetString(16)
+    
+    configuration = {
+        clientToken: randomClientToken,
+        applicationId: randomAppId,
+        site: randomSite,
+        env: randomEnv,
+        service: randomService
+    }
+    
+    ' When
+    fakeGlobal = CreateObject("roSGNode", "ContentNode")
+    
+    datadogroku_initialize(configuration, fakeGlobal)   
+    
+    ' Then
+    actualUploader = fakeGlobal.getField("datadogUploader")
+
+    Assert.that(actualUploader.clientToken).isEqualTo(randomClientToken)
+    return ""
+end function
+


### PR DESCRIPTION
### What does this PR do?

Setting an object into `m.global` then assigning its attribute can cause roku "rendezvous" issue. More explaination in this [article](https://medium.com/@amitdogra70512/rendezevous-in-roku-bd55d81fc994).

We need to the other way around, creating the object, setting up all the attributes, then set to `m.global` once.

### Motivation
RUM-8230


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

