### PR TITLE
RUM-14368: Fix crash in RumViewScope

### DIFF
--- a/dist/components/rum/RumActionScope.brs
+++ b/dist/components/rum/RumActionScope.brs
@@ -19,7 +19,14 @@ sub init()
     m.lastEventTimestamp& = m.startTimestamp&
     m.errorCount = 0
     m.resourceCount = 0
-    datadogRumContext = m.global.datadogRumContext
+    datadogRumContext = (function(m)
+            __bsConsequent = m.global.datadogRumContext
+            if __bsConsequent <> invalid then
+                return __bsConsequent
+            else
+                return {}
+            end if
+        end function)(m)
     datadogRumContext.actionId = m.actionId
     m.global.setField("datadogRumContext", datadogRumContext)
 end sub

--- a/dist/components/rum/RumSessionScope.brs
+++ b/dist/components/rum/RumSessionScope.brs
@@ -131,7 +131,14 @@ sub renewSession(timestamp& as longinteger)
     else
         m.sessionState = "not_tracked"
     end if
-    datadogRumContext = m.global.datadogRumContext
+    datadogRumContext = (function(m)
+            __bsConsequent = m.global.datadogRumContext
+            if __bsConsequent <> invalid then
+                return __bsConsequent
+            else
+                return {}
+            end if
+        end function)(m)
     datadogRumContext.sessionId = m.sessionId
     m.global.setField("datadogRumContext", datadogRumContext)
 end sub

--- a/dist/components/rum/RumViewScope.brs
+++ b/dist/components/rum/RumViewScope.brs
@@ -24,7 +24,14 @@ sub init()
     m.actionCount = 0
     m.errorCount = 0
     m.resourceCount = 0
-    datadogRumContext = m.global.datadogRumContext
+    datadogRumContext = (function(m)
+            __bsConsequent = m.global.datadogRumContext
+            if __bsConsequent <> invalid then
+                return __bsConsequent
+            else
+                return {}
+            end if
+        end function)(m)
     datadogRumContext.viewId = m.viewId
     m.instanceId = (function(datadogRumContext)
             __bsConsequent = datadogRumContext.instanceId

--- a/library/components/rum/RumActionScope.bs
+++ b/library/components/rum/RumActionScope.bs
@@ -21,7 +21,7 @@ sub init()
     m.lastEventTimestamp& = m.startTimestamp&
     m.errorCount = 0
     m.resourceCount = 0
-    datadogRumContext = m.global.datadogRumContext
+    datadogRumContext = m.global.datadogRumContext ?? {}
     datadogRumContext.actionId = m.actionId
     m.global.setField("datadogRumContext", datadogRumContext)
 end sub

--- a/library/components/rum/RumSessionScope.bs
+++ b/library/components/rum/RumSessionScope.bs
@@ -116,7 +116,7 @@ sub renewSession(timestamp& as longinteger)
         m.sessionState = RumSessionState.not_tracked
     end if
 
-    datadogRumContext = m.global.datadogRumContext
+    datadogRumContext = m.global.datadogRumContext ?? {}
     datadogRumContext.sessionId = m.sessionId
     m.global.setField("datadogRumContext", datadogRumContext)
 end sub

--- a/library/components/rum/RumViewScope.bs
+++ b/library/components/rum/RumViewScope.bs
@@ -26,7 +26,7 @@ sub init()
     m.actionCount = 0
     m.errorCount = 0
     m.resourceCount = 0
-    datadogRumContext = m.global.datadogRumContext
+    datadogRumContext = m.global.datadogRumContext ?? {}
     datadogRumContext.viewId = m.viewId
     m.instanceId = datadogRumContext.instanceId ?? ""
     m.global.setField("datadogRumContext", datadogRumContext)

--- a/test/source/tests/rum/Test__RumActionScope.bs
+++ b/test/source/tests/rum/Test__RumActionScope.bs
@@ -11,6 +11,7 @@ function TestSuite__RumActionScope() as object
     this.Name = "RumActionScope"
 
     this.addTest("WhenInit_ThenUpdateGlobalRumContext", RumActionScopeTest__WhenInit_ThenUpdateGlobalRumContext, RumActionScopeTest__SetUp, RumActionScopeTest__TearDown)
+    this.addTest("WhenInitWithInvalidRumContext_ThenDoesNotCrash", RumActionScopeTest__WhenInitWithInvalidRumContext_ThenDoesNotCrash, RumActionScopeTest__SetUp, RumActionScopeTest__TearDown)
     this.addTest("WhenGetContext_ThenReturnsContext", RumActionScopeTest__WhenGetContext_ThenReturnsContext, RumActionScopeTest__SetUp, RumActionScopeTest__TearDown)
     this.addTest("WhenIsActive_ThenReturnsTrue", RumActionScopeTest__WhenIsActive_ThenReturnsTrue, RumActionScopeTest__SetUp, RumActionScopeTest__TearDown)
     this.addTest("WhenStoppedIsActive_ThenReturnsFalse", RumActionScopeTest__WhenStoppedIsActive_ThenReturnsFalse, RumActionScopeTest__SetUp, RumActionScopeTest__TearDown)
@@ -97,6 +98,32 @@ function RumActionScopeTest__WhenInit_ThenUpdateGlobalRumContext() as string
 
     ' Then
     Assert.that(context.actionId).isEqualTo(m.global.datadogRumContext.actionId)
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: m.global.datadogRumContext is invalid
+'  When: initializing RumActionScope
+'  Then: does not crash and initializes correctly
+'----------------------------------------------------------------
+function RumActionScopeTest__WhenInitWithInvalidRumContext_ThenDoesNotCrash() as string
+    ' Given
+    m.global.setField("datadogRumContext", invalid)
+    
+    ' When
+    testedScope = CreateObject("roSGNode", "datadogroku_RumActionScope")
+    testedScope.parentScope = m.mockParentScope
+    testedScope.target = m.fakeTarget
+    testedScope.actionType = m.fakeType
+    testedScope.context = m.fakeInitialContext
+    
+    ' Then
+    Assert.that(testedScope).isNotInvalid()
+    Assert.that(testedScope@.isActive()).isEqualTo(true)
+    context = testedScope@.getRumContext()
+    Assert.that(context.actionId).isNotEmpty()
+    Assert.that(m.global.datadogRumContext).isNotInvalid()
+    Assert.that(m.global.datadogRumContext.actionId).isEqualTo(context.actionId)
     return ""
 end function
 

--- a/test/source/tests/rum/Test__RumSessionScope.bs
+++ b/test/source/tests/rum/Test__RumSessionScope.bs
@@ -11,6 +11,7 @@ function TestSuite__RumSessionScope() as object
     this.Name = "RumSessionScope"
 
     this.addTest("WhenInit_ThenUpdateGlobalRumContext", RumSessionScopeTest__WhenInit_ThenUpdateGlobalRumContext, RumSessionScopeTest__SetUp, RumSessionScopeTest__TearDown)
+    this.addTest("WhenRenewSessionWithInvalidRumContext_ThenDoesNotCrash", RumSessionScopeTest__WhenRenewSessionWithInvalidRumContext_ThenDoesNotCrash, RumSessionScopeTest__SetUpNoSession, RumSessionScopeTest__TearDown)
     this.addTest("WhenGetContext_ThenReturnsContext", RumSessionScopeTest__WhenGetContext_ThenReturnsContext, RumSessionScopeTest__SetUp, RumSessionScopeTest__TearDown)
     this.addTest("WhenHandleStartViewEvent_ThenCreateViewScope", RumSessionScopeTest__WhenHandleStartViewEvent_ThenCreateViewScope, RumSessionScopeTest__SetUp, RumSessionScopeTest__TearDown)
     this.addTest("WhenHandleStartViewEventWithLocalContext_ThenCreateViewScope", RumSessionScopeTest__WhenHandleStartViewEventWithLocalContext_ThenCreateViewScope, RumSessionScopeTest__SetUp, RumSessionScopeTest__TearDown)
@@ -83,6 +84,30 @@ function RumSessionScopeTest__WhenInit_ThenUpdateGlobalRumContext() as string
 
     ' Then
     Assert.that(context.sessionId).isEqualTo(m.global.datadogRumContext.sessionId)
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: m.global.datadogRumContext is invalid
+'  When: renewing session (handling an interactive event)
+'  Then: does not crash and initializes correctly
+'----------------------------------------------------------------
+function RumSessionScopeTest__WhenRenewSessionWithInvalidRumContext_ThenDoesNotCrash() as string
+    ' Given
+    m.global.setField("datadogRumContext", invalid)
+    fakeAction = { target: IG_GetString(16), type: IG_GetOneOf(["click", "tap", "scroll", "swipe", "application_start", "back"]) }
+    fakeEvent = { mock: "event", eventType: "addAction", action: fakeAction }
+    fakeWriter = { mock: "writer" }
+    
+    ' When
+    m.testedScope@.handleEvent(fakeEvent, fakeWriter)
+    
+    ' Then
+    Assert.that(m.testedScope).isNotInvalid()
+    context = m.testedScope@.getRumContext()
+    Assert.that(context.sessionId).isNotEmpty()
+    Assert.that(m.global.datadogRumContext).isNotInvalid()
+    Assert.that(m.global.datadogRumContext.sessionId).isEqualTo(context.sessionId)
     return ""
 end function
 

--- a/test/source/tests/rum/Test__RumViewScope.bs
+++ b/test/source/tests/rum/Test__RumViewScope.bs
@@ -13,6 +13,7 @@ function TestSuite__RumViewScope() as object
     this.Name = "RumViewScope"
 
     this.addTest("WhenInit_ThenUpdateGlobalRumContext", RumViewScopeTest__WhenInit_ThenUpdateGlobalRumContext, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
+    this.addTest("WhenInitWithInvalidRumContext_ThenDoesNotCrash", RumViewScopeTest__WhenInitWithInvalidRumContext_ThenDoesNotCrash, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
     this.addTest("WhenGetContext_ThenReturnsContext", RumViewScopeTest__WhenGetContext_ThenReturnsContext, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
     this.addTest("WhenIsActive_ThenReturnsTrue", RumViewScopeTest__WhenIsActive_ThenReturnsTrue, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
     this.addTest("WhenStoppedIsActive_ThenReturnsFalse", RumViewScopeTest__WhenStoppedIsActive_ThenReturnsFalse, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
@@ -129,6 +130,34 @@ function RumViewScopeTest__WhenInit_ThenUpdateGlobalRumContext() as string
 
     ' Then
     Assert.that(context.viewId).isEqualTo(m.global.datadogRumContext.viewId)
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: m.global.datadogRumContext is invalid
+'  When: initializing RumViewScope
+'  Then: does not crash and initializes correctly
+'----------------------------------------------------------------
+function RumViewScopeTest__WhenInitWithInvalidRumContext_ThenDoesNotCrash() as string
+    ' Given
+    m.global.setField("datadogRumContext", invalid)
+    
+    ' When
+    testedScope = CreateObject("roSGNode", "datadogroku_RumViewScope")
+    testedScope.parentScope = m.mockParentScope
+    testedScope.viewName = m.fakeViewName
+    testedScope.viewUrl = m.fakeViewUrl
+    testedScope.context = m.fakeInitialContext
+    
+    ' Then
+    Assert.that(testedScope).isNotInvalid()
+    Assert.that(testedScope@.isActive()).isEqualTo(true)
+    context = testedScope@.getRumContext()
+    Assert.that(context.viewId).isNotEmpty()
+    Assert.that(context.viewName).isEqualTo(m.fakeViewName)
+    Assert.that(context.viewUrl).isEqualTo(m.fakeViewUrl)
+    Assert.that(m.global.datadogRumContext).isNotInvalid()
+    Assert.that(m.global.datadogRumContext.viewId).isEqualTo(context.viewId)
     return ""
 end function
 


### PR DESCRIPTION
### What does this PR do?

In some edge cases, `datadogRumContext` is not set when `RumViewScope` or other scopes are created, `datadogRumContext` will be `invalid`, causing crash when trying to access the field of it.

This PR fixes the issue by falling back to empty context when it is invalid.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

