### PR TITLE
RUM-14690: Reduce rendezvous events in RumAgent

### DIFF
--- a/dist/components/core/WriterTask.brs
+++ b/dist/components/core/WriterTask.brs
@@ -18,8 +18,12 @@ sub init()
     m.port = createObject("roMessagePort")
     m.top.observeFieldScoped("writeEvent", m.port)
     m.top.observeFieldScoped("trackType", m.port)
+    m.top.observeFieldScoped("payloadSeparator", m.port)
+    m.top.observeFieldScoped("maxBatchSize", m.port)
     m.top.functionName = "writerLoop"
     m.top.control = "RUN"
+    m.maxBatchSize = m.top.maxBatchSize
+    m.payloadSeparator = m.top.payloadSeparator
 end sub
 
 ' ----------------------------------------------------------------
@@ -38,6 +42,10 @@ sub writerLoop()
                 onWriteEvent(eventData)
             else if (fieldName = "trackType")
                 m.trackType = msg.getData()
+            else if (fieldName = "payloadSeparator")
+                m.payloadSeparator = msg.getData()
+            else if (fieldName = "maxBatchSize")
+                m.maxBatchSize = msg.getData()
             else
                 ddLogWarning(fieldName + " not handled")
             end if
@@ -60,7 +68,7 @@ sub onWriteEvent(event as string)
     if (m.fileSystem.Exists(filePath))
         fileSize = m.fileSystem.Stat(filePath).size
         if (fileSize > 0)
-            AppendAsciiFile(filePath, m.top.payloadSeparator)
+            AppendAsciiFile(filePath, m.payloadSeparator)
         end if
     end if
     AppendAsciiFile(filePath, event)
@@ -100,10 +108,10 @@ function getWriteableFile(eventSize as integer) as string
                     if __bsConsequent <> invalid then
                         return __bsConsequent
                     else
-                        return m.top.maxBatchSize
+                        return m.maxBatchSize
                     end if
                 end function)(lastFilePath, m)
-            if (lastFileSize + m.top.payloadSeparator.Len() + eventSize < m.top.maxBatchSize)
+            if (lastFileSize + m.payloadSeparator.Len() + eventSize < m.maxBatchSize)
                 return folderPath + "/" + lastFilename
             end if
         end if

--- a/dist/components/rum/RumAgent.brs
+++ b/dist/components/rum/RumAgent.brs
@@ -21,10 +21,15 @@ sub init()
     m.top.observeFieldScoped("addAction", m.port)
     m.top.observeFieldScoped("addError", m.port)
     m.top.observeFieldScoped("addResource", m.port)
-    m.top.observeFieldScoped("sendCrash", m.port)
     m.top.observeFieldScoped("addConfigTelemetry", m.port)
     m.top.observeFieldScoped("addErrorTelemetry", m.port)
     m.top.observeFieldScoped("addDebugTelemetry", m.port)
+    m.top.observeFieldScoped("areFieldsSet", m.port)
+    'Observe nodes injected by the test
+    m.top.observeFieldScoped("uploader", m.port)
+    m.top.observeFieldScoped("writer", m.port)
+    m.top.observeFieldScoped("rumScope", m.port)
+    m.top.observeFieldScoped("telemetryScope", m.port)
     m.top.functionName = "rumAgentLoop"
     m.top.control = "RUN"
 end sub
@@ -34,8 +39,6 @@ end sub
 ' ----------------------------------------------------------------
 sub rumAgentLoop()
     ddLogThread("RumAgent.rumAgentLoop()")
-    sendCrash(m.top.lastExitOrTerminationReason)
-    addConfigTelemetry(m.top.configuration)
     while (true)
         msg = wait(0, m.port)
         msgType = type(msg)
@@ -51,14 +54,24 @@ sub rumAgentLoop()
                 __onAddError(msg.getData())
             else if (fieldName = "addResource")
                 __onAddResource(msg.getData())
-            else if (fieldName = "sendCrash")
-                __onSendCrash(msg.getData())
             else if (fieldName = "addConfigTelemetry")
                 __onAddConfigTelemetry(msg.getData())
             else if (fieldName = "addErrorTelemetry")
                 __onAddErrorTelemetry(msg.getData())
             else if (fieldName = "addDebugTelemetry")
                 __onAddDebugTelemetry(msg.getData())
+            else if (fieldName = "uploader")
+                m.uploader = msg.getData()
+            else if (fieldName = "writer")
+                m.writer = msg.getData()
+            else if (fieldName = "rumScope")
+                m.rumScope = msg.getData()
+            else if (fieldName = "telemetryScope")
+                m.telemetryScope = msg.getData()
+            else if (fieldName = "areFieldsSet")
+                if (msg.getData())
+                    updateFields()
+                end if
             end if
         else
             ddLogWarning("Unexpected message " + msgType + ": " + FormatJson(msg))
@@ -82,8 +95,10 @@ end sub
 ' ----------------------------------------------------------------
 sub __onStartView(event as object)
     ensureSetup()
-    m.top.rumScope.callfunc("handleEvent", event, m.top.writer)
-    m.top.rumScope.callfunc("handleEvent", keepAliveEvent(), m.top.writer)
+    if (m.rumScope <> invalid)
+        m.rumScope.callfunc("handleEvent", event, m.writer)
+        m.rumScope.callfunc("handleEvent", keepAliveEvent(), m.writer)
+    end if
 end sub
 
 ' ----------------------------------------------------------------
@@ -102,7 +117,9 @@ end sub
 ' ----------------------------------------------------------------
 sub __onStopView(event as object)
     ensureSetup()
-    m.top.rumScope.callfunc("handleEvent", event, m.top.writer)
+    if (m.rumScope <> invalid)
+        m.rumScope.callfunc("handleEvent", event, m.writer)
+    end if
 end sub
 
 ' ----------------------------------------------------------------
@@ -120,7 +137,9 @@ end sub
 ' ----------------------------------------------------------------
 sub __onAddAction(event as object)
     ensureSetup()
-    m.top.rumScope.callfunc("handleEvent", event, m.top.writer)
+    if (m.rumScope <> invalid)
+        m.rumScope.callfunc("handleEvent", event, m.writer)
+    end if
 end sub
 
 ' ----------------------------------------------------------------
@@ -138,7 +157,9 @@ end sub
 ' ----------------------------------------------------------------
 sub __onAddError(event as object)
     ensureSetup()
-    m.top.rumScope.callfunc("handleEvent", event, m.top.writer)
+    if (m.rumScope <> invalid)
+        m.rumScope.callfunc("handleEvent", event, m.writer)
+    end if
 end sub
 
 ' ----------------------------------------------------------------
@@ -156,27 +177,20 @@ end sub
 ' ----------------------------------------------------------------
 sub __onAddResource(event as object)
     ensureSetup()
-    m.top.rumScope.callfunc("handleEvent", event, m.top.writer)
-end sub
-
-' ----------------------------------------------------------------
-' Sends a crash report from a previous view
-' @param lastExitOrTerminationReason (object) the lastExitOrTerminationReason parameter
-' from the channel's RunUserInterface
-' ----------------------------------------------------------------
-sub sendCrash(lastExitOrTerminationReason as string)
-    m.top.sendCrash = lastExitOrTerminationReason
+    if (m.rumScope <> invalid)
+        m.rumScope.callfunc("handleEvent", event, m.writer)
+    end if
 end sub
 
 ' ----------------------------------------------------------------
 ' Private: Handles sendCrash field change event
 ' @param lastExitOrTerminationReason (string) the last exit or termination reason
 ' ----------------------------------------------------------------
-sub __onSendCrash(lastExitOrTerminationReason as string)
+sub sendCrash(lastExitOrTerminationReason as string)
     ensureSetup()
     crashReporter = CreateObject("roSGNode", "RumCrashReporterTask")
-    crashReporter.writer = m.top.writer
-    if (m.top.osVersionMajor.toInt() >= 13)
+    crashReporter.writer = m.writer
+    if (m.osVersionMajor.toInt() >= 13)
         appManager = createObject("roAppManager")
         lastExitInfo = appManager.GetLastExitInfo()
         exitCode = lastExitInfo.exit_code
@@ -204,7 +218,7 @@ end sub
 ' ----------------------------------------------------------------
 sub __onAddConfigTelemetry(event as object)
     ensureSetup()
-    m.top.telemetryScope.callfunc("handleEvent", event, m.top.writer)
+    m.telemetryScope.callfunc("handleEvent", event, m.writer)
 end sub
 
 ' ----------------------------------------------------------------
@@ -221,7 +235,7 @@ end sub
 ' ----------------------------------------------------------------
 sub __onAddErrorTelemetry(event as object)
     ensureSetup()
-    m.top.telemetryScope.callfunc("handleEvent", event, m.top.writer)
+    m.telemetryScope.callfunc("handleEvent", event, m.writer)
 end sub
 
 ' ----------------------------------------------------------------
@@ -238,7 +252,7 @@ end sub
 ' ----------------------------------------------------------------
 sub __onAddDebugTelemetry(event as object)
     ensureSetup()
-    m.top.telemetryScope.callfunc("handleEvent", event, m.top.writer)
+    m.telemetryScope.callfunc("handleEvent", event, m.writer)
 end sub
 
 ' ----------------------------------------------------------------
@@ -256,31 +270,28 @@ end sub
 ' or instantiate one.
 ' ----------------------------------------------------------------
 sub ensureRumScope()
-    if (m.top.rumScope = invalid)
-        fields = m.top.getFields()
-        applicationId = fields.applicationId
+    if (m.rumScope = invalid and m.areFieldsSet = true)
         m.instanceId = CreateObject("roDeviceInfo").GetRandomUUID()
         ddLogWarning("RumAgent.instanceId:" + m.instanceId)
         m.global.addFields({
-            datadogRumContext: {}
+            datadogRumContext: {
+                applicationId: m.applicationId
+                instanceId: m.instanceId
+            }
         })
-        datadogRumContext = m.global.datadogRumContext
-        datadogRumContext.applicationId = applicationId
-        datadogRumContext.instanceId = m.instanceId
-        m.global.setField("datadogRumContext", datadogRumContext)
         ddLogVerbose("Creating RumApplicationScope")
-        rumScope = CreateObject("roSGNode", "RumApplicationScope")
-        rumScope.setFields({
-            applicationId: applicationId
-            service: fields.service
-            version: fields.version
-            deviceName: fields.deviceName
-            deviceModel: fields.deviceModel
-            osVersion: fields.osVersion
-            osVersionMajor: fields.osVersionMajor
-            sessionSampleRate: fields.sessionSampleRate
+        m.rumScope = CreateObject("roSGNode", "RumApplicationScope")
+        m.rumScope.setFields({
+            applicationId: m.applicationId
+            service: m.service
+            version: m.version
+            deviceName: m.deviceName
+            deviceModel: m.deviceModel
+            osVersion: m.osVersion
+            osVersionMajor: m.osVersionMajor
+            sessionSampleRate: m.sessionSampleRate
         })
-        m.top.rumScope = rumScope
+        m.top.rumScope = m.rumScope
     end if
 end sub
 
@@ -289,9 +300,10 @@ end sub
 ' or instantiate one.
 ' ----------------------------------------------------------------
 sub ensureTelemetryScope()
-    if (m.top.telemetryScope = invalid)
+    if (m.telemetryScope = invalid)
         ddLogVerbose("Creating RumTelemetryScope")
-        m.top.telemetryScope = CreateObject("roSGNode", "RumTelemetryScope")
+        m.telemetryScope = CreateObject("roSGNode", "RumTelemetryScope")
+        m.top.telemetryScope = m.telemetryScope
     end if
 end sub
 
@@ -300,20 +312,20 @@ end sub
 ' or instantiate one.
 ' ----------------------------------------------------------------
 sub ensureUploader()
-    uploader = m.top.uploader
-    if (uploader = invalid)
+    if (m.uploader = invalid)
         ddLogVerbose("Creating MultiTrackUploaderTask")
-        uploader = CreateObject("roSGNode", "MultiTrackUploaderTask")
+        m.uploader = CreateObject("roSGNode", "MultiTrackUploaderTask")
+        m.top.uploader = m.uploader
     end if
     trackId = "rum_" + m.top.threadInfo().node.address
-    tracks = (function(uploader)
-            __bsConsequent = uploader.tracks
+    tracks = (function(m)
+            __bsConsequent = m.uploader.tracks
             if __bsConsequent <> invalid then
                 return __bsConsequent
             else
                 return {}
             end if
-        end function)(uploader)
+        end function)(m)
     tracks[trackId] = {
         url: getIntakeUrl(m.top.site, "rum")
         trackType: "rum"
@@ -322,12 +334,13 @@ sub ensureUploader()
         contentType: "text/plain;charset=UTF-8"
         queryParams: {
             ddsource: agentSource()
-            ddtags: "sdk_version:" + sdkVersion() + ",env:" + m.top.env
+            ddtags: "sdk_version:" + sdkVersion() + ",env:" + m.env
         }
     }
-    uploader.tracks = tracks
-    uploader.clientToken = m.top.clientToken
-    m.top.uploader = uploader
+    m.uploader.setFields({
+        tracks: tracks
+        clientToken: m.clientToken
+    })
 end sub
 
 ' ----------------------------------------------------------------
@@ -335,12 +348,43 @@ end sub
 ' or instantiate one.
 ' ----------------------------------------------------------------
 sub ensureWriter()
-    writer = m.top.writer
-    if (writer = invalid)
+    if (m.writer = invalid)
         ddLogVerbose("Creating WriterTask")
-        writer = CreateObject("roSGNode", "WriterTask")
+        m.writer = CreateObject("roSGNode", "WriterTask")
+        m.top.writer = m.writer
     end if
-    writer.trackType = "rum"
-    writer.payloadSeparator = chr(10)
-    m.top.writer = writer
+    m.writer.setFields({
+        trackType: "rum"
+        payloadSeparator: chr(10)
+    })
+end sub
+
+sub updateFields()
+    fields = m.top.getFields()
+    m.applicationId = fields.applicationId
+    m.service = fields.service
+    m.version = fields.version
+    m.deviceName = fields.deviceName
+    m.deviceModel = fields.deviceModel
+    m.osVersion = fields.osVersion
+    m.osVersionMajor = fields.osVersionMajor
+    m.sessionSampleRate = fields.sessionSampleRate
+    m.clientToken = fields.clientToken
+    m.env = fields.env
+    m.site = fields.site
+    m.areFieldsSet = fields.areFieldsSet
+    ' lastExitOrTerminationReason should be set only once at startup and it triggers sendCrash.
+    if (m.lastExitOrTerminationReason = invalid or m.lastExitOrTerminationReason = "")
+        m.lastExitOrTerminationReason = fields.lastExitOrTerminationReason
+        if (m.lastExitOrTerminationReason <> invalid and m.lastExitOrTerminationReason <> "")
+            sendCrash(m.lastExitOrTerminationReason)
+        end if
+    end if
+    ' configuration should be set only once at startup and it triggers addConfigTelemetry.
+    if (m.configuration = invalid or m.configuration.Count() = 0)
+        m.configuration = fields.configuration
+        if (m.configuration <> invalid and m.configuration.Count() > 0)
+            addConfigTelemetry(m.configuration)
+        end if
+    end if
 end sub

--- a/dist/components/rum/RumAgent.xml
+++ b/dist/components/rum/RumAgent.xml
@@ -15,12 +15,12 @@
         <field id="sessionSampleRate" type="integer" value="100" />
         <field id="lastExitOrTerminationReason" type="string" value="" />
         <field id="configuration" type="assocarray" value="{}" />
+        <field id="areFieldsSet" type="boolean" value="false" />
         <field id="startView" type="assocarray" />
         <field id="stopView" type="assocarray" />
         <field id="addAction" type="assocarray" />
         <field id="addError" type="assocarray" />
         <field id="addResource" type="assocarray" />
-        <field id="sendCrash" type="string" />
         <field id="addConfigTelemetry" type="assocarray" />
         <field id="addErrorTelemetry" type="assocarray" />
         <field id="addDebugTelemetry" type="assocarray" />

--- a/dist/source/datadogSdk.brs
+++ b/dist/source/datadogSdk.brs
@@ -108,6 +108,8 @@ sub initialize(configuration as object, global as object)
             deviceModel: deviceModel
             osVersion: deviceOsVersionFull
             osVersionMajor: deviceOsVersion.major
+            configuration: configuration
+            areFieldsSet: true
         })
         global.addFields({
             datadogRumAgent: rumAgent

--- a/library/components/core/WriterTask.bs
+++ b/library/components/core/WriterTask.bs
@@ -20,8 +20,12 @@ sub init()
     m.port = createObject("roMessagePort")
     m.top.observeFieldScoped("writeEvent", m.port)
     m.top.observeFieldScoped("trackType", m.port)
+    m.top.observeFieldScoped("payloadSeparator", m.port)
+    m.top.observeFieldScoped("maxBatchSize", m.port)
     m.top.functionName = "writerLoop"
     m.top.control = "RUN"
+    m.maxBatchSize = m.top.maxBatchSize
+    m.payloadSeparator = m.top.payloadSeparator
 end sub
 
 ' ----------------------------------------------------------------
@@ -41,6 +45,10 @@ sub writerLoop()
                 onWriteEvent(eventData)
             else if (fieldName = "trackType")
                 m.trackType = msg.getData()
+            else if (fieldName = "payloadSeparator")
+                m.payloadSeparator = msg.getData()
+            else if (fieldName = "maxBatchSize")
+                m.maxBatchSize = msg.getData()
             else
                 ddLogWarning(fieldName + " not handled")
             end if
@@ -65,7 +73,7 @@ sub onWriteEvent(event as string)
     if (m.fileSystem.Exists(filePath))
         fileSize = m.fileSystem.Stat(filePath).size
         if (fileSize > 0)
-            AppendAsciiFile(filePath, m.top.payloadSeparator)
+            AppendAsciiFile(filePath, m.payloadSeparator)
         end if
     end if
 
@@ -104,8 +112,8 @@ function getWriteableFile(eventSize as integer) as string
         uploadTimestamp& = fileTimestamp& + 25000
         if ((uploadTimestamp& > currentTimestamp&))
             lastFilePath = folderPath + "/" + lastFilename
-            lastFileSize = m.fileSystem.Stat(lastFilePath).size ?? m.top.maxBatchSize
-            if (lastFileSize + m.top.payloadSeparator.Len() + eventSize < m.top.maxBatchSize)
+            lastFileSize = m.fileSystem.Stat(lastFilePath).size ?? m.maxBatchSize
+            if (lastFileSize + m.payloadSeparator.Len() + eventSize < m.maxBatchSize)
                 return folderPath + "/" + lastFilename
             end if
         end if

--- a/library/components/rum/RumAgent.bs
+++ b/library/components/rum/RumAgent.bs
@@ -23,12 +23,19 @@ sub init()
     m.top.observeFieldScoped("addAction", m.port)
     m.top.observeFieldScoped("addError", m.port)
     m.top.observeFieldScoped("addResource", m.port)
-    m.top.observeFieldScoped("sendCrash", m.port)
     m.top.observeFieldScoped("addConfigTelemetry", m.port)
     m.top.observeFieldScoped("addErrorTelemetry", m.port)
     m.top.observeFieldScoped("addDebugTelemetry", m.port)
+    m.top.observeFieldScoped("areFieldsSet", m.port)
+
+    'Observe nodes injected by the test
+    m.top.observeFieldScoped("uploader", m.port)
+    m.top.observeFieldScoped("writer", m.port)
+    m.top.observeFieldScoped("rumScope", m.port)
+    m.top.observeFieldScoped("telemetryScope", m.port)
     m.top.functionName = "rumAgentLoop"
     m.top.control = "RUN"
+
 end sub
 
 ' ----------------------------------------------------------------
@@ -36,8 +43,6 @@ end sub
 ' ----------------------------------------------------------------
 sub rumAgentLoop()
     ddLogThread("RumAgent.rumAgentLoop()")
-    sendCrash(m.top.lastExitOrTerminationReason)
-    addConfigTelemetry(m.top.configuration)
     while(true)
         msg = wait(0, m.port)
         msgType = type(msg)
@@ -53,14 +58,24 @@ sub rumAgentLoop()
                 __onAddError(msg.getData())
             else if(fieldName = "addResource")
                 __onAddResource(msg.getData())
-            else if(fieldName = "sendCrash")
-                __onSendCrash(msg.getData())
             else if(fieldName = "addConfigTelemetry")
                 __onAddConfigTelemetry(msg.getData())
             else if(fieldName = "addErrorTelemetry")
                 __onAddErrorTelemetry(msg.getData())
             else if(fieldName = "addDebugTelemetry")
                 __onAddDebugTelemetry(msg.getData())
+            else if(fieldName = "uploader")
+                m.uploader = msg.getData()
+            else if(fieldName = "writer")
+                m.writer = msg.getData()
+            else if(fieldName = "rumScope")
+                m.rumScope = msg.getData()
+            else if(fieldName = "telemetryScope")
+                m.telemetryScope = msg.getData()
+            else if(fieldName = "areFieldsSet")
+                if(msg.getData())
+                    updateFields()
+                end if
             end if
         else 
             ddLogWarning("Unexpected message " + msgType + ": " + FormatJson(msg))
@@ -84,8 +99,10 @@ end sub
 ' ----------------------------------------------------------------
 sub __onStartView(event as object)
     ensureSetup()
-    m.top.rumScope@.handleEvent(event, m.top.writer)
-    m.top.rumScope@.handleEvent(keepAliveEvent(), m.top.writer)
+    if(m.rumScope <> invalid)
+        m.rumScope@.handleEvent(event, m.writer)
+        m.rumScope@.handleEvent(keepAliveEvent(), m.writer)
+    end if
 end sub
 
 ' ----------------------------------------------------------------
@@ -104,7 +121,9 @@ end sub
 ' ----------------------------------------------------------------
 sub __onStopView(event as object)
     ensureSetup()
-    m.top.rumScope@.handleEvent(event, m.top.writer)
+    if(m.rumScope <> invalid)
+        m.rumScope@.handleEvent(event, m.writer)
+    end if
 end sub
 
 ' ----------------------------------------------------------------
@@ -122,7 +141,9 @@ end sub
 ' ----------------------------------------------------------------
 sub __onAddAction(event as object)
     ensureSetup()
-    m.top.rumScope@.handleEvent(event, m.top.writer)
+    if(m.rumScope <> invalid)
+        m.rumScope@.handleEvent(event, m.writer)
+    end if
 end sub
 
 ' ----------------------------------------------------------------
@@ -140,7 +161,9 @@ end sub
 ' ----------------------------------------------------------------
 sub __onAddError(event as object)
     ensureSetup()
-    m.top.rumScope@.handleEvent(event, m.top.writer)
+    if(m.rumScope <> invalid)
+        m.rumScope@.handleEvent(event, m.writer)
+    end if
 end sub
 
 ' ----------------------------------------------------------------
@@ -158,27 +181,20 @@ end sub
 ' ----------------------------------------------------------------
 sub __onAddResource(event as object)
     ensureSetup()
-    m.top.rumScope@.handleEvent(event, m.top.writer)
-end sub
-
-' ----------------------------------------------------------------
-' Sends a crash report from a previous view
-' @param lastExitOrTerminationReason (object) the lastExitOrTerminationReason parameter
-' from the channel's RunUserInterface
-' ----------------------------------------------------------------
-sub sendCrash(lastExitOrTerminationReason as string)
-    m.top.sendCrash = lastExitOrTerminationReason
+    if(m.rumScope <> invalid)
+        m.rumScope@.handleEvent(event, m.writer)
+    end if
 end sub
 
 ' ----------------------------------------------------------------
 ' Private: Handles sendCrash field change event
 ' @param lastExitOrTerminationReason (string) the last exit or termination reason
 ' ----------------------------------------------------------------
-sub __onSendCrash(lastExitOrTerminationReason as string)
+sub sendCrash(lastExitOrTerminationReason as string)
     ensureSetup()
     crashReporter = CreateObject("roSGNode", "RumCrashReporterTask")
-    crashReporter.writer = m.top.writer
-    if (m.top.osVersionMajor.toInt() >= 13)
+    crashReporter.writer = m.writer
+    if (m.osVersionMajor.toInt() >= 13)
         appManager = createObject("roAppManager")
         lastExitInfo = appManager.GetLastExitInfo()
         exitCode = lastExitInfo.exit_code
@@ -206,7 +222,7 @@ end sub
 ' ----------------------------------------------------------------
 sub __onAddConfigTelemetry(event as object)
     ensureSetup()
-    m.top.telemetryScope@.handleEvent(event, m.top.writer)
+    m.telemetryScope@.handleEvent(event, m.writer)
 end sub
 
 ' ----------------------------------------------------------------
@@ -223,7 +239,7 @@ end sub
 ' ----------------------------------------------------------------
 sub __onAddErrorTelemetry(event as object)
     ensureSetup()
-    m.top.telemetryScope@.handleEvent(event, m.top.writer)
+    m.telemetryScope@.handleEvent(event, m.writer)
 end sub
 
 ' ----------------------------------------------------------------
@@ -240,7 +256,7 @@ end sub
 ' ----------------------------------------------------------------
 sub __onAddDebugTelemetry(event as object)
     ensureSetup()
-    m.top.telemetryScope@.handleEvent(event, m.top.writer)
+    m.telemetryScope@.handleEvent(event, m.writer)
 end sub
 
 ' ----------------------------------------------------------------
@@ -258,31 +274,30 @@ end sub
 ' or instantiate one.
 ' ----------------------------------------------------------------
 sub ensureRumScope()
-    if (m.top.rumScope = invalid)
-        fields = m.top.getFields()
-        applicationId = fields.applicationId
+    if (m.rumScope = invalid and m.areFieldsSet = true)
         m.instanceId = CreateObject("roDeviceInfo").GetRandomUUID()
         ddLogWarning("RumAgent.instanceId:" + m.instanceId)
-        m.global.addFields({ datadogRumContext: {} })
-        datadogRumContext = m.global.datadogRumContext
-        datadogRumContext.applicationId = applicationId
-        datadogRumContext.instanceId = m.instanceId
-        m.global.setField("datadogRumContext", datadogRumContext)
+        m.global.addFields({
+            datadogRumContext: {
+                applicationId: m.applicationId,
+                instanceId: m.instanceId
+            }
+        })
 
         ddLogVerbose("Creating RumApplicationScope")
 
-        rumScope = CreateObject("roSGNode", "RumApplicationScope")
-        rumScope.setFields({
-            applicationId: applicationId,
-            service: fields.service,
-            version: fields.version,
-            deviceName: fields.deviceName,
-            deviceModel: fields.deviceModel,
-            osVersion: fields.osVersion,
-            osVersionMajor: fields.osVersionMajor,
-            sessionSampleRate: fields.sessionSampleRate
+        m.rumScope = CreateObject("roSGNode", "RumApplicationScope")
+        m.rumScope.setFields({
+            applicationId: m.applicationId,
+            service: m.service,
+            version: m.version,
+            deviceName: m.deviceName,
+            deviceModel: m.deviceModel,
+            osVersion: m.osVersion,
+            osVersionMajor: m.osVersionMajor,
+            sessionSampleRate: m.sessionSampleRate
         })
-        m.top.rumScope = rumScope
+        m.top.rumScope = m.rumScope
     end if
 end sub
 
@@ -291,9 +306,10 @@ end sub
 ' or instantiate one.
 ' ----------------------------------------------------------------
 sub ensureTelemetryScope()
-    if (m.top.telemetryScope = invalid)
+    if (m.telemetryScope = invalid)
         ddLogVerbose("Creating RumTelemetryScope")
-        m.top.telemetryScope = CreateObject("roSGNode", "RumTelemetryScope")
+        m.telemetryScope = CreateObject("roSGNode", "RumTelemetryScope")
+        m.top.telemetryScope = m.telemetryScope
     end if
 end sub
 
@@ -302,25 +318,26 @@ end sub
 ' or instantiate one.
 ' ----------------------------------------------------------------
 sub ensureUploader()
-    uploader = m.top.uploader
-    if (uploader = invalid)
+    if (m.uploader = invalid)
         ddLogVerbose("Creating MultiTrackUploaderTask")
-        uploader = CreateObject("roSGNode", "MultiTrackUploaderTask")
+        m.uploader = CreateObject("roSGNode", "MultiTrackUploaderTask")
+        m.top.uploader = m.uploader
     end if
-
     trackId = "rum_" + m.top.threadInfo().node.address
-    tracks = uploader.tracks ?? {}
+    tracks = m.uploader.tracks ?? {}
     tracks[trackId] = {
         url: getIntakeUrl(m.top.site, TrackType.rum),
         trackType: TrackType.rum,
         payloadPrefix: "",
         payloadPostfix: "",
         contentType: "text/plain;charset=UTF-8",
-        queryParams: { ddsource: agentSource(), ddtags: "sdk_version:" + sdkVersion() + ",env:" + m.top.env }
+        queryParams: { ddsource: agentSource(), ddtags: "sdk_version:" + sdkVersion() + ",env:" + m.env }
     }
-    uploader.tracks = tracks
-    uploader.clientToken = m.top.clientToken
-    m.top.uploader = uploader
+    m.uploader.setFields({
+        tracks: tracks,
+        clientToken: m.clientToken
+    })
+    
 end sub
 
 ' ----------------------------------------------------------------
@@ -328,13 +345,46 @@ end sub
 ' or instantiate one.
 ' ----------------------------------------------------------------
 sub ensureWriter()
-    writer = m.top.writer
-    if (writer = invalid)
+    if (m.writer = invalid)
         ddLogVerbose("Creating WriterTask")
-        writer = CreateObject("roSGNode", "WriterTask")
+        m.writer = CreateObject("roSGNode", "WriterTask")
+        m.top.writer = m.writer
+    end if
+    m.writer.setFields({
+        trackType: TrackType.rum,
+        payloadSeparator: chr(10)
+    })
+end sub
+
+
+sub updateFields()
+    fields = m.top.getFields()
+    m.applicationId = fields.applicationId
+    m.service = fields.service
+    m.version = fields.version
+    m.deviceName = fields.deviceName
+    m.deviceModel = fields.deviceModel
+    m.osVersion = fields.osVersion
+    m.osVersionMajor = fields.osVersionMajor
+    m.sessionSampleRate = fields.sessionSampleRate
+    m.clientToken = fields.clientToken
+    m.env = fields.env
+    m.site = fields.site
+    m.areFieldsSet = fields.areFieldsSet
+
+    ' lastExitOrTerminationReason should be set only once at startup and it triggers sendCrash.
+    if(m.lastExitOrTerminationReason = invalid or m.lastExitOrTerminationReason = "")
+        m.lastExitOrTerminationReason = fields.lastExitOrTerminationReason
+        if(m.lastExitOrTerminationReason <> invalid and m.lastExitOrTerminationReason <> "")
+            sendCrash(m.lastExitOrTerminationReason)
+        end if
     end if
 
-    writer.trackType = TrackType.rum
-    writer.payloadSeparator = chr(10)
-    m.top.writer = writer
+    ' configuration should be set only once at startup and it triggers addConfigTelemetry.
+    if (m.configuration = invalid or  m.configuration.Count() = 0)
+        m.configuration = fields.configuration
+        if(m.configuration <> invalid and m.configuration.Count() > 0)
+            addConfigTelemetry(m.configuration)
+        end if
+    end if
 end sub

--- a/library/components/rum/RumAgent.xml
+++ b/library/components/rum/RumAgent.xml
@@ -26,13 +26,13 @@ Copyright 2022-Today Datadog, Inc.
         <field id="sessionSampleRate" type="integer" value="100" />
         <field id="lastExitOrTerminationReason" type="string" value=""/>
         <field id="configuration" type="assocarray" value="{}"/>
+        <field id="areFieldsSet" type="boolean" value="false"/>
 
         <field id="startView" type="assocarray" />
         <field id="stopView" type="assocarray" />
         <field id="addAction" type="assocarray" />
         <field id="addError" type="assocarray" />
         <field id="addResource" type="assocarray" />
-        <field id="sendCrash" type="string" />
         <field id="addConfigTelemetry" type="assocarray" />
         <field id="addErrorTelemetry" type="assocarray" />
         <field id="addDebugTelemetry" type="assocarray" />

--- a/library/source/datadogSdk.bs
+++ b/library/source/datadogSdk.bs
@@ -74,7 +74,9 @@ sub initialize(configuration as object, global as object)
             deviceName: deviceName,
             deviceModel: deviceModel,
             osVersion: deviceOsVersionFull,
-            osVersionMajor: deviceOsVersion.major
+            osVersionMajor: deviceOsVersion.major,
+            configuration: configuration,
+            areFieldsSet: true
         })
         global.addFields({ datadogRumAgent: rumAgent })
     end if

--- a/test/source/tests/Test__timeUtils.bs
+++ b/test/source/tests/Test__timeUtils.bs
@@ -28,13 +28,13 @@ function TimeUtilsTest__WhenGetTimestamp_ThenReturnsTimestampInMilliseconds() as
     ' Given
     ' hardcoded values to get a valid range
     timestampMS_1jan2025 = 1735686000000
-    timestampMS_1jan2026 = 1767225600000
+    timestampMS_1jan2028 = 1830294000000
 
     ' When
     result = datadogroku_getTimestamp()
 
     ' Then
-    Assert.that(result).isInRange(timestampMS_1jan2025, timestampMS_1jan2026)
+    Assert.that(result).isInRange(timestampMS_1jan2025, timestampMS_1jan2028)
     return ""
 end function
 

--- a/test/source/tests/rum/Test__RumAgent.bs
+++ b/test/source/tests/rum/Test__RumAgent.bs
@@ -13,6 +13,8 @@ function TestSuite__RumAgent() as object
     this.addTest("WhenStartView_ThenDelegateToRumScope", RumAgentTest__WhenStartView_ThenDelegateToRumScope, RumAgentTest__SetUp, RumAgentTest__TearDown)
     this.addTest("WhenStartViewWithContext_ThenDelegateToRumScope", RumAgentTest__WhenStartViewWithContext_ThenDelegateToRumScope, RumAgentTest__SetUp, RumAgentTest__TearDown)
     this.addTest("WhenStopView_ThenDelegateToRumScope", RumAgentTest__WhenStopView_ThenDelegateToRumScope, RumAgentTest__SetUp, RumAgentTest__TearDown)
+    this.addTest("WhenStopView_AfterWriterTrackTypeChanged_WriterTrackTypeRestoredToRum", RumAgentTest__WhenStopView_AfterWriterTrackTypeChanged_WriterTrackTypeRestoredToRum, RumAgentTest__SetUp, RumAgentTest__TearDown)
+    this.addTest("WhenStopView_AfterUploaderTrackTypeChanged_UploaderTrackTypeRestoredToRum", RumAgentTest__WhenStopView_AfterUploaderTrackTypeChanged_UploaderTrackTypeRestoredToRum, RumAgentTest__SetUp, RumAgentTest__TearDown)
     this.addTest("WhenStopViewWithContext_ThenDelegateToRumScope", RumAgentTest__WhenStopViewWithContext_ThenDelegateToRumScope, RumAgentTest__SetUp, RumAgentTest__TearDown)
     this.addTest("WhenAddAction_ThenDelegateToRumScope", RumAgentTest__WhenAddAction_ThenDelegateToRumScope, RumAgentTest__SetUp, RumAgentTest__TearDown)
     this.addTest("WhenAddActionWithContext_ThenDelegateToRumScope", RumAgentTest__WhenAddActionWithContext_ThenDelegateToRumScope, RumAgentTest__SetUp, RumAgentTest__TearDown)
@@ -25,7 +27,7 @@ function TestSuite__RumAgent() as object
     this.addTest("WhenAddErrorTelemetry_ThenDelegateToTelemetryScope", RumAgentTest__WhenAddErrorTelemetry_ThenDelegateToTelemetryScope, RumAgentTest__SetUp, RumAgentTest__TearDown)
     this.addTest("WhenAddDebugTelemetry_ThenDelegateToTelemetryScope", RumAgentTest__WhenAddDebugTelemetry_ThenDelegateToTelemetryScope, RumAgentTest__SetUp, RumAgentTest__TearDown)
 
-    this.addTest("WhenDoNothing_ThenInitDependencies", RumAgentTest__WhenDoNothing_ThenInitDependencies, RumAgentTest__SetUpNoMock, RumAgentTest__TearDown)
+    this.addTest("WhenHandlingEvent_ThenInitDependencies", RumAgentTest__WhenHandlingEvent_ThenInitDependencies, RumAgentTest__SetUpNoMock, RumAgentTest__TearDown)
 
     return this
 end function
@@ -67,6 +69,10 @@ sub RumAgentTest__SetUp()
     m.testSuite.testedNode.deviceModel = m.testSuite.fakeDeviceModel
     m.testSuite.testedNode.osVersion = m.testSuite.fakeOsVersion
     m.testSuite.testedNode.osVersionMajor = m.testSuite.fakeOsVersionMajor
+    m.testSuite.testedNode.areFieldsSet = true
+    ' Allow the RumAgent task to process DI messages (uploader, writer, rumScope, etc.)
+    ' so m.rumScope is set before tests call addAction/startView/etc.
+    sleep(100)
 end sub
 
 sub RumAgentTest__SetUpNoMock()
@@ -81,6 +87,8 @@ sub RumAgentTest__SetUpNoMock()
     m.testSuite.fakeApplicationId = IG_GetString(32)
     m.testSuite.fakeService = IG_GetString(32)
     m.testSuite.fakeKeepAliveDelayMs = 10 + IG_GetInteger(30)
+    m.testSuite.fakeEnv = IG_GetString(10)
+    m.testSuite.fakeVersion = IG_GetString(32)
 
     ' Tested Task
     m.testSuite.testedNode = CreateObject("roSGNode", "datadogroku_RumAgent")
@@ -94,12 +102,21 @@ sub RumAgentTest__SetUpNoMock()
     m.testSuite.testedNode.deviceModel = m.testSuite.fakeDeviceModel
     m.testSuite.testedNode.osVersion = m.testSuite.fakeOsVersion
     m.testSuite.testedNode.osVersionMajor = m.testSuite.fakeOsVersionMajor
+    m.testSuite.testedNode.env = m.testSuite.fakeEnv
+    m.testSuite.testedNode.areFieldsSet = true
+    ' Allow the RumAgent task to process DI messages (uploader, writer, rumScope, etc.)
+    ' so m.rumScope is set before tests call addAction/startView/etc.
+    sleep(100)
 end sub
 
 sub RumAgentTest__TearDown()
     m.testSuite.testedNode.control = "STOP"
-    m.testSuite.testedNode.writer.control = "STOP"
-    m.testSuite.testedNode.uploader.control = "STOP"
+    if(m.testSuite.testedNode.writer <> invalid) 
+        m.testSuite.testedNode.writer.control = "STOP"
+    end if
+    if(m.testSuite.testedNode.uploader <> invalid)
+        m.testSuite.testedNode.uploader.control = "STOP"
+    end if
     m.testSuite.testedNode.Delete("uploader")
     m.testSuite.testedNode.Delete("writer")
     m.testSuite.Delete("mockUploader")
@@ -124,7 +141,7 @@ function RumAgentTest__WhenStartView_ThenDelegateToRumScope() as string
 
     ' Then
     expectedArgs = { event: { eventType: "startView", viewName: fakeViewName, viewUrl: fakeViewUrl }, writer: m.mockWriter }
-    return m.mockRumScope@.assertFunctionCalled("handleEvent", expectedArgs)
+    return m.testedNode.rumScope@.assertFunctionCalled("handleEvent", expectedArgs)
 end function
 
 '----------------------------------------------------------------
@@ -142,6 +159,7 @@ function RumAgentTest__WhenStartViewWithContext_ThenDelegateToRumScope() as stri
     end for
 
     ' When
+    m.testedNode.writer = m.mockWriter
     m.testedNode@.startView(fakeViewName, fakeViewUrl, fakeContext)
     sleep(30)
 
@@ -167,6 +185,65 @@ function RumAgentTest__WhenStopView_ThenDelegateToRumScope() as string
     ' Then
     expectedArgs = { event: { eventType: "stopView", viewName: fakeViewName, viewUrl: fakeViewUrl }, writer: m.mockWriter }
     return m.mockRumScope@.assertFunctionCalled("handleEvent", expectedArgs)
+end function
+
+'----------------------------------------------------------------
+' Given: a RumAgent
+'  When: handle start view (writer track type becomes rum), set writer to another track type, then handle stop view
+'  Then: writer track type is still rum (ensureWriter re-applies rum on each event)
+'----------------------------------------------------------------
+function RumAgentTest__WhenStopView_AfterWriterTrackTypeChanged_WriterTrackTypeRestoredToRum() as string
+    ' Given
+    fakeViewName = IG_GetString(32)
+    fakeViewUrl = IG_GetString(32)
+
+    ' When: start view -> ensureWriter runs, writer.trackType is set to "rum"
+    m.testedNode@.startView(fakeViewName, fakeViewUrl)
+    sleep(30)
+
+    ' Then: writer track type is rum
+    Assert.that(m.testedNode.writer.trackType).isEqualTo("rum")
+
+    ' When: set writer to another track type, then stop view (ensureWriter runs again)
+    m.testedNode.writer.trackType = "logs"
+    m.testedNode@.stopView(fakeViewName, fakeViewUrl)
+    sleep(30)
+
+    ' Then: writer track type is still rum (restored by ensureWriter in stop view handling)
+    Assert.that(m.testedNode.writer.trackType).isEqualTo("rum")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a RumAgent
+'  When: handle start view (uploader rum track type is rum), set uploader track to another type, then handle stop view
+'  Then: uploader rum track type is still rum (ensureUploader re-applies rum on each event)
+'----------------------------------------------------------------
+function RumAgentTest__WhenStopView_AfterUploaderTrackTypeChanged_UploaderTrackTypeRestoredToRum() as string
+    ' Given
+    fakeViewName = IG_GetString(32)
+    fakeViewUrl = IG_GetString(32)
+    expectedTrackName = "rum_" + m.testedNode.threadInfo().node.address
+
+    ' When: start view -> ensureUploader runs, uploader has rum track with trackType "rum"
+    m.testedNode@.startView(fakeViewName, fakeViewUrl)
+    sleep(30)
+
+    ' Then: uploader rum track type is rum
+    uploaderTracks = m.testedNode.uploader.tracks
+    Assert.that(uploaderTracks).isNotInvalid().containsKey(expectedTrackName)
+    Assert.that(uploaderTracks[expectedTrackName].trackType).isEqualTo("rum")
+
+    ' When: set uploader rum track to another track type, then stop view (ensureUploader runs again)
+    uploaderTracks[expectedTrackName].trackType = "logs"
+    m.testedNode@.stopView(fakeViewName, fakeViewUrl)
+    sleep(30)
+
+    ' Then: uploader rum track type is still rum (restored by ensureUploader in stop view handling)
+    uploaderTracks = m.testedNode.uploader.tracks
+    Assert.that(uploaderTracks).isNotInvalid().containsKey(expectedTrackName)
+    Assert.that(uploaderTracks[expectedTrackName].trackType).isEqualTo("rum")
+    return ""
 end function
 
 '----------------------------------------------------------------
@@ -371,16 +448,20 @@ end function
 '  When: initializing
 '  Then: ensure the dependencies are created if not present
 '----------------------------------------------------------------
-function RumAgentTest__WhenDoNothing_ThenInitDependencies() as string
+function RumAgentTest__WhenHandlingEvent_ThenInitDependencies() as string
     ' Given
     m.testedNode.uploader = invalid
     m.testedNode.writer = invalid
     m.testedNode.rumScope = invalid
     site = IG_GetOneOf(["us1", "us3", "us5", "eu1"])
     m.testedNode.site = site
-    m.testedNode.env = m.fakeEnv
     expectedUrl = datadogroku_getIntakeUrl(site, "rum")
     expectedTrackName = "rum_" + m.testedNode.threadInfo().node.address
+
+    fakeMessage = IG_GetString(128)
+
+    ' When - any event handling call should trigger ensureSetup
+    m.testedNode@.addDebugTelemetry(fakeMessage)
 
     ' When
     sleep(100)


### PR DESCRIPTION
### What does this PR do?

This PR mainly reduce the rendezvous events by:
* caching `rumScope`, `uploader` & ` writer` inside brightscript scope instead of visiting SceneGraph thread everytime.
* caching all the fields and listen to their updates.

### Results 

This PR reduces the rendezvous events in application launch from 102-> 63 (38% improvements)

<img width="2920" height="996" alt="image" src="https://github.com/user-attachments/assets/0903776b-c936-45b6-86e3-44daf3e79297" />

### Additional Notes

* Next steps should focus on upload/writer, to avoid repeating setup in `RumAgent`

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

