### PR TITLE
[RUM-14638] Create RUM Vital Event factory

### DIFF
--- a/dist/source/rum/rumRawEvents.brs
+++ b/dist/source/rum/rumRawEvents.brs
@@ -115,6 +115,66 @@ function addTelemetryDebugEvent(message as string) as object
         message: message
     }
 end function
+
+' ----------------------------------------------------------------
+' @param name (string) the operation name (e.g.: "Login", "Checkout")
+' @param operationKey (dynamic) the operation key for distinguishing parallel operations, or invalid for unkeyed
+' @param context (object) an assocarray of custom attributes to add to the event
+' @return (object) an event describing a startFeatureOperation action
+' ----------------------------------------------------------------
+function startFeatureOperationEvent(name as string, operationKey as dynamic, context as object) as object
+    return {
+        eventType: "startFeatureOperation"
+        name: name
+        operationKey: operationKey
+        vitalId: CreateObject("roDeviceInfo").GetRandomUUID()
+        context: context
+    }
+end function
+
+' ----------------------------------------------------------------
+' @param name (string) the operation name (e.g.: "Login", "Checkout")
+' @param operationKey (dynamic) the operation key for distinguishing parallel operations, or invalid for unkeyed
+' @param context (object) an assocarray of custom attributes to add to the event
+' @return (object) an event describing a succeedFeatureOperation action
+' ----------------------------------------------------------------
+function succeedFeatureOperationEvent(name as string, operationKey as dynamic, context as object) as object
+    return {
+        eventType: "stopFeatureOperation"
+        name: name
+        operationKey: operationKey
+        vitalId: CreateObject("roDeviceInfo").GetRandomUUID()
+        context: context
+    }
+end function
+
+' ----------------------------------------------------------------
+' @param name (string) the operation name (e.g.: "Login", "Checkout")
+' @param operationKey (dynamic) the operation key for distinguishing parallel operations, or invalid for unkeyed
+' @param failureReason (string) the failure reason (use FailureReason enum values: "error", "abandoned", "other")
+' @param context (object) an assocarray of custom attributes to add to the event
+' @return (object) an event describing a failFeatureOperation action
+' ----------------------------------------------------------------
+function failFeatureOperationEvent(name as string, operationKey as dynamic, failureReason as string, context as object) as object
+    return {
+        eventType: "stopFeatureOperation"
+        name: name
+        operationKey: operationKey
+        failureReason: failureReason
+        vitalId: CreateObject("roDeviceInfo").GetRandomUUID()
+        context: context
+    }
+end function
 ' ----------------------------------------------------------------
 ' RawEvent: enum listing all the possible events handled by RUM scopes
+' ----------------------------------------------------------------
+
+' ----------------------------------------------------------------
+' VitalStepType: enum listing the step types for vital operation events
+' Values match the schema-defined string equivalents from vital-operation-step-schema.json
+' ----------------------------------------------------------------
+
+' ----------------------------------------------------------------
+' FailureReason: enum listing the failure reasons for vital operation events
+' Values match the schema-defined string equivalents from vital-operation-step-schema.json
 ' ----------------------------------------------------------------

--- a/library/source/rum/rumRawEvents.bs
+++ b/library/source/rum/rumRawEvents.bs
@@ -118,6 +118,56 @@ function addTelemetryDebugEvent(message as string) as object
 end function
 
 ' ----------------------------------------------------------------
+' @param name (string) the operation name (e.g.: "Login", "Checkout")
+' @param operationKey (dynamic) the operation key for distinguishing parallel operations, or invalid for unkeyed
+' @param context (object) an assocarray of custom attributes to add to the event
+' @return (object) an event describing a startFeatureOperation action
+' ----------------------------------------------------------------
+function startFeatureOperationEvent(name as string, operationKey as dynamic, context as object) as object
+    return {
+        eventType: RawEvent.startFeatureOperation,
+        name: name,
+        operationKey: operationKey,
+        vitalId: CreateObject("roDeviceInfo").GetRandomUUID(),
+        context: context
+    }
+end function
+
+' ----------------------------------------------------------------
+' @param name (string) the operation name (e.g.: "Login", "Checkout")
+' @param operationKey (dynamic) the operation key for distinguishing parallel operations, or invalid for unkeyed
+' @param context (object) an assocarray of custom attributes to add to the event
+' @return (object) an event describing a succeedFeatureOperation action
+' ----------------------------------------------------------------
+function succeedFeatureOperationEvent(name as string, operationKey as dynamic, context as object) as object
+    return {
+        eventType: RawEvent.stopFeatureOperation,
+        name: name,
+        operationKey: operationKey,
+        vitalId: CreateObject("roDeviceInfo").GetRandomUUID(),
+        context: context
+    }
+end function
+
+' ----------------------------------------------------------------
+' @param name (string) the operation name (e.g.: "Login", "Checkout")
+' @param operationKey (dynamic) the operation key for distinguishing parallel operations, or invalid for unkeyed
+' @param failureReason (string) the failure reason (use FailureReason enum values: "error", "abandoned", "other")
+' @param context (object) an assocarray of custom attributes to add to the event
+' @return (object) an event describing a failFeatureOperation action
+' ----------------------------------------------------------------
+function failFeatureOperationEvent(name as string, operationKey as dynamic, failureReason as string, context as object) as object
+    return {
+        eventType: RawEvent.stopFeatureOperation,
+        name: name,
+        operationKey: operationKey,
+        failureReason: failureReason,
+        vitalId: CreateObject("roDeviceInfo").GetRandomUUID(),
+        context: context
+    }
+end function
+
+' ----------------------------------------------------------------
 ' RawEvent: enum listing all the possible events handled by RUM scopes
 ' ----------------------------------------------------------------
 enum RawEvent

--- a/library/source/rum/rumRawEvents.bs
+++ b/library/source/rum/rumRawEvents.bs
@@ -131,4 +131,27 @@ enum RawEvent
     telemetryConfig = "telemetryConfig"
     telemetryDebug = "telemetryDebug"
     telemetryError = "telemetryError"
+    startFeatureOperation = "startFeatureOperation"
+    stopFeatureOperation = "stopFeatureOperation"
+end enum
+
+' ----------------------------------------------------------------
+' VitalStepType: enum listing the step types for vital operation events
+' Values match the schema-defined string equivalents from vital-operation-step-schema.json
+' ----------------------------------------------------------------
+enum VitalStepType
+    start = "start"
+    stepEnd = "end"
+    update = "update"
+    retry = "retry"
+end enum
+
+' ----------------------------------------------------------------
+' FailureReason: enum listing the failure reasons for vital operation events
+' Values match the schema-defined string equivalents from vital-operation-step-schema.json
+' ----------------------------------------------------------------
+enum FailureReason
+    error = "error"
+    abandoned = "abandoned"
+    other = "other"
 end enum


### PR DESCRIPTION
  ### What does this PR do?

  Adds the raw event types and factory functions needed to support RUM Vital Operations (feature operations) in the Roku SDK. This includes:

  - Three factory functions for creating vital operation raw events:
    - `startFeatureOperationEvent()` — creates a start event with a unique `vitalId`
    - `succeedFeatureOperationEvent()` — creates a stop event (success case)
    - `failFeatureOperationEvent()` — creates a stop event with a `failureReason`
  - Two new `RawEvent` enum members: `startFeatureOperation` and `stopFeatureOperation`
  - `VitalStepType` enum (`start`, `end`, `update`, `retry`) matching the vital-operation-step schema
  - `FailureReason` enum (`error`, `abandoned`, `other`) matching the vital-operation-step schema

  All factory functions accept `name`, `operationKey` (for distinguishing parallel operations), and `context` (custom attributes). Each generates a random UUID as `vitalId`.

  ### Motivation

  This is the foundational layer for RUM Vital Operations support in the Roku SDK, providing the raw event definitions and constructors that will be consumed by the RUM scope processing pipeline. Vital operations allow customers to track key user workflows (e.g., "Login", "Checkout") with duration, success/failure status, and custom context.

  ### Additional Notes

  - This PR only adds the raw event layer (`rumRawEvents.bs`). Scope processing, public API, and integration will follow in subsequent PRs.
  - Enum values for `VitalStepType` and `FailureReason` match the schema-defined strings from `vital-operation-step-schema.json`.
  - `operationKey` is typed as `dynamic` to allow `invalid` for unkeyed (non-parallel) operations.

  ### Review checklist (to be filled by reviewers)

  - [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
  - [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
  - [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

