### PR TITLE
[RUM-14641] Add sample app operations screen, video playback instrumentation, and docs

### DIFF
--- a/sample/components/MainScene.bs
+++ b/sample/components/MainScene.bs
@@ -16,11 +16,13 @@ sub init()
     m.videoLabel = m.top.findNode("videoLabel")
     m.networkLabel = m.top.findNode("networkLabel")
     m.debugLabel = m.top.findNode("debugLabel")
+    m.operationsLabel = m.top.findNode("operationsLabel")
 
     m.homeScreen = m.top.findNode("homeScreen")
     m.videoScreen = m.top.findNode("videoScreen")
     m.networkScreen = m.top.findNode("networkScreen")
     m.debugScreen = m.top.findNode("debugScreen")
+    m.operationsScreen = m.top.findNode("operationsScreen")
     switchScreen("home")
 end sub
 
@@ -58,6 +60,9 @@ sub switchScreen(name as string)
     m.debugScreen.visible = false
     m.debugScreen.setFocus(false)
     m.debugLabel.color = "0xffffff80"
+    m.operationsScreen.visible = false
+    m.operationsScreen.setFocus(false)
+    m.operationsLabel.color = "0xffffff80"
 
     if (m.global.datadogLogsAgent <> invalid)
         m.global.datadogLogsAgent@.logOk("Switching screen to " + name, { screen: name })
@@ -80,6 +85,8 @@ function getScreenByName(name as string) as dynamic
         return m.networkScreen
     else if (name = "debug")
         return m.debugScreen
+    else if (name = "operations")
+        return m.operationsScreen
     end if
     return invalid
 end function
@@ -93,6 +100,8 @@ function getLabelByName(name as string) as dynamic
         return m.networkLabel
     else if (name = "debug")
         return m.debugLabel
+    else if (name = "operations")
+        return m.operationsLabel
     end if
     return invalid
 end function
@@ -105,6 +114,8 @@ function getNextScreen() as string
     else if (m.screen = "network")
         return "debug"
     else if (m.screen = "debug")
+        return "operations"
+    else if (m.screen = "operations")
         return "home"
     end if
     return "home"
@@ -112,13 +123,15 @@ end function
 
 function getPreviousScreen() as string
     if (m.screen = "home")
-        return "debug"
+        return "operations"
     else if (m.screen = "video")
         return "home"
     else if (m.screen = "network")
         return "video"
     else if (m.screen = "debug")
         return "network"
+    else if (m.screen = "operations")
+        return "debug"
     end if
     return "home"
 end function

--- a/sample/components/MainScene.xml
+++ b/sample/components/MainScene.xml
@@ -21,10 +21,14 @@ Copyright 2022-Today Datadog, Inc.
         <Label id="debugLabel" text="Debug" translation="[800,50]" color="0xffffff80">
             <Font role="font" size="48" uri="pkg:/fonts/FiraSans-Regular.ttf" />
         </Label>
+        <Label id="operationsLabel" text="Operations" translation="[1050,50]" color="0xffffff80">
+            <Font role="font" size="48" uri="pkg:/fonts/FiraSans-Regular.ttf" />
+        </Label>
 
         <HomeScreen id="homeScreen" />
         <VideoScreen id="videoScreen" />
         <NetworkScreen id="networkScreen" />
         <DebugScreen id="debugScreen" />
+        <OperationsScreen id="operationsScreen" />
     </children>
 </component>

--- a/sample/components/screens/OperationsScreen.bs
+++ b/sample/components/screens/OperationsScreen.bs
@@ -79,13 +79,17 @@ end sub
 
 sub succeedContentLoad()
     m.global.datadogRumAgent@.succeedOperation("contentLoad")
-    if m.contentLoadTimer <> invalid then m.contentLoadTimer.control = "stop"
+    if (m.contentLoadTimer <> invalid)
+        m.contentLoadTimer.control = "stop"
+    end if
     m.msgLabel.text = "Content load succeeded!"
 end sub
 
 sub failContentLoad()
     m.global.datadogRumAgent@.failOperation("contentLoad", "abandoned")
-    if m.contentLoadTimer <> invalid then m.contentLoadTimer.control = "stop"
+    if (m.contentLoadTimer <> invalid)
+        m.contentLoadTimer.control = "stop"
+    end if
     m.msgLabel.text = "Content load failed (abandoned)"
 end sub
 
@@ -105,7 +109,9 @@ end sub
 
 sub failLogin()
     m.global.datadogRumAgent@.failOperation("login", "error", invalid, { error_code: "auth_timeout" })
-    if m.loginTimer <> invalid then m.loginTimer.control = "stop"
+    if (m.loginTimer <> invalid)
+        m.loginTimer.control = "stop"
+    end if
     m.msgLabel.text = "Login failed (error: auth_timeout)"
 end sub
 
@@ -122,7 +128,7 @@ sub startKeyedOperation()
 end sub
 
 sub succeedKeyedOperation()
-    if m.lastOperationKey = invalid
+    if (m.lastOperationKey = invalid)
         m.msgLabel.text = "No keyed operation in progress"
         return
     end if

--- a/sample/components/screens/OperationsScreen.bs
+++ b/sample/components/screens/OperationsScreen.bs
@@ -1,0 +1,132 @@
+' Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+' This product includes software developed at Datadog (https://www.datadoghq.com/).
+' Copyright 2022-Today Datadog, Inc.
+
+import "pkg:/source/roku_modules/datadogroku/datadogSdk.brs"
+import "pkg:/source/roku_modules/datadogroku/internalLogger.brs"
+import "pkg:/source/roku_modules/datadogroku/timeUtils.brs"
+
+sub init()
+    datadogroku_ddLogThread("OperationsScreen.init()")
+
+    m.msgLabel = m.top.findNode("messageLabel")
+    m.items = [
+        "Start Content Load",
+        "Succeed Content Load",
+        "Fail Content Load",
+        "Start Login",
+        "Fail Login (error)",
+        "Start Keyed Operation",
+        "Succeed Keyed Operation"
+    ]
+
+    m.operationsLabelList = m.top.findNode("operationsLabelList")
+    m.operationsLabelList.observeField("itemSelected", "onItemSelected")
+    list = CreateObject("RoSGNode", "ContentNode")
+
+    for each item in m.items
+        node = list.createChild("ContentNode")
+        node.title = item
+    end for
+    m.operationsLabelList.content = list
+
+    m.top.observeField("focusedChild", "onFocused")
+
+    m.contentLoadTimer = invalid
+    m.loginTimer = invalid
+    m.lastOperationKey = invalid
+end sub
+
+sub onFocused()
+    m.operationsLabelList.setFocus(true)
+end sub
+
+sub onItemSelected()
+    datadogroku_ddLogThread("onItemSelected")
+    itemSelected = m.operationsLabelList.itemSelected
+    item = m.items[itemSelected]
+
+    dateTime = CreateObject("roDateTime")
+    dateTime.ToLocalTime()
+
+    m.msgLabel.text = "Clicked on " + item + " at " + dateTime.ToISOString()
+
+    if (itemSelected = 0)
+        startContentLoad()
+    else if (itemSelected = 1)
+        succeedContentLoad()
+    else if (itemSelected = 2)
+        failContentLoad()
+    else if (itemSelected = 3)
+        startLogin()
+    else if (itemSelected = 4)
+        failLogin()
+    else if (itemSelected = 5)
+        startKeyedOperation()
+    else if (itemSelected = 6)
+        succeedKeyedOperation()
+    end if
+end sub
+
+sub startContentLoad()
+    m.global.datadogRumAgent@.startOperation("contentLoad")
+    m.contentLoadTimer = CreateObject("roSGNode", "Timer")
+    m.contentLoadTimer.duration = 2.0
+    m.contentLoadTimer.observeField("fire", "onContentLoadComplete")
+    m.contentLoadTimer.control = "start"
+    m.msgLabel.text = "Content load started... (will auto-succeed in 2s)"
+end sub
+
+sub succeedContentLoad()
+    m.global.datadogRumAgent@.succeedOperation("contentLoad")
+    if m.contentLoadTimer <> invalid then m.contentLoadTimer.control = "stop"
+    m.msgLabel.text = "Content load succeeded!"
+end sub
+
+sub failContentLoad()
+    m.global.datadogRumAgent@.failOperation("contentLoad", "abandoned")
+    if m.contentLoadTimer <> invalid then m.contentLoadTimer.control = "stop"
+    m.msgLabel.text = "Content load failed (abandoned)"
+end sub
+
+sub onContentLoadComplete()
+    m.global.datadogRumAgent@.succeedOperation("contentLoad")
+    m.msgLabel.text = "Content load auto-succeeded after 2s"
+end sub
+
+sub startLogin()
+    m.global.datadogRumAgent@.startOperation("login")
+    m.loginTimer = CreateObject("roSGNode", "Timer")
+    m.loginTimer.duration = 1.5
+    m.loginTimer.observeField("fire", "onLoginTimeout")
+    m.loginTimer.control = "start"
+    m.msgLabel.text = "Login started... (will timeout in 1.5s)"
+end sub
+
+sub failLogin()
+    m.global.datadogRumAgent@.failOperation("login", "error", invalid, { error_code: "auth_timeout" })
+    if m.loginTimer <> invalid then m.loginTimer.control = "stop"
+    m.msgLabel.text = "Login failed (error: auth_timeout)"
+end sub
+
+sub onLoginTimeout()
+    m.global.datadogRumAgent@.failOperation("login", "error", invalid, { error_code: "timeout" })
+    m.msgLabel.text = "Login timed out after 1.5s (error)"
+end sub
+
+sub startKeyedOperation()
+    opKey = "item_" + Rnd(1000).toStr()
+    m.lastOperationKey = opKey
+    m.global.datadogRumAgent@.startOperation("contentLoad", opKey, { content_type: "movie" })
+    m.msgLabel.text = "Keyed operation started: contentLoad [" + opKey + "]"
+end sub
+
+sub succeedKeyedOperation()
+    if m.lastOperationKey = invalid
+        m.msgLabel.text = "No keyed operation in progress"
+        return
+    end if
+    m.global.datadogRumAgent@.succeedOperation("contentLoad", m.lastOperationKey)
+    m.msgLabel.text = "Keyed operation succeeded: contentLoad [" + m.lastOperationKey + "]"
+    m.lastOperationKey = invalid
+end sub

--- a/sample/components/screens/OperationsScreen.xml
+++ b/sample/components/screens/OperationsScreen.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 
+Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+This product includes software developed at Datadog (https://www.datadoghq.com/).
+Copyright 2022-Today Datadog, Inc.
+-->
+<component name="OperationsScreen" extends="Group">
+
+    <children>
+
+        <LabelList id="operationsLabelList" translation="[64,192]">
+            <Font role="font" size="28" uri="pkg:/fonts/FiraCode-Regular.ttf" />
+            <Font role="focusedFont" size="36" uri="pkg:/fonts/FiraCode-Regular.ttf" />
+        </LabelList>
+
+        <Label id="messageLabel" text="Waiting for input…" translation="[64,896]" color="0xffffff80">
+            <Font role="font" size="24" uri="pkg:/fonts/FiraCode-Regular.ttf" />
+        </Label>
+    </children>
+
+    <script type="text/brightscript" uri="pkg:/components/screens/OperationsScreen.bs" />
+
+</component>

--- a/sample/components/screens/VideoScreen.bs
+++ b/sample/components/screens/VideoScreen.bs
@@ -26,6 +26,12 @@ function onKeyEvent(key as string, press as boolean) as boolean
         m.global.datadogRumAgent@.startOperation("playbackStart")
         m.devTube.control = "play"
         m.devTube.observeField("state", "onVideoStateChange")
+        m.playbackStarted = false
+    else if (key = "back" and press)
+        if (m.playbackStarted = false)
+            m.global.datadogRumAgent@.failOperation("playbackStart", "abandoned")
+            m.devTube.unobserveField("state")
+        end if
     end if
     return false
 end function
@@ -41,10 +47,12 @@ end sub
 
 sub onVideoStateChange()
     state = m.devTube.state
-    if state = "playing"
+    if (state = "playing")
+        m.playbackStarted = true
         m.global.datadogRumAgent@.succeedOperation("playbackStart")
         m.devTube.unobserveField("state")
-    else if state = "error"
+    else if (state = "error")
+        m.playbackStarted = true
         m.global.datadogRumAgent@.failOperation("playbackStart", "error")
         m.devTube.unobserveField("state")
     end if

--- a/sample/components/screens/VideoScreen.bs
+++ b/sample/components/screens/VideoScreen.bs
@@ -23,7 +23,9 @@ function onKeyEvent(key as string, press as boolean) as boolean
     if(key = "play" and press)
         datadogroku_ddLogInfo("Video State: " + m.devTube.state)
         m.global.datadogRumAgent@.addAction({ target: "play", type: "click" })
+        m.global.datadogRumAgent@.startOperation("playbackStart")
         m.devTube.control = "play"
+        m.devTube.observeField("state", "onVideoStateChange")
     end if
     return false
 end function
@@ -35,4 +37,15 @@ sub setVideoContent()
     videoContent.streamformat = "hls"
 
     m.devTube.content = videoContent
+end sub
+
+sub onVideoStateChange()
+    state = m.devTube.state
+    if state = "playing"
+        m.global.datadogRumAgent@.succeedOperation("playbackStart")
+        m.devTube.unobserveField("state")
+    else if state = "error"
+        m.global.datadogRumAgent@.failOperation("playbackStart", "error")
+        m.devTube.unobserveField("state")
+    end if
 end sub


### PR DESCRIPTION
  ### What does this PR do?

  Adds documentation, changelog, and sample app demonstrations for the RUM vital operations feature. Built on top of PR #119 (session scope processing).

  **README.md** — new "Track RUM Operations (Preview)" section with usage examples:
  - Basic start/succeed flow
  - Fail with reason (`"error"`, `"abandoned"`, `"other"`)
  - Parallel operations with `operationKey` and custom attributes

  **CHANGELOG.md** — adds `[FEATURE] Add Operation Monitoring (Preview)` entry under 1.4.0.

  **Sample app — new OperationsScreen** (`OperationsScreen.bs` / `.xml`):
  - Interactive LabelList with 7 actions demonstrating the full API surface:
    - Start/Succeed/Fail a `"contentLoad"` operation (with 2s auto-succeed timer)
    - Start/Fail a `"login"` operation (with 1.5s auto-timeout)
    - Start/Succeed a keyed `"contentLoad"` operation (random `operationKey`, custom context)
  - Status label showing real-time feedback for each action
  - Registered in `MainScene` as a new screen tab ("Operations") in the navigation cycle

  **Sample app — VideoScreen instrumentation**:
  - `play` key now calls `startOperation("playbackStart")` and observes video state
  - `onVideoStateChange` callback: `succeedOperation` on `"playing"`, `failOperation` on `"error"`
  - `back` key calls `failOperation("playbackStart", "abandoned")` if playback hasn't started yet (user navigated away)

  ### Motivation

  Provides developer-facing documentation and a working sample app that exercises the entire vital operations API. The OperationsScreen serves as both a smoke test and a reference implementation for integrators. The VideoScreen instrumentation demonstrates a realistic
  real-world use case (tracking time-to-first-frame for video playback).

  ### Additional Notes

  - Stacked on PR #119 (`valpertui/feature/rum-session-scope-processing`) which implements the event processing layer.
  - The CHANGELOG PR number placeholder (`#NNN`) should be updated to the final merged PR number before release.
  - The README documentation link `[6]` points to the Roku RUM docs page which should be updated when the operations docs are published.
  - The OperationsScreen uses timer-based auto-completion to demonstrate realistic async operation flows without requiring actual network calls.

  ### Review checklist (to be filled by reviewers)

  - [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
  - [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
  - [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)