### PR TITLE
RUM-11210: Fix RumAgent crash when initialising uploader

### DIFF
--- a/dist/components/rum/RumAgent.brs
+++ b/dist/components/rum/RumAgent.brs
@@ -209,7 +209,7 @@ end sub
 ' ----------------------------------------------------------------
 sub ensureUploader()
     uploader = m.top.uploader
-    if (m.top.uploader = invalid)
+    if (uploader = invalid)
         ddLogVerbose("Creating MultiTrackUploaderTask")
         uploader = CreateObject("roSGNode", "MultiTrackUploaderTask")
     end if

--- a/library/components/rum/RumAgent.bs
+++ b/library/components/rum/RumAgent.bs
@@ -211,7 +211,7 @@ end sub
 ' ----------------------------------------------------------------
 sub ensureUploader()
     uploader = m.top.uploader
-    if (m.top.uploader = invalid)
+    if (uploader = invalid)
         ddLogVerbose("Creating MultiTrackUploaderTask")
         uploader = CreateObject("roSGNode", "MultiTrackUploaderTask")
     end if


### PR DESCRIPTION
### What does this PR do?

There is a concurrent issue that, `uploader` is assigned with `invalid`(null) value  on L213, then checking `m.top.uploader`, it is not null anymore (`m.top.x` is a global attribute, can be assigned from any other places), but local attribute `uploader` has the copy of `invalid`, then the `if` block is skipped, which causes the crash of calling method on `invalid` attribute.

The way of fixing it, is to always check local attribute instead of global attribute

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

