### PR TITLE
[CIEXE] Migrate off legacy CI runners

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,6 @@ include:
 variables:
   REPO: 'dd-sdk-roku'
   CI_IMAGE_VERSION: "5"
-  BUILD_STABLE_REGISTRY: '486234852809.dkr.ecr.us-east-1.amazonaws.com'
   CI_IMAGE: 'registry.ddbuild.io/ci/$REPO:$CI_IMAGE_VERSION'
   GIT_REPOSITORY: 'git@github.com:DataDog/dd-sdk-roku.git'
   MAIN_BRANCH: 'main'
@@ -32,7 +31,7 @@ stages:
   - notify
 
 .base-configuration:
-  tags: ['runner:main', 'size:large']
+  tags: ['arch:amd64']
   image: $CI_IMAGE
 
 ########################################################################################################################
@@ -43,12 +42,16 @@ ci-image:
   stage: ci-image
   when: manual
   except: [ tags, schedules ]
-  tags: ['runner:docker', 'size:large']
-  image: $BUILD_STABLE_REGISTRY/docker:18.03.1
+  tags: ['arch:amd64']
+  image: "registry.ddbuild.io/images/docker:27.3.1"
   script:
     - echo $CI_IMAGE
-    - docker build --tag $CI_IMAGE -f Dockerfile.gitlab .
-    - docker push $CI_IMAGE
+    - docker buildx build
+      --file Dockerfile.gitlab
+      --platform linux/amd64
+      --tag $CI_IMAGE
+      --push
+      .
 
 ########################################################################################################################
 # STATIC ANALYSIS


### PR DESCRIPTION
### What does this PR do?

Migrate the gitlab CI jobs to the kubernetes runners since
we can do docker builds in K8s via buildkit and the other
jobs don't access docker at all.

### Motivation

This repo is still using `runner:main` and `runner:docker`
which are legacy runners that will be decommissioned soon
due to running on EOL OS.

### Additional Notes

Relevant docs:
- [CI Legacy Runner Deprecation](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/5471568252/CI+Legacy+Runner+Deprecation#User-Guides)

> [!NOTE]
> For any questions, contact us on [#ci-runner-docker-deprecation](https://dd.enterprise.slack.com/archives/C069CKY4NQ6)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

