### PR TITLE
[RUM-14640] Add RUM operation event processing at session scope

### DIFF
--- a/dist/components/rum/RumAgent.brs
+++ b/dist/components/rum/RumAgent.brs
@@ -33,6 +33,9 @@ sub init()
     m.top.observeFieldScoped("writer", m.port)
     m.top.observeFieldScoped("rumScope", m.port)
     m.top.observeFieldScoped("telemetryScope", m.port)
+    m.top.observeFieldScoped("startOperation", m.port)
+    m.top.observeFieldScoped("succeedOperation", m.port)
+    m.top.observeFieldScoped("failOperation", m.port)
     m.top.functionName = "rumAgentLoop"
     m.top.control = "RUN"
 end sub
@@ -81,6 +84,12 @@ sub rumAgentLoop()
                 if (msg.getData())
                     updateFields()
                 end if
+            else if (fieldName = "startOperation")
+                __onStartOperation(msg.getData())
+            else if (fieldName = "succeedOperation")
+                __onSucceedOperation(msg.getData())
+            else if (fieldName = "failOperation")
+                __onFailOperation(msg.getData())
             end if
         else
             ddLogWarning("Unexpected message " + msgType + ": " + FormatJson(msg))

--- a/dist/components/rum/RumAgent.brs
+++ b/dist/components/rum/RumAgent.brs
@@ -33,9 +33,6 @@ sub init()
     m.top.observeFieldScoped("writer", m.port)
     m.top.observeFieldScoped("rumScope", m.port)
     m.top.observeFieldScoped("telemetryScope", m.port)
-    m.top.observeFieldScoped("startOperation", m.port)
-    m.top.observeFieldScoped("succeedOperation", m.port)
-    m.top.observeFieldScoped("failOperation", m.port)
     m.top.functionName = "rumAgentLoop"
     m.top.control = "RUN"
 end sub
@@ -84,12 +81,6 @@ sub rumAgentLoop()
                 if (msg.getData())
                     updateFields()
                 end if
-            else if (fieldName = "startOperation")
-                __onStartOperation(msg.getData())
-            else if (fieldName = "succeedOperation")
-                __onSucceedOperation(msg.getData())
-            else if (fieldName = "failOperation")
-                __onFailOperation(msg.getData())
             end if
         else
             ddLogWarning("Unexpected message " + msgType + ": " + FormatJson(msg))
@@ -298,7 +289,9 @@ end sub
 ' ----------------------------------------------------------------
 sub __onStartOperation(event as object)
     ensureSetup()
-    m.rumScope.callfunc("handleEvent", event, m.writer)
+    if (m.rumScope <> invalid)
+        m.rumScope.callfunc("handleEvent", event, m.writer)
+    end if
 end sub
 
 ' ----------------------------------------------------------------
@@ -326,7 +319,9 @@ end sub
 ' ----------------------------------------------------------------
 sub __onSucceedOperation(event as object)
     ensureSetup()
-    m.rumScope.callfunc("handleEvent", event, m.writer)
+    if (m.rumScope <> invalid)
+        m.rumScope.callfunc("handleEvent", event, m.writer)
+    end if
 end sub
 
 ' ----------------------------------------------------------------
@@ -359,7 +354,9 @@ end sub
 ' ----------------------------------------------------------------
 sub __onFailOperation(event as object)
     ensureSetup()
-    m.rumScope.callfunc("handleEvent", event, m.writer)
+    if (m.rumScope <> invalid)
+        m.rumScope.callfunc("handleEvent", event, m.writer)
+    end if
 end sub
 
 ' ----------------------------------------------------------------

--- a/dist/components/rum/RumSessionScope.brs
+++ b/dist/components/rum/RumSessionScope.brs
@@ -1,8 +1,10 @@
 ' Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 ' This product includes software developed at Datadog (https://www.datadoghq.com/).
 ' Copyright 2022-Today Datadog, Inc.
+'import "pkg:/source/datadogSdk.bs"
 'import "pkg:/source/internalLogger.bs"
 'import "pkg:/source/timeUtils.bs"
+'import "pkg:/source/rum/rumHelper.bs"
 'import "pkg:/source/rum/rumRawEvents.bs"
 'import "pkg:/source/rum/rumSessionState.bs"
 ' ****************************************************************
@@ -46,6 +48,11 @@ sub handleEvent(event as object, writer as object)
             writer: "noOp"
             writeEvent: ""
         }
+    end if
+    ' Handle vital events at session scope (not delegated to view)
+    if (event.eventType = "startFeatureOperation" or event.eventType = "stopFeatureOperation")
+        handleVitalEvent(event, currentWriter)
+        return
     end if
     if (m.top.activeView <> invalid)
         m.top.activeView.callfunc("handleEvent", event, currentWriter)
@@ -125,6 +132,7 @@ sub renewSession(timestamp& as longinteger)
     ddLogInfo("Renewing the session (sampling rate: " + m.top.sessionSampleRate.toStr() + ")")
     m.sessionId = CreateObject("roDeviceInfo").GetRandomUUID()
     m.sessionStartMs = timestamp&
+    m.activeOperations = {}
     rndSession = (Rnd(101) - 1) ' Rnd(n) returns a number between 1 and n (both inclusive)
     if (rndSession < m.top.sessionSampleRate)
         m.sessionState = "tracked"
@@ -142,3 +150,178 @@ sub renewSession(timestamp& as longinteger)
     datadogRumContext.sessionId = m.sessionId
     m.global.setField("datadogRumContext", datadogRumContext)
 end sub
+
+' ----------------------------------------------------------------
+' Handles a vital operation event (start or stop)
+' @param event (object) the raw event (startFeatureOperation or stopFeatureOperation)
+' @param writer (object) the writer node (see WriterTask component)
+' ----------------------------------------------------------------
+sub handleVitalEvent(event as object, writer as object)
+    ' Determine step type from event type
+    if (event.eventType = "startFeatureOperation")
+        stepType = "start"
+    else
+        stepType = "end"
+    end if
+    ' Track active operations and log developer warnings
+    lookupKey = __operationLookupKey(event.name, event.operationKey)
+    if (stepType = "start")
+        __trackOperationStart(event.name, event.operationKey, lookupKey)
+    else
+        __trackOperationEnd(event.name, event.operationKey, lookupKey)
+    end if
+    ' Build and write the vital event (always emitted, warnings do not suppress)
+    sendVitalEvent(event, stepType, writer)
+end sub
+
+' ----------------------------------------------------------------
+' Sends a vital operation step event
+' @param event (object) the raw event containing vitalId, name, operationKey, failureReason, and context
+' @param stepType (string) the step type (VitalStepType enum value: "start" or "end")
+' @param writer (object) the writer node (see WriterTask component)
+' ----------------------------------------------------------------
+sub sendVitalEvent(event as object, stepType as string, writer as object)
+    timestamp& = getTimestamp()
+    rumContext = getRumContext(invalid)
+    ' Get view context if available
+    if (m.top.activeView <> invalid)
+        viewId = m.top.activeView.callfunc("getRumContext", invalid).viewId
+        viewUrl = m.top.activeView.viewUrl
+        viewName = m.top.activeView.viewName
+        viewContext = (function(m)
+                __bsConsequent = m.top.activeView.context
+                if __bsConsequent <> invalid then
+                    return __bsConsequent
+                else
+                    return {}
+                end if
+            end function)(m)
+    else
+        ddLogWarning("Vital operation event received without an active view. The event will be sent with incomplete context information.")
+        viewId = "00000000-0000-0000-0000-000000000000"
+        viewUrl = ""
+        viewName = invalid
+        viewContext = {}
+    end if
+    ' Merge attributes: Global < View < Command
+    mergedContext = mergeContext(mergeContext(m.global.datadogContext, viewContext), (function(event)
+            __bsConsequent = event.context
+            if __bsConsequent <> invalid then
+                return __bsConsequent
+            else
+                return {}
+            end if
+        end function)(event))
+    vitalEvent = {
+        _dd: {
+            format_version: 2
+            session: {
+                plan: 1
+            }
+        }
+        application: {
+            id: rumContext.applicationId
+        }
+        context: mergedContext
+        date: timestamp&
+        device: {
+            type: "tv"
+            name: rumContext.deviceName
+            model: rumContext.deviceModel
+            brand: "Roku"
+        }
+        os: {
+            name: "Roku"
+            version: rumContext.osVersion
+            version_major: rumContext.osVersionMajor
+        }
+        service: rumContext.service
+        session: {
+            has_replay: false
+            id: rumContext.sessionId
+            type: "user"
+        }
+        source: agentSource()
+        type: "vital"
+        usr: m.global.datadogUserInfo
+        version: rumContext.applicationVersion
+        view: {
+            id: viewId
+            url: viewUrl
+            name: viewName
+        }
+        vital: {
+            id: event.vitalId
+            name: event.name
+            type: "operation_step"
+            operation_key: event.operationKey
+            step_type: stepType
+            failure_reason: event.failureReason
+        }
+    }
+    ddLogInfo("Tracking vital operation '" + event.name + "' (" + stepType + ")")
+    writer.writeEvent = FormatJson(vitalEvent)
+end sub
+
+' ----------------------------------------------------------------
+' Returns the lookup key for an operation based on its name and operationKey
+' @param name (string) the operation name
+' @param operationKey (dynamic) the operation key, or invalid for unkeyed operations
+' @return (string) the lookup key for tracking active operations
+' ----------------------------------------------------------------
+function __operationLookupKey(name as string, operationKey as dynamic) as string
+    if (operationKey <> invalid)
+        return name + operationKey
+    end if
+    return name
+end function
+
+' ----------------------------------------------------------------
+' Ensures the active operations map is initialized (lazy initialization)
+' ----------------------------------------------------------------
+sub __ensureActiveOperations()
+    if (m.activeOperations = invalid)
+        m.activeOperations = {}
+    end if
+end sub
+
+' ----------------------------------------------------------------
+' Tracks the start of an operation, logging a warning if already active
+' @param name (string) the operation name
+' @param operationKey (dynamic) the operation key, or invalid for unkeyed operations
+' @param lookupKey (string) the lookup key from __operationLookupKey()
+' ----------------------------------------------------------------
+sub __trackOperationStart(name as string, operationKey as dynamic, lookupKey as string)
+    __ensureActiveOperations()
+    if (m.activeOperations.DoesExist(lookupKey))
+        ddLogWarning("Operation " + __formatOperationName(name, operationKey) + " has already been started. The previous instance may be terminated by the backend.")
+    end if
+    m.activeOperations[lookupKey] = true
+end sub
+
+' ----------------------------------------------------------------
+' Tracks the end of an operation, logging a warning if not currently active
+' @param name (string) the operation name
+' @param operationKey (dynamic) the operation key, or invalid for unkeyed operations
+' @param lookupKey (string) the lookup key from __operationLookupKey()
+' ----------------------------------------------------------------
+sub __trackOperationEnd(name as string, operationKey as dynamic, lookupKey as string)
+    __ensureActiveOperations()
+    if (not m.activeOperations.DoesExist(lookupKey))
+        ddLogWarning("Stop was called, but operation " + __formatOperationName(name, operationKey) + " is currently not active. Make sure to call startOperation first.")
+    end if
+    m.activeOperations.Delete(lookupKey)
+end sub
+
+' ----------------------------------------------------------------
+' Formats an operation name and key for use in developer warning messages
+' @param name (string) the operation name
+' @param operationKey (dynamic) the operation key, or invalid for unkeyed operations
+' @return (string) formatted operation identifier for warning messages
+' ----------------------------------------------------------------
+function __formatOperationName(name as string, operationKey as dynamic) as string
+    if (operationKey <> invalid)
+        return "'" + name + "' (key '" + operationKey + "')"
+    end if
+    return "'" + name + "'"
+end function

--- a/dist/components/rum/RumSessionScope.xml
+++ b/dist/components/rum/RumSessionScope.xml
@@ -10,4 +10,7 @@
     <script type="text/brightscript" uri="pkg:/source/timeUtils.brs" />
     <script type="text/brightscript" uri="pkg:/source/rum/rumSessionState.brs" />
     <script type="text/brightscript" uri="pkg:/source/rum/rumRawEvents.brs" />
+    <script type="text/brightscript" uri="pkg:/source/rum/rumHelper.brs" />
+    <script type="text/brightscript" uri="pkg:/source/fileUtils.brs" />
+    <script type="text/brightscript" uri="pkg:/source/datadogSdk.brs" />
 </component>

--- a/library/components/rum/RumAgent.bs
+++ b/library/components/rum/RumAgent.bs
@@ -293,7 +293,9 @@ end sub
 ' ----------------------------------------------------------------
 sub __onStartOperation(event as object)
     ensureSetup()
-    m.rumScope@.handleEvent(event, m.writer)
+    if(m.rumScope <> invalid)
+        m.rumScope@.handleEvent(event, m.writer)
+    end if
 end sub
 
 ' ----------------------------------------------------------------
@@ -321,7 +323,9 @@ end sub
 ' ----------------------------------------------------------------
 sub __onSucceedOperation(event as object)
     ensureSetup()
-    m.rumScope@.handleEvent(event, m.writer)
+    if(m.rumScope <> invalid)
+        m.rumScope@.handleEvent(event, m.writer)
+    end if
 end sub
 
 ' ----------------------------------------------------------------
@@ -354,7 +358,9 @@ end sub
 ' ----------------------------------------------------------------
 sub __onFailOperation(event as object)
     ensureSetup()
-    m.rumScope@.handleEvent(event, m.writer)
+    if(m.rumScope <> invalid)
+        m.rumScope@.handleEvent(event, m.writer)
+    end if
 end sub
 
 ' ----------------------------------------------------------------

--- a/library/components/rum/RumSessionScope.bs
+++ b/library/components/rum/RumSessionScope.bs
@@ -2,8 +2,10 @@
 ' This product includes software developed at Datadog (https://www.datadoghq.com/).
 ' Copyright 2022-Today Datadog, Inc.
 
+import "pkg:/source/datadogSdk.bs"
 import "pkg:/source/internalLogger.bs"
 import "pkg:/source/timeUtils.bs"
+import "pkg:/source/rum/rumHelper.bs"
 import "pkg:/source/rum/rumRawEvents.bs"
 import "pkg:/source/rum/rumSessionState.bs"
 
@@ -47,6 +49,12 @@ sub handleEvent(event as object, writer as object)
         currentWriter = writer
     else
         currentWriter = { writer: "noOp", writeEvent: "" }
+    end if
+
+    ' Handle vital events at session scope (not delegated to view)
+    if (event.eventType = RawEvent.startFeatureOperation or event.eventType = RawEvent.stopFeatureOperation)
+        handleVitalEvent(event, currentWriter)
+        return
     end if
 
     if (m.top.activeView <> invalid)
@@ -108,6 +116,7 @@ sub renewSession(timestamp& as longinteger)
     ddLogInfo("Renewing the session (sampling rate: " + m.top.sessionSampleRate.toStr() + ")")
     m.sessionId = CreateObject("roDeviceInfo").GetRandomUUID()
     m.sessionStartMs = timestamp&
+    m.activeOperations = {}
 
     rndSession = (Rnd(101) - 1) ' Rnd(n) returns a number between 1 and n (both inclusive)
     if (rndSession < m.top.sessionSampleRate)
@@ -120,3 +129,168 @@ sub renewSession(timestamp& as longinteger)
     datadogRumContext.sessionId = m.sessionId
     m.global.setField("datadogRumContext", datadogRumContext)
 end sub
+
+' ----------------------------------------------------------------
+' Handles a vital operation event (start or stop)
+' @param event (object) the raw event (startFeatureOperation or stopFeatureOperation)
+' @param writer (object) the writer node (see WriterTask component)
+' ----------------------------------------------------------------
+sub handleVitalEvent(event as object, writer as object)
+    ' Determine step type from event type
+    if (event.eventType = RawEvent.startFeatureOperation)
+        stepType = VitalStepType.start
+    else
+        stepType = VitalStepType.stepEnd
+    end if
+
+    ' Track active operations and log developer warnings
+    lookupKey = __operationLookupKey(event.name, event.operationKey)
+    if (stepType = VitalStepType.start)
+        __trackOperationStart(event.name, event.operationKey, lookupKey)
+    else
+        __trackOperationEnd(event.name, event.operationKey, lookupKey)
+    end if
+
+    ' Build and write the vital event (always emitted, warnings do not suppress)
+    sendVitalEvent(event, stepType, writer)
+end sub
+
+' ----------------------------------------------------------------
+' Sends a vital operation step event
+' @param event (object) the raw event containing vitalId, name, operationKey, failureReason, and context
+' @param stepType (string) the step type (VitalStepType enum value: "start" or "end")
+' @param writer (object) the writer node (see WriterTask component)
+' ----------------------------------------------------------------
+sub sendVitalEvent(event as object, stepType as string, writer as object)
+    timestamp& = getTimestamp()
+    rumContext = getRumContext(invalid)
+
+    ' Get view context if available
+    if (m.top.activeView <> invalid)
+        viewId = m.top.activeView@.getRumContext().viewId
+        viewUrl = m.top.activeView.viewUrl
+        viewName = m.top.activeView.viewName
+        viewContext = m.top.activeView.context ?? {}
+    else
+        ddLogWarning("Vital operation event received without an active view. The event will be sent with incomplete context information.")
+        viewId = "00000000-0000-0000-0000-000000000000"
+        viewUrl = ""
+        viewName = invalid
+        viewContext = {}
+    end if
+
+    ' Merge attributes: Global < View < Command
+    mergedContext = mergeContext(mergeContext(m.global.datadogContext, viewContext), event.context ?? {})
+
+    vitalEvent = {
+        _dd: {
+            format_version: 2,
+            session: { plan: 1 }
+        },
+        application: {
+            id: rumContext.applicationId
+        },
+        context: mergedContext,
+        date: timestamp&,
+        device: {
+            type: "tv",
+            name: rumContext.deviceName,
+            model: rumContext.deviceModel,
+            brand: "Roku"
+        },
+        os: {
+            name: "Roku",
+            version: rumContext.osVersion,
+            version_major: rumContext.osVersionMajor
+        },
+        service: rumContext.service,
+        session: {
+            has_replay: false,
+            id: rumContext.sessionId,
+            type: "user"
+        },
+        source: agentSource(),
+        type: "vital",
+        usr: m.global.datadogUserInfo,
+        version: rumContext.applicationVersion,
+        view: {
+            id: viewId,
+            url: viewUrl,
+            name: viewName
+        },
+        vital: {
+            id: event.vitalId,
+            name: event.name,
+            type: "operation_step",
+            operation_key: event.operationKey,
+            step_type: stepType,
+            failure_reason: event.failureReason
+        }
+    }
+
+    ddLogInfo("Tracking vital operation '" + event.name + "' (" + stepType + ")")
+    writer.writeEvent = FormatJson(vitalEvent)
+end sub
+
+' ----------------------------------------------------------------
+' Returns the lookup key for an operation based on its name and operationKey
+' @param name (string) the operation name
+' @param operationKey (dynamic) the operation key, or invalid for unkeyed operations
+' @return (string) the lookup key for tracking active operations
+' ----------------------------------------------------------------
+function __operationLookupKey(name as string, operationKey as dynamic) as string
+    if (operationKey <> invalid)
+        return name + operationKey
+    end if
+    return name
+end function
+
+' ----------------------------------------------------------------
+' Ensures the active operations map is initialized (lazy initialization)
+' ----------------------------------------------------------------
+sub __ensureActiveOperations()
+    if (m.activeOperations = invalid)
+        m.activeOperations = {}
+    end if
+end sub
+
+' ----------------------------------------------------------------
+' Tracks the start of an operation, logging a warning if already active
+' @param name (string) the operation name
+' @param operationKey (dynamic) the operation key, or invalid for unkeyed operations
+' @param lookupKey (string) the lookup key from __operationLookupKey()
+' ----------------------------------------------------------------
+sub __trackOperationStart(name as string, operationKey as dynamic, lookupKey as string)
+    __ensureActiveOperations()
+    if (m.activeOperations.DoesExist(lookupKey))
+        ddLogWarning("Operation " + __formatOperationName(name, operationKey) + " has already been started. The previous instance may be terminated by the backend.")
+    end if
+    m.activeOperations[lookupKey] = true
+end sub
+
+' ----------------------------------------------------------------
+' Tracks the end of an operation, logging a warning if not currently active
+' @param name (string) the operation name
+' @param operationKey (dynamic) the operation key, or invalid for unkeyed operations
+' @param lookupKey (string) the lookup key from __operationLookupKey()
+' ----------------------------------------------------------------
+sub __trackOperationEnd(name as string, operationKey as dynamic, lookupKey as string)
+    __ensureActiveOperations()
+    if (not m.activeOperations.DoesExist(lookupKey))
+        ddLogWarning("Stop was called, but operation " + __formatOperationName(name, operationKey) + " is currently not active. Make sure to call startOperation first.")
+    end if
+    m.activeOperations.Delete(lookupKey)
+end sub
+
+' ----------------------------------------------------------------
+' Formats an operation name and key for use in developer warning messages
+' @param name (string) the operation name
+' @param operationKey (dynamic) the operation key, or invalid for unkeyed operations
+' @return (string) formatted operation identifier for warning messages
+' ----------------------------------------------------------------
+function __formatOperationName(name as string, operationKey as dynamic) as string
+    if (operationKey <> invalid)
+        return "'" + name + "' (key '" + operationKey + "')"
+    end if
+    return "'" + name + "'"
+end function

--- a/test/source/tests/rum/Test__RumSessionScope.bs
+++ b/test/source/tests/rum/Test__RumSessionScope.bs
@@ -33,6 +33,33 @@ function TestSuite__RumSessionScope() as object
     this.addTest("WhenHandleActionEventAfterTimeout_ThenRenewSession", RumSessionScopeTest__WhenHandleActionEventAfterTimeout_ThenRenewSession, RumSessionScopeTest__SetUpNoSession, RumSessionScopeTest__TearDown)
     this.addTest("WhenHandleViewEventAfterTimeout_ThenRenewSession", RumSessionScopeTest__WhenHandleViewEventAfterTimeout_ThenRenewSession, RumSessionScopeTest__SetUpNoSession, RumSessionScopeTest__TearDown)
 
+    ' Vital event payload structure tests
+    this.addTest("WhenHandleStartVitalEvent_ThenWriteCorrectPayload", RumSessionScopeTest__WhenHandleStartVitalEvent_ThenWriteCorrectPayload, RumSessionScopeTest__SetUpWithView, RumSessionScopeTest__TearDown)
+    this.addTest("WhenHandleSucceedVitalEvent_ThenWriteCorrectPayload", RumSessionScopeTest__WhenHandleSucceedVitalEvent_ThenWriteCorrectPayload, RumSessionScopeTest__SetUpWithView, RumSessionScopeTest__TearDown)
+    this.addTest("WhenHandleFailVitalEvent_ThenWriteCorrectPayload", RumSessionScopeTest__WhenHandleFailVitalEvent_ThenWriteCorrectPayload, RumSessionScopeTest__SetUpWithView, RumSessionScopeTest__TearDown)
+
+    ' Developer warning behavioral tests
+    this.addTest("WhenDuplicateStartSameNameAndKey_ThenBothEventsEmitted", RumSessionScopeTest__WhenDuplicateStartSameNameAndKey_ThenBothEventsEmitted, RumSessionScopeTest__SetUpWithView, RumSessionScopeTest__TearDown)
+    this.addTest("WhenDuplicateStartUnkeyed_ThenBothEventsEmitted", RumSessionScopeTest__WhenDuplicateStartUnkeyed_ThenBothEventsEmitted, RumSessionScopeTest__SetUpWithView, RumSessionScopeTest__TearDown)
+    this.addTest("WhenStopWithoutStart_ThenEventStillEmitted", RumSessionScopeTest__WhenStopWithoutStart_ThenEventStillEmitted, RumSessionScopeTest__SetUpWithView, RumSessionScopeTest__TearDown)
+    this.addTest("WhenStartThenStop_ThenBothEventsEmitted", RumSessionScopeTest__WhenStartThenStop_ThenBothEventsEmitted, RumSessionScopeTest__SetUpWithView, RumSessionScopeTest__TearDown)
+
+    ' Parallel keyed operations tests
+    this.addTest("WhenParallelKeyedOperations_ThenTrackedIndependently", RumSessionScopeTest__WhenParallelKeyedOperations_ThenTrackedIndependently, RumSessionScopeTest__SetUpWithView, RumSessionScopeTest__TearDown)
+    this.addTest("WhenStopWrongKey_ThenEventStillEmitted", RumSessionScopeTest__WhenStopWrongKey_ThenEventStillEmitted, RumSessionScopeTest__SetUpWithView, RumSessionScopeTest__TearDown)
+    this.addTest("WhenUnkeyedOperationDispatch_ThenCorrectPayload", RumSessionScopeTest__WhenUnkeyedOperationDispatch_ThenCorrectPayload, RumSessionScopeTest__SetUpWithView, RumSessionScopeTest__TearDown)
+
+    ' Edge case and integration flow tests
+    this.addTest("WhenVitalEventWithNoView_ThenWriteWithNullViewId", RumSessionScopeTest__WhenVitalEventWithNoView_ThenWriteWithNullViewId, RumSessionScopeTest__SetUp, RumSessionScopeTest__TearDown)
+    this.addTest("WhenCrossViewOperation_ThenEachEventCarriesCorrectViewContext", RumSessionScopeTest__WhenCrossViewOperation_ThenEachEventCarriesCorrectViewContext, RumSessionScopeTest__SetUpWithView, RumSessionScopeTest__TearDown)
+    this.addTest("WhenSessionRenewalMidOperation_ThenActiveOperationsCleared", RumSessionScopeTest__WhenSessionRenewalMidOperation_ThenActiveOperationsCleared, RumSessionScopeTest__SetUpWithView, RumSessionScopeTest__TearDown)
+    this.addTest("WhenVitalEventWithUnicodeNameAndKey_ThenWriteCorrectPayload", RumSessionScopeTest__WhenVitalEventWithUnicodeNameAndKey_ThenWriteCorrectPayload, RumSessionScopeTest__SetUpWithView, RumSessionScopeTest__TearDown)
+    this.addTest("WhenVitalEventWithLongName_ThenWriteCorrectPayload", RumSessionScopeTest__WhenVitalEventWithLongName_ThenWriteCorrectPayload, RumSessionScopeTest__SetUpWithView, RumSessionScopeTest__TearDown)
+    this.addTest("WhenVitalEventWithSpecialCharsInName_ThenWriteCorrectPayload", RumSessionScopeTest__WhenVitalEventWithSpecialCharsInName_ThenWriteCorrectPayload, RumSessionScopeTest__SetUpWithView, RumSessionScopeTest__TearDown)
+
+    ' Attribute merging priority test
+    this.addTest("WhenVitalEventWithMergedAttributes_ThenCommandOverridesViewOverridesGlobal", RumSessionScopeTest__WhenVitalEventWithMergedAttributes_ThenCommandOverridesViewOverridesGlobal, RumSessionScopeTest__SetUpWithView, RumSessionScopeTest__TearDown)
+
     return this
 end function
 
@@ -42,7 +69,7 @@ sub RumSessionScopeTest__SetUp()
     m.testSuite.mockParentScope = CreateObject("roSGNode", "MockRumScope")
 
     ' Fake data
-    m.testSuite.global.addFields({ datadogRumContext: {} })
+    m.testSuite.global.addFields({ datadogRumContext: {}, datadogContext: {}, datadogUserInfo: {} })
 
     ' Tested Task
     m.testSuite.testedScope = CreateObject("roSGNode", "datadogroku_RumSessionScope")
@@ -65,6 +92,47 @@ sub RumSessionScopeTest__SetUpNoSession()
     m.testSuite.testedScope.parentScope = m.testSuite.mockParentScope
     m.testSuite.testedScope.inactivityThresholdMs = 100
     m.testSuite.testedScope.maxDurationMs = 1000
+end sub
+
+sub RumSessionScopeTest__SetUpWithView()
+    ' Mocks
+    m.testSuite.mockWriter = CreateObject("roSGNode", "MockWriterTask")
+    m.testSuite.mockParentScope = CreateObject("roSGNode", "MockRumScope")
+
+    ' Fake data for parent context
+    m.testSuite.fakeApplicationId = IG_GetString(32)
+    m.testSuite.fakeService = IG_GetString(32)
+    m.testSuite.fakeVersion = IG_GetString(16)
+    m.testSuite.fakeDeviceName = IG_GetString(16)
+    m.testSuite.fakeDeviceModel = IG_GetString(16)
+    m.testSuite.fakeOsVersion = IG_GetString(16)
+    m.testSuite.fakeOsVersionMajor = IG_GetString(16)
+    m.testSuite.fakeViewName = IG_GetString(16)
+    m.testSuite.fakeViewUrl = "https://" + IG_GetString(32)
+    m.testSuite.fakeParentContext = {
+        applicationId: m.testSuite.fakeApplicationId,
+        service: m.testSuite.fakeService,
+        applicationVersion: m.testSuite.fakeVersion,
+        deviceName: m.testSuite.fakeDeviceName,
+        deviceModel: m.testSuite.fakeDeviceModel,
+        osVersion: m.testSuite.fakeOsVersion,
+        osVersionMajor: m.testSuite.fakeOsVersionMajor
+    }
+    m.testSuite.mockParentScope@.stubCall("getRumContext", { _ph: invalid }, m.testSuite.fakeParentContext)
+
+    ' Global fields (required by SDK infrastructure)
+    m.testSuite.global.addFields({ datadogRumContext: {}, datadogContext: {}, datadogUserInfo: {} })
+
+    ' Create and initialize session scope
+    m.testSuite.testedScope = CreateObject("roSGNode", "datadogroku_RumSessionScope")
+    m.testSuite.testedScope.parentScope = m.testSuite.mockParentScope
+    m.testSuite.testedScope.inactivityThresholdMs = 100
+    m.testSuite.testedScope.maxDurationMs = 1000
+    ' Initialize session (resetSession triggers renewSession)
+    m.testSuite.testedScope@.handleEvent({ mock: "event", eventType: "resetSession" }, { mock: "writer" })
+
+    ' Create an active view
+    m.testSuite.testedScope@.handleEvent({ mock: "event", eventType: "startView", viewName: m.testSuite.fakeViewName, viewUrl: m.testSuite.fakeViewUrl }, m.testSuite.mockWriter)
 end sub
 
 sub RumSessionScopeTest__TearDown()
@@ -568,5 +636,661 @@ function RumSessionScopeTest__WhenHandleViewEventAfterTimeout_ThenRenewSession()
     ' Then
     Assert.that(updatedContext.sessionId).isNotEqualTo(initialContext.sessionId)
     Assert.that(updatedContext.sessionState).isEqualTo("tracked")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a RumSessionScope with an active view
+'  When: handling a startFeatureOperation vital event
+'  Then: writes a complete vital event payload with correct structure
+'----------------------------------------------------------------
+function RumSessionScopeTest__WhenHandleStartVitalEvent_ThenWriteCorrectPayload() as string
+    ' Given
+    fakeName = IG_GetString(32)
+    fakeKey = IG_GetString(32)
+    fakeVitalId = CreateObject("roDeviceInfo").GetRandomUUID()
+    fakeEvent = { eventType: "startFeatureOperation", name: fakeName, operationKey: fakeKey, vitalId: fakeVitalId, context: {} }
+
+    ' Count existing writer updates from setUp (startView does NOT write to writer)
+    existingUpdates = m.mockWriter@.getFieldUpdates("writeEvent")
+    existingCount = existingUpdates.count()
+
+    ' When
+    timestampBefore& = datadogroku_getTimestamp()
+    m.testedScope@.handleEvent(fakeEvent, m.mockWriter)
+    timestampAfter& = datadogroku_getTimestamp()
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    Assert.that(updates).hasSize(existingCount + 1)
+    vitalEvent = ParseJson(updates[existingCount])
+    Assert.that(vitalEvent).isNotInvalid()
+
+    ' _dd section
+    Assert.that(vitalEvent._dd.format_version).isEqualTo(2)
+    Assert.that(vitalEvent._dd.session.plan).isEqualTo(1)
+
+    ' Application and session context
+    Assert.that(vitalEvent.application.id).isEqualTo(m.fakeApplicationId)
+    Assert.that(vitalEvent.session.id).isNotEmpty()
+    Assert.that(vitalEvent.session.type).isEqualTo("user")
+    Assert.that(vitalEvent.session.has_replay).isEqualTo(false)
+
+    ' Device and OS
+    Assert.that(vitalEvent.device.type).isEqualTo("tv")
+    Assert.that(vitalEvent.device.name).isEqualTo(m.fakeDeviceName)
+    Assert.that(vitalEvent.device.model).isEqualTo(m.fakeDeviceModel)
+    Assert.that(vitalEvent.device.brand).isEqualTo("Roku")
+    Assert.that(vitalEvent.os.name).isEqualTo("Roku")
+    Assert.that(vitalEvent.os.version).isEqualTo(m.fakeOsVersion)
+    Assert.that(vitalEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+
+    ' Common fields
+    Assert.that(vitalEvent.service).isEqualTo(m.fakeService)
+    Assert.that(vitalEvent.source).isEqualTo("roku")
+    Assert.that(vitalEvent.type).isEqualTo("vital")
+    Assert.that(vitalEvent.version).isEqualTo(m.fakeVersion)
+    Assert.that(vitalEvent.date).isInRange(timestampBefore&, timestampAfter& + 5)
+
+    ' View context
+    Assert.that(vitalEvent.view.id).isNotEmpty()
+    Assert.that(vitalEvent.view.url).isEqualTo(m.fakeViewUrl)
+
+    ' Vital-specific section
+    Assert.that(vitalEvent.vital.id).isEqualTo(fakeVitalId)
+    Assert.that(vitalEvent.vital.name).isEqualTo(fakeName)
+    Assert.that(vitalEvent.vital.type).isEqualTo("operation_step")
+    Assert.that(vitalEvent.vital.step_type).isEqualTo("start")
+    Assert.that(vitalEvent.vital.operation_key).isEqualTo(fakeKey)
+    Assert.that(vitalEvent.vital.failure_reason).isEqualTo(invalid)
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a RumSessionScope with an active view
+'  When: handling a stopFeatureOperation vital event (succeed, no failure)
+'  Then: writes a complete vital event payload with step_type "end" and no failure_reason
+'----------------------------------------------------------------
+function RumSessionScopeTest__WhenHandleSucceedVitalEvent_ThenWriteCorrectPayload() as string
+    ' Given
+    fakeName = IG_GetString(32)
+    fakeKey = IG_GetString(32)
+    fakeVitalId = CreateObject("roDeviceInfo").GetRandomUUID()
+    fakeEvent = { eventType: "stopFeatureOperation", name: fakeName, operationKey: fakeKey, vitalId: fakeVitalId, context: {} }
+
+    ' Count existing writer updates from setUp
+    existingUpdates = m.mockWriter@.getFieldUpdates("writeEvent")
+    existingCount = existingUpdates.count()
+
+    ' When
+    timestampBefore& = datadogroku_getTimestamp()
+    m.testedScope@.handleEvent(fakeEvent, m.mockWriter)
+    timestampAfter& = datadogroku_getTimestamp()
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    Assert.that(updates).hasSize(existingCount + 1)
+    vitalEvent = ParseJson(updates[existingCount])
+    Assert.that(vitalEvent).isNotInvalid()
+
+    ' _dd section
+    Assert.that(vitalEvent._dd.format_version).isEqualTo(2)
+    Assert.that(vitalEvent._dd.session.plan).isEqualTo(1)
+
+    ' Application and session context
+    Assert.that(vitalEvent.application.id).isEqualTo(m.fakeApplicationId)
+    Assert.that(vitalEvent.session.id).isNotEmpty()
+    Assert.that(vitalEvent.session.type).isEqualTo("user")
+    Assert.that(vitalEvent.session.has_replay).isEqualTo(false)
+
+    ' Device and OS
+    Assert.that(vitalEvent.device.type).isEqualTo("tv")
+    Assert.that(vitalEvent.device.name).isEqualTo(m.fakeDeviceName)
+    Assert.that(vitalEvent.device.model).isEqualTo(m.fakeDeviceModel)
+    Assert.that(vitalEvent.device.brand).isEqualTo("Roku")
+    Assert.that(vitalEvent.os.name).isEqualTo("Roku")
+    Assert.that(vitalEvent.os.version).isEqualTo(m.fakeOsVersion)
+    Assert.that(vitalEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+
+    ' Common fields
+    Assert.that(vitalEvent.service).isEqualTo(m.fakeService)
+    Assert.that(vitalEvent.source).isEqualTo("roku")
+    Assert.that(vitalEvent.type).isEqualTo("vital")
+    Assert.that(vitalEvent.version).isEqualTo(m.fakeVersion)
+    Assert.that(vitalEvent.date).isInRange(timestampBefore&, timestampAfter& + 5)
+
+    ' View context
+    Assert.that(vitalEvent.view.id).isNotEmpty()
+    Assert.that(vitalEvent.view.url).isEqualTo(m.fakeViewUrl)
+
+    ' Vital-specific section
+    Assert.that(vitalEvent.vital.id).isEqualTo(fakeVitalId)
+    Assert.that(vitalEvent.vital.name).isEqualTo(fakeName)
+    Assert.that(vitalEvent.vital.type).isEqualTo("operation_step")
+    Assert.that(vitalEvent.vital.step_type).isEqualTo("end")
+    Assert.that(vitalEvent.vital.operation_key).isEqualTo(fakeKey)
+    Assert.that(vitalEvent.vital.failure_reason).isEqualTo(invalid)
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a RumSessionScope with an active view
+'  When: handling a stopFeatureOperation vital event (fail, with failure reason)
+'  Then: writes a complete vital event payload with step_type "end" and failure_reason "error"
+'----------------------------------------------------------------
+function RumSessionScopeTest__WhenHandleFailVitalEvent_ThenWriteCorrectPayload() as string
+    ' Given
+    fakeName = IG_GetString(32)
+    fakeKey = IG_GetString(32)
+    fakeVitalId = CreateObject("roDeviceInfo").GetRandomUUID()
+    fakeEvent = { eventType: "stopFeatureOperation", name: fakeName, operationKey: fakeKey, failureReason: "error", vitalId: fakeVitalId, context: {} }
+
+    ' Count existing writer updates from setUp
+    existingUpdates = m.mockWriter@.getFieldUpdates("writeEvent")
+    existingCount = existingUpdates.count()
+
+    ' When
+    timestampBefore& = datadogroku_getTimestamp()
+    m.testedScope@.handleEvent(fakeEvent, m.mockWriter)
+    timestampAfter& = datadogroku_getTimestamp()
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    Assert.that(updates).hasSize(existingCount + 1)
+    vitalEvent = ParseJson(updates[existingCount])
+    Assert.that(vitalEvent).isNotInvalid()
+
+    ' _dd section
+    Assert.that(vitalEvent._dd.format_version).isEqualTo(2)
+    Assert.that(vitalEvent._dd.session.plan).isEqualTo(1)
+
+    ' Application and session context
+    Assert.that(vitalEvent.application.id).isEqualTo(m.fakeApplicationId)
+    Assert.that(vitalEvent.session.id).isNotEmpty()
+    Assert.that(vitalEvent.session.type).isEqualTo("user")
+    Assert.that(vitalEvent.session.has_replay).isEqualTo(false)
+
+    ' Device and OS
+    Assert.that(vitalEvent.device.type).isEqualTo("tv")
+    Assert.that(vitalEvent.device.name).isEqualTo(m.fakeDeviceName)
+    Assert.that(vitalEvent.device.model).isEqualTo(m.fakeDeviceModel)
+    Assert.that(vitalEvent.device.brand).isEqualTo("Roku")
+    Assert.that(vitalEvent.os.name).isEqualTo("Roku")
+    Assert.that(vitalEvent.os.version).isEqualTo(m.fakeOsVersion)
+    Assert.that(vitalEvent.os.version_major).isEqualTo(m.fakeOsVersionMajor)
+
+    ' Common fields
+    Assert.that(vitalEvent.service).isEqualTo(m.fakeService)
+    Assert.that(vitalEvent.source).isEqualTo("roku")
+    Assert.that(vitalEvent.type).isEqualTo("vital")
+    Assert.that(vitalEvent.version).isEqualTo(m.fakeVersion)
+    Assert.that(vitalEvent.date).isInRange(timestampBefore&, timestampAfter& + 5)
+
+    ' View context
+    Assert.that(vitalEvent.view.id).isNotEmpty()
+    Assert.that(vitalEvent.view.url).isEqualTo(m.fakeViewUrl)
+
+    ' Vital-specific section
+    Assert.that(vitalEvent.vital.id).isEqualTo(fakeVitalId)
+    Assert.that(vitalEvent.vital.name).isEqualTo(fakeName)
+    Assert.that(vitalEvent.vital.type).isEqualTo("operation_step")
+    Assert.that(vitalEvent.vital.step_type).isEqualTo("end")
+    Assert.that(vitalEvent.vital.operation_key).isEqualTo(fakeKey)
+    Assert.that(vitalEvent.vital.failure_reason).isEqualTo("error")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a RumSessionScope with an active view
+'  When: sending two startFeatureOperation events with same name and same operationKey
+'  Then: both events are written to the writer (warnings don't suppress emission)
+'----------------------------------------------------------------
+function RumSessionScopeTest__WhenDuplicateStartSameNameAndKey_ThenBothEventsEmitted() as string
+    ' Given
+    fakeName = IG_GetString(32)
+    fakeKey = IG_GetString(32)
+    fakeVitalId1 = CreateObject("roDeviceInfo").GetRandomUUID()
+    fakeVitalId2 = CreateObject("roDeviceInfo").GetRandomUUID()
+    fakeEvent1 = { eventType: "startFeatureOperation", name: fakeName, operationKey: fakeKey, vitalId: fakeVitalId1, context: {} }
+    fakeEvent2 = { eventType: "startFeatureOperation", name: fakeName, operationKey: fakeKey, vitalId: fakeVitalId2, context: {} }
+
+    existingUpdates = m.mockWriter@.getFieldUpdates("writeEvent")
+    existingCount = existingUpdates.count()
+
+    ' When
+    m.testedScope@.handleEvent(fakeEvent1, m.mockWriter)
+    m.testedScope@.handleEvent(fakeEvent2, m.mockWriter)
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    Assert.that(updates).hasSize(existingCount + 2)
+    vitalEvent1 = ParseJson(updates[existingCount])
+    vitalEvent2 = ParseJson(updates[existingCount + 1])
+    Assert.that(vitalEvent1).isNotInvalid()
+    Assert.that(vitalEvent2).isNotInvalid()
+    Assert.that(vitalEvent1.vital.step_type).isEqualTo("start")
+    Assert.that(vitalEvent2.vital.step_type).isEqualTo("start")
+    Assert.that(vitalEvent1.vital.name).isEqualTo(fakeName)
+    Assert.that(vitalEvent2.vital.name).isEqualTo(fakeName)
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a RumSessionScope with an active view
+'  When: sending two startFeatureOperation events with same name, operationKey = invalid (unkeyed)
+'  Then: both events are emitted
+'----------------------------------------------------------------
+function RumSessionScopeTest__WhenDuplicateStartUnkeyed_ThenBothEventsEmitted() as string
+    ' Given
+    fakeName = IG_GetString(32)
+    fakeVitalId1 = CreateObject("roDeviceInfo").GetRandomUUID()
+    fakeVitalId2 = CreateObject("roDeviceInfo").GetRandomUUID()
+    fakeEvent1 = { eventType: "startFeatureOperation", name: fakeName, operationKey: invalid, vitalId: fakeVitalId1, context: {} }
+    fakeEvent2 = { eventType: "startFeatureOperation", name: fakeName, operationKey: invalid, vitalId: fakeVitalId2, context: {} }
+
+    existingUpdates = m.mockWriter@.getFieldUpdates("writeEvent")
+    existingCount = existingUpdates.count()
+
+    ' When
+    m.testedScope@.handleEvent(fakeEvent1, m.mockWriter)
+    m.testedScope@.handleEvent(fakeEvent2, m.mockWriter)
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    Assert.that(updates).hasSize(existingCount + 2)
+    vitalEvent1 = ParseJson(updates[existingCount])
+    vitalEvent2 = ParseJson(updates[existingCount + 1])
+    Assert.that(vitalEvent1).isNotInvalid()
+    Assert.that(vitalEvent2).isNotInvalid()
+    Assert.that(vitalEvent1.vital.step_type).isEqualTo("start")
+    Assert.that(vitalEvent2.vital.step_type).isEqualTo("start")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a RumSessionScope with an active view, NO prior startFeatureOperation
+'  When: sending a stopFeatureOperation event
+'  Then: event is still emitted (Roku is a thin pipe — warnings don't suppress)
+'----------------------------------------------------------------
+function RumSessionScopeTest__WhenStopWithoutStart_ThenEventStillEmitted() as string
+    ' Given
+    fakeName = IG_GetString(32)
+    fakeKey = IG_GetString(32)
+    fakeVitalId = CreateObject("roDeviceInfo").GetRandomUUID()
+    fakeEvent = { eventType: "stopFeatureOperation", name: fakeName, operationKey: fakeKey, vitalId: fakeVitalId, context: {} }
+
+    existingUpdates = m.mockWriter@.getFieldUpdates("writeEvent")
+    existingCount = existingUpdates.count()
+
+    ' When
+    m.testedScope@.handleEvent(fakeEvent, m.mockWriter)
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    Assert.that(updates).hasSize(existingCount + 1)
+    vitalEvent = ParseJson(updates[existingCount])
+    Assert.that(vitalEvent).isNotInvalid()
+    Assert.that(vitalEvent.vital.step_type).isEqualTo("end")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a RumSessionScope with an active view
+'  When: sending startFeatureOperation then stopFeatureOperation with same name/key
+'  Then: 2 events written. First has step_type "start", second has step_type "end".
+'----------------------------------------------------------------
+function RumSessionScopeTest__WhenStartThenStop_ThenBothEventsEmitted() as string
+    ' Given
+    fakeName = IG_GetString(32)
+    fakeKey = IG_GetString(32)
+    fakeVitalId1 = CreateObject("roDeviceInfo").GetRandomUUID()
+    fakeVitalId2 = CreateObject("roDeviceInfo").GetRandomUUID()
+    fakeStartEvent = { eventType: "startFeatureOperation", name: fakeName, operationKey: fakeKey, vitalId: fakeVitalId1, context: {} }
+    fakeStopEvent = { eventType: "stopFeatureOperation", name: fakeName, operationKey: fakeKey, vitalId: fakeVitalId2, context: {} }
+
+    existingUpdates = m.mockWriter@.getFieldUpdates("writeEvent")
+    existingCount = existingUpdates.count()
+
+    ' When
+    m.testedScope@.handleEvent(fakeStartEvent, m.mockWriter)
+    m.testedScope@.handleEvent(fakeStopEvent, m.mockWriter)
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    Assert.that(updates).hasSize(existingCount + 2)
+    startVitalEvent = ParseJson(updates[existingCount])
+    stopVitalEvent = ParseJson(updates[existingCount + 1])
+    Assert.that(startVitalEvent).isNotInvalid()
+    Assert.that(stopVitalEvent).isNotInvalid()
+    Assert.that(startVitalEvent.vital.step_type).isEqualTo("start")
+    Assert.that(stopVitalEvent.vital.step_type).isEqualTo("end")
+    Assert.that(startVitalEvent.vital.name).isEqualTo(fakeName)
+    Assert.that(stopVitalEvent.vital.name).isEqualTo(fakeName)
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a RumSessionScope with an active view
+'  When: start "checkout" with key "cart1", start "checkout" with key "cart2", stop "checkout" with key "cart1"
+'  Then: 3 events emitted, all valid vital events
+'----------------------------------------------------------------
+function RumSessionScopeTest__WhenParallelKeyedOperations_ThenTrackedIndependently() as string
+    ' Given
+    fakeVitalId1 = CreateObject("roDeviceInfo").GetRandomUUID()
+    fakeVitalId2 = CreateObject("roDeviceInfo").GetRandomUUID()
+    fakeVitalId3 = CreateObject("roDeviceInfo").GetRandomUUID()
+    fakeEvent1 = { eventType: "startFeatureOperation", name: "checkout", operationKey: "cart1", vitalId: fakeVitalId1, context: {} }
+    fakeEvent2 = { eventType: "startFeatureOperation", name: "checkout", operationKey: "cart2", vitalId: fakeVitalId2, context: {} }
+    fakeEvent3 = { eventType: "stopFeatureOperation", name: "checkout", operationKey: "cart1", vitalId: fakeVitalId3, context: {} }
+
+    existingUpdates = m.mockWriter@.getFieldUpdates("writeEvent")
+    existingCount = existingUpdates.count()
+
+    ' When
+    m.testedScope@.handleEvent(fakeEvent1, m.mockWriter)
+    m.testedScope@.handleEvent(fakeEvent2, m.mockWriter)
+    m.testedScope@.handleEvent(fakeEvent3, m.mockWriter)
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    Assert.that(updates).hasSize(existingCount + 3)
+    vitalEvent1 = ParseJson(updates[existingCount])
+    vitalEvent2 = ParseJson(updates[existingCount + 1])
+    vitalEvent3 = ParseJson(updates[existingCount + 2])
+    Assert.that(vitalEvent1).isNotInvalid()
+    Assert.that(vitalEvent2).isNotInvalid()
+    Assert.that(vitalEvent3).isNotInvalid()
+    Assert.that(vitalEvent1.type).isEqualTo("vital")
+    Assert.that(vitalEvent2.type).isEqualTo("vital")
+    Assert.that(vitalEvent3.type).isEqualTo("vital")
+    Assert.that(vitalEvent1.vital.step_type).isEqualTo("start")
+    Assert.that(vitalEvent2.vital.step_type).isEqualTo("start")
+    Assert.that(vitalEvent3.vital.step_type).isEqualTo("end")
+    Assert.that(vitalEvent1.vital.operation_key).isEqualTo("cart1")
+    Assert.that(vitalEvent2.vital.operation_key).isEqualTo("cart2")
+    Assert.that(vitalEvent3.vital.operation_key).isEqualTo("cart1")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a RumSessionScope with an active view, start "checkout" with key "cart1"
+'  When: stop "checkout" with key "cart3" (never started)
+'  Then: both events emitted (stop-without-start warning logged but doesn't suppress)
+'----------------------------------------------------------------
+function RumSessionScopeTest__WhenStopWrongKey_ThenEventStillEmitted() as string
+    ' Given
+    fakeVitalId1 = CreateObject("roDeviceInfo").GetRandomUUID()
+    fakeVitalId2 = CreateObject("roDeviceInfo").GetRandomUUID()
+    fakeStartEvent = { eventType: "startFeatureOperation", name: "checkout", operationKey: "cart1", vitalId: fakeVitalId1, context: {} }
+    fakeStopEvent = { eventType: "stopFeatureOperation", name: "checkout", operationKey: "cart3", vitalId: fakeVitalId2, context: {} }
+
+    existingUpdates = m.mockWriter@.getFieldUpdates("writeEvent")
+    existingCount = existingUpdates.count()
+
+    ' When
+    m.testedScope@.handleEvent(fakeStartEvent, m.mockWriter)
+    m.testedScope@.handleEvent(fakeStopEvent, m.mockWriter)
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    Assert.that(updates).hasSize(existingCount + 2)
+    startVitalEvent = ParseJson(updates[existingCount])
+    stopVitalEvent = ParseJson(updates[existingCount + 1])
+    Assert.that(startVitalEvent).isNotInvalid()
+    Assert.that(stopVitalEvent).isNotInvalid()
+    Assert.that(startVitalEvent.vital.operation_key).isEqualTo("cart1")
+    Assert.that(stopVitalEvent.vital.operation_key).isEqualTo("cart3")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a RumSessionScope with an active view
+'  When: sending startFeatureOperation with name = fakeName, operationKey = invalid (unkeyed)
+'  Then: vital event payload has operation_key = invalid (FormatJson omits it, ParseJson returns invalid for missing key)
+'----------------------------------------------------------------
+function RumSessionScopeTest__WhenUnkeyedOperationDispatch_ThenCorrectPayload() as string
+    ' Given
+    fakeName = IG_GetString(32)
+    fakeVitalId = CreateObject("roDeviceInfo").GetRandomUUID()
+    fakeEvent = { eventType: "startFeatureOperation", name: fakeName, operationKey: invalid, vitalId: fakeVitalId, context: {} }
+
+    existingUpdates = m.mockWriter@.getFieldUpdates("writeEvent")
+    existingCount = existingUpdates.count()
+
+    ' When
+    m.testedScope@.handleEvent(fakeEvent, m.mockWriter)
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    Assert.that(updates).hasSize(existingCount + 1)
+    vitalEvent = ParseJson(updates[existingCount])
+    Assert.that(vitalEvent).isNotInvalid()
+    Assert.that(vitalEvent.vital.name).isEqualTo(fakeName)
+    Assert.that(vitalEvent.vital.step_type).isEqualTo("start")
+    Assert.that(vitalEvent.vital.operation_key).isEqualTo(invalid)
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a RumSessionScope initialized (via SetUp, no active view)
+'  When: sending a startFeatureOperation event
+'  Then: payload has view.id = "00000000-0000-0000-0000-000000000000", view.url = ""
+'----------------------------------------------------------------
+function RumSessionScopeTest__WhenVitalEventWithNoView_ThenWriteWithNullViewId() as string
+    ' Given
+    fakeName = IG_GetString(32)
+    fakeVitalId = CreateObject("roDeviceInfo").GetRandomUUID()
+    fakeEvent = { eventType: "startFeatureOperation", name: fakeName, operationKey: invalid, vitalId: fakeVitalId, context: {} }
+
+    existingUpdates = m.mockWriter@.getFieldUpdates("writeEvent")
+    existingCount = existingUpdates.count()
+
+    ' When
+    m.testedScope@.handleEvent(fakeEvent, m.mockWriter)
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    Assert.that(updates).hasSize(existingCount + 1)
+    vitalEvent = ParseJson(updates[existingCount])
+    Assert.that(vitalEvent).isNotInvalid()
+    Assert.that(vitalEvent.view.id).isEqualTo("00000000-0000-0000-0000-000000000000")
+    Assert.that(vitalEvent.view.url).isEqualTo("")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a RumSessionScope with view A active, start vital operation
+'  When: start view B, then stop vital operation
+'  Then: first vital event has view A context, second has view B context (emit-time capture)
+'----------------------------------------------------------------
+function RumSessionScopeTest__WhenCrossViewOperation_ThenEachEventCarriesCorrectViewContext() as string
+    ' Given
+    fakeViewUrlB = "https://" + IG_GetString(32)
+    fakeViewNameB = IG_GetString(16)
+    fakeName = IG_GetString(32)
+    fakeVitalId1 = CreateObject("roDeviceInfo").GetRandomUUID()
+    fakeVitalId2 = CreateObject("roDeviceInfo").GetRandomUUID()
+    fakeStartEvent = { eventType: "startFeatureOperation", name: fakeName, operationKey: invalid, vitalId: fakeVitalId1, context: {} }
+    fakeStopEvent = { eventType: "stopFeatureOperation", name: fakeName, operationKey: invalid, vitalId: fakeVitalId2, context: {} }
+
+    existingUpdates = m.mockWriter@.getFieldUpdates("writeEvent")
+    existingCount = existingUpdates.count()
+
+    ' When: start vital (view A is active from SetUpWithView)
+    m.testedScope@.handleEvent(fakeStartEvent, m.mockWriter)
+    ' Switch to view B
+    m.testedScope@.handleEvent({ eventType: "startView", viewName: fakeViewNameB, viewUrl: fakeViewUrlB }, m.mockWriter)
+    ' Stop vital (now view B is active)
+    m.testedScope@.handleEvent(fakeStopEvent, m.mockWriter)
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    Assert.that(updates).hasSize(existingCount + 2)
+    startVitalEvent = ParseJson(updates[existingCount])
+    stopVitalEvent = ParseJson(updates[existingCount + 1])
+    Assert.that(startVitalEvent).isNotInvalid()
+    Assert.that(stopVitalEvent).isNotInvalid()
+    Assert.that(startVitalEvent.view.url).isEqualTo(m.fakeViewUrl)
+    Assert.that(stopVitalEvent.view.url).isEqualTo(fakeViewUrlB)
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a RumSessionScope with view active, start vital operation "login"
+'  When: expire session, send interactive event to trigger renewal, then stop "login"
+'  Then: stop event has different session.id than start event (session renewed), stop is effectively stop-without-start in new session
+'----------------------------------------------------------------
+function RumSessionScopeTest__WhenSessionRenewalMidOperation_ThenActiveOperationsCleared() as string
+    ' Given
+    fakeName = "login"
+    fakeKey = IG_GetString(32)
+    fakeVitalId1 = CreateObject("roDeviceInfo").GetRandomUUID()
+    fakeVitalId2 = CreateObject("roDeviceInfo").GetRandomUUID()
+    fakeStartEvent = { eventType: "startFeatureOperation", name: fakeName, operationKey: fakeKey, vitalId: fakeVitalId1, context: {} }
+    fakeStopEvent = { eventType: "stopFeatureOperation", name: fakeName, operationKey: fakeKey, vitalId: fakeVitalId2, context: {} }
+
+    existingUpdates = m.mockWriter@.getFieldUpdates("writeEvent")
+    existingCount = existingUpdates.count()
+
+    ' When: start vital
+    m.testedScope@.handleEvent(fakeStartEvent, m.mockWriter)
+    ' Expire session (sleep for inactivityThresholdMs)
+    sleep(100)
+    ' Trigger session renewal with interactive event (addAction is interactive)
+    fakeAction = { target: IG_GetString(16), type: "tap" }
+    fakeRenewalEvent = { eventType: "addAction", action: fakeAction }
+    m.testedScope@.handleEvent(fakeRenewalEvent, m.mockWriter)
+    ' Stop vital in new session
+    m.testedScope@.handleEvent(fakeStopEvent, m.mockWriter)
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    Assert.that(updates).hasSize(existingCount + 2)
+    startVitalEvent = ParseJson(updates[existingCount])
+    stopVitalEvent = ParseJson(updates[existingCount + 1])
+    Assert.that(startVitalEvent).isNotInvalid()
+    Assert.that(stopVitalEvent).isNotInvalid()
+    ' Session IDs should be different (session was renewed)
+    Assert.that(stopVitalEvent.session.id).isNotEqualTo(startVitalEvent.session.id)
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a RumSessionScope with an active view
+'  When: sending startFeatureOperation with accented characters in name and key
+'  Then: payload preserves unicode characters correctly
+'----------------------------------------------------------------
+function RumSessionScopeTest__WhenVitalEventWithUnicodeNameAndKey_ThenWriteCorrectPayload() as string
+    ' Given
+    fakeName = "paiement-cafe"
+    fakeKey = "cle-unicode-123"
+    fakeVitalId = CreateObject("roDeviceInfo").GetRandomUUID()
+    fakeEvent = { eventType: "startFeatureOperation", name: fakeName, operationKey: fakeKey, vitalId: fakeVitalId, context: {} }
+
+    existingUpdates = m.mockWriter@.getFieldUpdates("writeEvent")
+    existingCount = existingUpdates.count()
+
+    ' When
+    m.testedScope@.handleEvent(fakeEvent, m.mockWriter)
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    Assert.that(updates).hasSize(existingCount + 1)
+    vitalEvent = ParseJson(updates[existingCount])
+    Assert.that(vitalEvent).isNotInvalid()
+    Assert.that(vitalEvent.vital.name).isEqualTo(fakeName)
+    Assert.that(vitalEvent.vital.operation_key).isEqualTo(fakeKey)
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a RumSessionScope with an active view
+'  When: sending startFeatureOperation with long name and key (256/128 chars)
+'  Then: payload preserves full strings
+'----------------------------------------------------------------
+function RumSessionScopeTest__WhenVitalEventWithLongName_ThenWriteCorrectPayload() as string
+    ' Given
+    fakeName = IG_GetString(256)
+    fakeKey = IG_GetString(128)
+    fakeVitalId = CreateObject("roDeviceInfo").GetRandomUUID()
+    fakeEvent = { eventType: "startFeatureOperation", name: fakeName, operationKey: fakeKey, vitalId: fakeVitalId, context: {} }
+
+    existingUpdates = m.mockWriter@.getFieldUpdates("writeEvent")
+    existingCount = existingUpdates.count()
+
+    ' When
+    m.testedScope@.handleEvent(fakeEvent, m.mockWriter)
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    Assert.that(updates).hasSize(existingCount + 1)
+    vitalEvent = ParseJson(updates[existingCount])
+    Assert.that(vitalEvent).isNotInvalid()
+    Assert.that(vitalEvent.vital.name).isEqualTo(fakeName)
+    Assert.that(vitalEvent.vital.operation_key).isEqualTo(fakeKey)
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a RumSessionScope with an active view
+'  When: sending startFeatureOperation with special characters in name
+'  Then: payload preserves special characters exactly
+'----------------------------------------------------------------
+function RumSessionScopeTest__WhenVitalEventWithSpecialCharsInName_ThenWriteCorrectPayload() as string
+    ' Given
+    fakeName = "login/signup@v2#test"
+    fakeVitalId = CreateObject("roDeviceInfo").GetRandomUUID()
+    fakeEvent = { eventType: "startFeatureOperation", name: fakeName, operationKey: invalid, vitalId: fakeVitalId, context: {} }
+
+    existingUpdates = m.mockWriter@.getFieldUpdates("writeEvent")
+    existingCount = existingUpdates.count()
+
+    ' When
+    m.testedScope@.handleEvent(fakeEvent, m.mockWriter)
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    Assert.that(updates).hasSize(existingCount + 1)
+    vitalEvent = ParseJson(updates[existingCount])
+    Assert.that(vitalEvent).isNotInvalid()
+    Assert.that(vitalEvent.vital.name).isEqualTo(fakeName)
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a RumSessionScope with view active, global context, view context, and command context
+'  When: sending startFeatureOperation with command context
+'  Then: context merging follows command > view > global priority
+'----------------------------------------------------------------
+function RumSessionScopeTest__WhenVitalEventWithMergedAttributes_ThenCommandOverridesViewOverridesGlobal() as string
+    ' Given: set global context
+    m.global.setField("datadogContext", { "key_a": "global", "key_b": "global", "key_c": "global" })
+    ' Set view context by starting a new view with context
+    fakeViewName = IG_GetString(16)
+    fakeViewUrl = "https://" + IG_GetString(32)
+    viewContext = { "key_a": "view", "key_b": "view" }
+    m.testedScope@.handleEvent({ eventType: "startView", viewName: fakeViewName, viewUrl: fakeViewUrl, context: viewContext }, m.mockWriter)
+    ' Prepare command context
+    commandContext = { "key_a": "command" }
+
+    fakeName = IG_GetString(32)
+    fakeVitalId = CreateObject("roDeviceInfo").GetRandomUUID()
+    fakeEvent = { eventType: "startFeatureOperation", name: fakeName, operationKey: invalid, vitalId: fakeVitalId, context: commandContext }
+
+    existingUpdates = m.mockWriter@.getFieldUpdates("writeEvent")
+    existingCount = existingUpdates.count()
+
+    ' When
+    m.testedScope@.handleEvent(fakeEvent, m.mockWriter)
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    Assert.that(updates).hasSize(existingCount + 1)
+    vitalEvent = ParseJson(updates[existingCount])
+    Assert.that(vitalEvent).isNotInvalid()
+    ' Attribute merging priority: command > view > global
+    Assert.that(vitalEvent.context.key_a).isEqualTo("command")
+    Assert.that(vitalEvent.context.key_b).isEqualTo("view")
+    Assert.that(vitalEvent.context.key_c).isEqualTo("global")
     return ""
 end function


### PR DESCRIPTION
### What does this PR do?

  Adds vital operation event handling in `RumSessionScope` — intercepting `startFeatureOperation` and `stopFeatureOperation` raw events, constructing the full JSON payload conforming to the vital-operation-step schema, and writing it to the transport layer. Built on top
  of PR #118 (RumAgent public API).

  **RumSessionScope.bs** — event handling, payload construction, and active operation tracking:

  - **Event interception**: vital events are handled at session scope (not delegated to view scopes), with an early return in `handleEvent()`
  - **JSON payload construction** (`sendVitalEvent`): builds the complete `type: "vital"` event with all required sections:
    - `_dd` (format_version, session plan)
    - `application`, `session`, `device`, `os`, `service`, `source`, `version`, `usr`
    - `view` context (id, url, name from active view, or nil-view fallback with zero UUID)
    - `vital` section (id, name, type `"operation_step"`, operation_key, step_type, failure_reason)
    - `context` with 3-level attribute merging: Global < View < Command
  - **Active operation tracking** (`m.activeOperations` map):
    - `__trackOperationStart` — logs a developer warning on duplicate start for the same name+key
    - `__trackOperationEnd` — logs a developer warning on stop-without-prior-start
    - Tracking is advisory only: warnings never suppress event emission
    - Map is cleared on session renewal
  - **No-view fallback**: when no view is active, emits the event with `view.id = "00000000-0000-0000-0000-000000000000"` and logs a warning

  **Tests** — 19 new tests in `Test__RumSessionScope.bs` covering 5 categories:

  | Category | Tests |
  |----------|-------|
  | Payload structure | start, succeed, fail — full field-by-field assertions |
  | Developer warnings | duplicate start (keyed + unkeyed), stop-without-start, start-then-stop lifecycle |
  | Parallel keyed operations | independent tracking, stop with wrong key |
  | Edge cases | no active view (nil-view fallback), cross-view operation (emit-time capture), session renewal clears active ops, unicode names, long names (256 chars), special characters |
  | Attribute merging | command > view > global priority verification |

  New `SetUpWithView` helper initializes a session scope with a fully-configured mock parent context and an active view.

  ### Motivation

  This is the third layer in the RUM Vital Operations stack. The session scope is responsible for constructing the final JSON payload that gets written to the transport — it is the only scope that processes vital events (they bypass view scopes entirely). This design matches how vital operations are session-level concepts that can span multiple views.

  ### Additional Notes

  - Stacked on PR #118 (`valpertui/feature/rum-operations-api`) which exposes the public API on RumAgent.
  - Vital events are **not** delegated to view scopes — they are intercepted and fully handled at the session scope level. View context is read from the active view at emit time (not at start time).
  - The `m.activeOperations` tracking map uses `name + operationKey` as the lookup key. It only serves developer warnings and does not affect event emission.
  - The existing `SetUp` helper was updated to include `datadogContext` and `datadogUserInfo` global fields required by the payload construction.

  ### Review checklist (to be filled by reviewers)

  - [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
  - [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
  - [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

