### PR TITLE
Fix MultiTrackUploaderTask flaky test

### DIFF
--- a/dist/components/core/MultiTrackUploaderTask.brs
+++ b/dist/components/core/MultiTrackUploaderTask.brs
@@ -232,11 +232,14 @@ sub handleResponse(requestId as string, responseCode as integer, filePath as str
         if (not DeleteFile(filePath))
             message = "Unable to delete batch file at " + filePath
             ddLogWarning(message)
-            m.global.datadogRumAgent.callfunc("addErrorTelemetry", {
-                number: 0
-                message: message
-                backtrace: []
-            })
+            datadogRumAgent = m.global.datadogRumAgent
+            if (datadogRumAgent <> invalid)
+                datadogRumAgent.addErrorTelemetry({
+                    number: 0
+                    message: message
+                    backtrace: []
+                })
+            end if
         end if
     end if
 end sub

--- a/library/components/core/MultiTrackUploaderTask.bs
+++ b/library/components/core/MultiTrackUploaderTask.bs
@@ -244,7 +244,10 @@ sub handleResponse(requestId as string, responseCode as integer, filePath as str
         if (not DeleteFile(filePath))
             message = "Unable to delete batch file at " + filePath
             ddLogWarning(message)
-            m.global.datadogRumAgent@.addErrorTelemetry({ number: 0, message: message, backtrace: [] })
+            datadogRumAgent = m.global.datadogRumAgent
+            if (datadogRumAgent <> invalid)
+                datadogRumAgent.addErrorTelemetry({ number: 0, message: message, backtrace: [] })
+            end if
         end if
     end if
 end sub

--- a/test/source/tests/Test__DdUrlTransfer.bs
+++ b/test/source/tests/Test__DdUrlTransfer.bs
@@ -517,7 +517,7 @@ end function
 function createFakeGlobal(fakeSessionId as string) as object
     fakeDatadogRumAgent = CreateObject("roSGNode", "datadogRoku_RumAgent") 
     fakeSampleRate = IG_GetDouble()
-    fakeId = IG_GetInteger()
+    fakeId = IG_GetString(8)
     fakeName = IG_GetString(16)
     fakeEmail = IG_GetString(32)
     fakeGlobal = {


### PR DESCRIPTION
### What does this PR do?

There are two flaky test fixed in this PR:
* `fakeId` was not ASCII string, causing crash in source code when trying to parse it as ASCII
* `datadogRumAgent` is not set in unit test, causing crash.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

