### PR TITLE
RUM-14356: Add ignoredExitEvents in configuration

### DIFF
--- a/dist/components/rum/RumCrashReporterTask.brs
+++ b/dist/components/rum/RumCrashReporterTask.brs
@@ -23,22 +23,26 @@ sub sendCrashReport()
     ddLogThread("RumCrashReporterTask.sendCrashReport()")
     currentSessionlastViewEventFilePath = lastViewEventFilePath(m.top.instanceId)
     m.lastExitOrTerminationReason = m.top.lastExitOrTerminationReason
-    unexpectedExitStatus = [
-        "EXIT_BRIGHTSCRIPT_CRASH"
-        "EXIT_BRIGHTSCRIPT_TIMEOUT"
-        "EXIT_GRAPHICS_NOT_RELEASED"
-        "EXIT_SIGNAL_TIMEOUT"
-        "EXIT_OUT_OF_MEMORY"
-        "EXIT_MEM_LIMIT_EXCEEDED_FG"
-        "EXIT_MEM_LIMIT_EXCEEDED_BG"
-    ]
-    keep = false
-    for each status in unexpectedExitStatus
-        if (m.lastExitOrTerminationReason = status)
-            keep = true
-            exit for
-        end if
-    end for
+    ignoredExitEvents = (function(m)
+            __bsConsequent = m.global.datadogIgnoredExitEvents
+            if __bsConsequent <> invalid then
+                return __bsConsequent
+            else
+                return []
+            end if
+        end function)(m)
+    keep = true
+    if (m.lastExitOrTerminationReason = "")
+        ddLogInfo("Last exit status is empty, ignoring")
+        keep = false
+    else
+        for each status in ignoredExitEvents
+            if (m.lastExitOrTerminationReason = status)
+                keep = false
+                exit for
+            end if
+        end for
+    end if
     if (not keep)
         ddLogInfo("Last exit status " + m.lastExitOrTerminationReason + " is not a crash, ignoring")
     end if

--- a/dist/source/datadogSdk.brs
+++ b/dist/source/datadogSdk.brs
@@ -23,6 +23,9 @@
 '           - "tracecontext": W3C Trace Context header (cf: https://www.w3.org/TR/trace-context/)
 '           - "datadog": Datadog's `x-datadog-*` headers (cf: https://docs.datadoghq.com/real_user_monitoring/connect_rum_and_traces)
 '  - traceContextInjection (string) defines whether the trace context should be injected into all requests or only sampled ones.
+'  - ignoredExitEvents (array, optional) an array of exit status strings to ignore when detecting crashes.
+'     Any exit status NOT in this list will be reported as a crash. Defaults to:
+'     ["EXIT_UNKNOWN", "EXIT_POWER_MODE", "EXIT_IDLE_AUTO_EXIT", "EXIT_DIAL_DELETE", "EXIT_USER_KILL", "EXIT_USER_NAV"]
 ' @param global (object) the global node available from any node in the scenegraph
 ' ----------------------------------------------------------------
 sub initialize(configuration as object, global as object)
@@ -139,6 +142,9 @@ sub initialize(configuration as object, global as object)
             datadogLogsAgent: agent
         })
     end if
+    if (configuration.ignoredExitEvents <> invalid and configuration.ignoredExitEvents.count() = 0)
+        ddLogWarning("configuration.ignoredExitEvents is empty; all exit statuses will be reported as crashes.")
+    end if
     global.addFields({
         datadogTraceAgent: {
             traceSampleRate: (function(configuration)
@@ -166,6 +172,21 @@ sub initialize(configuration as object, global as object)
                     end if
                 end function)(configuration)
         }
+        datadogIgnoredExitEvents: (function(configuration)
+                __bsConsequent = configuration.ignoredExitEvents
+                if __bsConsequent <> invalid then
+                    return __bsConsequent
+                else
+                    return [
+                        "EXIT_UNKNOWN"
+                        "EXIT_POWER_MODE"
+                        "EXIT_IDLE_AUTO_EXIT"
+                        "EXIT_DIAL_DELETE"
+                        "EXIT_USER_KILL"
+                        "EXIT_USER_NAV"
+                    ]
+                end if
+            end function)(configuration)
     })
 end sub
 ' ----------------------------------------------------------------

--- a/library/components/rum/RumCrashReporterTask.bs
+++ b/library/components/rum/RumCrashReporterTask.bs
@@ -26,22 +26,19 @@ sub sendCrashReport()
     ddLogThread("RumCrashReporterTask.sendCrashReport()")
     currentSessionlastViewEventFilePath = lastViewEventFilePath(m.top.instanceId)
     m.lastExitOrTerminationReason = m.top.lastExitOrTerminationReason
-    unexpectedExitStatus = [
-        "EXIT_BRIGHTSCRIPT_CRASH",
-        "EXIT_BRIGHTSCRIPT_TIMEOUT",
-        "EXIT_GRAPHICS_NOT_RELEASED",
-        "EXIT_SIGNAL_TIMEOUT",
-        "EXIT_OUT_OF_MEMORY",
-        "EXIT_MEM_LIMIT_EXCEEDED_FG",
-        "EXIT_MEM_LIMIT_EXCEEDED_BG"
-    ]
-    keep = false
-    for each status in unexpectedExitStatus
-        if (m.lastExitOrTerminationReason = status)
-            keep = true
-            exit for
-        end if
-    end for
+    ignoredExitEvents = m.global.datadogIgnoredExitEvents ?? []
+    keep = true
+    if (m.lastExitOrTerminationReason = "")
+        ddLogInfo("Last exit status is empty, ignoring")
+        keep = false
+    else
+        for each status in ignoredExitEvents
+            if (m.lastExitOrTerminationReason = status)
+                keep = false
+                exit for
+            end if
+        end for
+    end if
 
     if (not keep)
         ddLogInfo("Last exit status " + m.lastExitOrTerminationReason + " is not a crash, ignoring")

--- a/library/source/datadogSdk.bs
+++ b/library/source/datadogSdk.bs
@@ -23,6 +23,9 @@
 '           - "tracecontext": W3C Trace Context header (cf: https://www.w3.org/TR/trace-context/)
 '           - "datadog": Datadog's `x-datadog-*` headers (cf: https://docs.datadoghq.com/real_user_monitoring/connect_rum_and_traces)
 '  - traceContextInjection (string) defines whether the trace context should be injected into all requests or only sampled ones.
+'  - ignoredExitEvents (array, optional) an array of exit status strings to ignore when detecting crashes.
+'     Any exit status NOT in this list will be reported as a crash. Defaults to:
+'     ["EXIT_UNKNOWN", "EXIT_POWER_MODE", "EXIT_IDLE_AUTO_EXIT", "EXIT_DIAL_DELETE", "EXIT_USER_KILL", "EXIT_USER_NAV"]
 ' @param global (object) the global node available from any node in the scenegraph
 ' ----------------------------------------------------------------
 sub initialize(configuration as object, global as object)
@@ -98,12 +101,24 @@ sub initialize(configuration as object, global as object)
         global.addFields({ datadogLogsAgent: agent })
     end if
 
+    if (configuration.ignoredExitEvents <> invalid and configuration.ignoredExitEvents.count() = 0)
+        ddLogWarning("configuration.ignoredExitEvents is empty; all exit statuses will be reported as crashes.")
+    end if
+
     global.addFields({
         datadogTraceAgent: {
             traceSampleRate: configuration.traceSampleRate ?? 100,
             tracingHeaderTypes: configuration.tracingHeaderTypes ?? {},
             traceContextInjection: configuration.traceContextInjection ?? TraceContextInjection.Sampled
-        }
+        },
+        datadogIgnoredExitEvents: configuration.ignoredExitEvents ?? [
+            "EXIT_UNKNOWN",
+            "EXIT_POWER_MODE",
+            "EXIT_IDLE_AUTO_EXIT",
+            "EXIT_DIAL_DELETE",
+            "EXIT_USER_KILL",
+            "EXIT_USER_NAV"
+        ]
     })
 end sub
 

--- a/sample/source/main.bs
+++ b/sample/source/main.bs
@@ -40,7 +40,15 @@ sub RunUserInterface(args as dynamic)
         launchArgs: args,
         traceSampleRate: 100,
         tracingHeaderTypes: credentials.mirrorHostsTracingHeaderTypes,
-        traceContextInjection: "all"
+        traceContextInjection: "all",
+        ignoredExitEvents: [
+            "EXIT_UNKNOWN",
+            "EXIT_POWER_MODE",
+            "EXIT_IDLE_AUTO_EXIT",
+            "EXIT_DIAL_DELETE",
+            "EXIT_USER_KILL",
+            "EXIT_USER_NAV"
+        ]
     }, globalNode)
     globalNode.setField("datadogUserInfo", { id: "42", name: "Abcd Efg", email: "abcd.efg@example.com" })
     globalNode.setField("datadogContext", { channel: "roku sample channel" })

--- a/test/source/tests/Test__datadog.bs
+++ b/test/source/tests/Test__datadog.bs
@@ -22,7 +22,10 @@ function TestSuite__Datadog() as object
 
     this.addTest("WhenInitialize_ThenRumAgentConfigurationIsSetInGlobal", DatadogTest__WhenInitialize_ThenRumAgentConfigurationIsSetInGlobal)
     this.addTest("WhenInitialize_ThenLogsAgentConfigurationIsSetInGlobal", DatadogTest__WhenInitialize_ThenLogsAgentConfigurationIsSetInGlobal)
-    this.addTest("WhenInitialize_ThenUploaderIsSetInGlobal", DatadogTest__WhenInitialize_ThenUploaderIsSetInGlobal) 
+    this.addTest("WhenInitialize_ThenUploaderIsSetInGlobal", DatadogTest__WhenInitialize_ThenUploaderIsSetInGlobal)
+    this.addTest("WhenInitialize_WithNoIgnoredExitEvents_ThenDefaultIsSetInGlobal", DatadogTest__WhenInitialize_WithNoIgnoredExitEvents_ThenDefaultIsSetInGlobal)
+    this.addTest("WhenInitialize_WithCustomIgnoredExitEvents_ThenCustomIsSetInGlobal", DatadogTest__WhenInitialize_WithCustomIgnoredExitEvents_ThenCustomIsSetInGlobal)
+    this.addTest("WhenInitialize_WithEmptyIgnoredExitEvents_ThenEmptyListIsSetInGlobal", DatadogTest__WhenInitialize_WithEmptyIgnoredExitEvents_ThenEmptyListIsSetInGlobal)
 
     this.addTest("WhenGetEndpointStaging_ThenCreateEndpoint", DatadogTest__WhenGetEndpointStaging_ThenCreateEndpoint)
 
@@ -312,6 +315,93 @@ function DatadogTest__WhenInitialize_ThenUploaderIsSetInGlobal() as string
     actualUploader = fakeGlobal.getField("datadogUploader")
 
     Assert.that(actualUploader.clientToken).isEqualTo(randomClientToken)
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a valid configuration without ignoredExitEvents
+'  When: initializing the SDK
+'  Then: the default ignored exit events list is set in the global object
+'----------------------------------------------------------------
+function DatadogTest__WhenInitialize_WithNoIgnoredExitEvents_ThenDefaultIsSetInGlobal() as string
+    ' Given
+    configuration = {
+        clientToken: IG_GetString(16),
+        applicationId: IG_GetString(16),
+        site: "us1",
+        env: IG_GetString(16)
+    }
+
+    ' When
+    fakeGlobal = CreateObject("roSGNode", "ContentNode")
+    datadogroku_initialize(configuration, fakeGlobal)
+
+    ' Then
+    actualIgnoredExitEvents = fakeGlobal.getField("datadogIgnoredExitEvents")
+    Assert.that(actualIgnoredExitEvents).isNotInvalid()
+    Assert.that(actualIgnoredExitEvents).contains("EXIT_UNKNOWN")
+    Assert.that(actualIgnoredExitEvents).contains("EXIT_POWER_MODE")
+    Assert.that(actualIgnoredExitEvents).contains("EXIT_IDLE_AUTO_EXIT")
+    Assert.that(actualIgnoredExitEvents).contains("EXIT_DIAL_DELETE")
+    Assert.that(actualIgnoredExitEvents).contains("EXIT_USER_KILL")
+    Assert.that(actualIgnoredExitEvents).contains("EXIT_USER_NAV")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a valid configuration with a custom ignoredExitEvents list
+'  When: initializing the SDK
+'  Then: the custom ignored exit events list is set in the global object
+'----------------------------------------------------------------
+function DatadogTest__WhenInitialize_WithCustomIgnoredExitEvents_ThenCustomIsSetInGlobal() as string
+    ' Given
+    customIgnoredExitEvents = ["EXIT_USER_KILL", "EXIT_USER_NAV", "EXIT_BRIGHTSCRIPT_CRASH"]
+    configuration = {
+        clientToken: IG_GetString(16),
+        applicationId: IG_GetString(16),
+        site: "us1",
+        env: IG_GetString(16),
+        ignoredExitEvents: customIgnoredExitEvents
+    }
+
+    ' When
+    fakeGlobal = CreateObject("roSGNode", "ContentNode")
+    datadogroku_initialize(configuration, fakeGlobal)
+
+    ' Then
+    actualIgnoredExitEvents = fakeGlobal.getField("datadogIgnoredExitEvents")
+    Assert.that(actualIgnoredExitEvents).isNotInvalid()
+    Assert.that(actualIgnoredExitEvents).hasSize(3)
+    Assert.that(actualIgnoredExitEvents).contains("EXIT_USER_KILL")
+    Assert.that(actualIgnoredExitEvents).contains("EXIT_USER_NAV")
+    Assert.that(actualIgnoredExitEvents).contains("EXIT_BRIGHTSCRIPT_CRASH")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a valid configuration with ignoredExitEvents set to an empty array
+'  When: initializing the SDK
+'  Then: the empty list is stored as-is in the global object
+'         (every exit status will be reported as a crash)
+'----------------------------------------------------------------
+function DatadogTest__WhenInitialize_WithEmptyIgnoredExitEvents_ThenEmptyListIsSetInGlobal() as string
+    ' Given
+    configuration = {
+        clientToken: IG_GetString(16),
+        applicationId: IG_GetString(16),
+        site: "us1",
+        env: IG_GetString(16),
+        ignoredExitEvents: []
+    }
+
+    ' When
+    fakeGlobal = CreateObject("roSGNode", "ContentNode")
+    datadogroku_initialize(configuration, fakeGlobal)
+
+    ' Then
+    actualIgnoredExitEvents = fakeGlobal.getField("datadogIgnoredExitEvents")
+    Assert.that(actualIgnoredExitEvents).isNotInvalid()
+    Assert.that(actualIgnoredExitEvents).hasSize(0)
     return ""
 end function
 

--- a/test/source/tests/rum/Test__RumCrashReporterTask.bs
+++ b/test/source/tests/rum/Test__RumCrashReporterTask.bs
@@ -15,9 +15,12 @@ function TestSuite__RumCrashReporterTask() as object
 
     this.addTest("WhenReasonIsValid_ThenWriteErrorAndViewEvents", RumCrashReporterTaskTest__WhenReasonIsValid_ThenWriteErrorAndViewEvents, RumCrashReporterTaskTest__SetUp, RumCrashReporterTaskTest__TearDown)
     this.addTest("WhenReasonIsValid_ThenWriteErrorWithStackAndViewEvents", RumCrashReporterTaskTest__WhenReasonIsValid_ThenWriteErrorWithStackAndViewEvents, RumCrashReporterTaskTest__SetUp, RumCrashReporterTaskTest__TearDown)
+    this.addTest("WhenReasonIsUnknown_ThenWriteErrorAndViewEvents", RumCrashReporterTaskTest__WhenReasonIsUnknown_ThenWriteErrorAndViewEvents, RumCrashReporterTaskTest__SetUp, RumCrashReporterTaskTest__TearDown)
     this.addTest("WhenLastViewIsCurrentSession_ThenDoNothing", RumCrashReporterTaskTest__WhenLastViewIsCurrentSession_ThenDoNothing, RumCrashReporterTaskTest__SetUp, RumCrashReporterTaskTest__TearDown)
-    this.addTest("WhenExitreasonInvalid_ThenDoNothing", RumCrashReporterTaskTest__WhenExitreasonInvalid_ThenDoNothing, RumCrashReporterTaskTest__SetUp, RumCrashReporterTaskTest__TearDown)
+    this.addTest("WhenExitreasonIsIgnored_ThenDoNothing", RumCrashReporterTaskTest__WhenExitreasonIsIgnored_ThenDoNothing, RumCrashReporterTaskTest__SetUp, RumCrashReporterTaskTest__TearDown)
+    this.addTest("WhenExitreasonIsCustomIgnored_ThenDoNothing", RumCrashReporterTaskTest__WhenExitreasonIsCustomIgnored_ThenDoNothing, RumCrashReporterTaskTest__SetUp, RumCrashReporterTaskTest__TearDown)
 
+    this.addTest("WhenExitreasonIsEmpty_ThenDoNothing", RumCrashReporterTaskTest__WhenExitreasonIsEmpty_ThenDoNothing, RumCrashReporterTaskTest__SetUp, RumCrashReporterTaskTest__TearDown)
     this.addTest("WhenLastViewIsMissing_ThenDoNothing", RumCrashReporterTaskTest__WhenLastViewIsMissing_ThenDoNothing, RumCrashReporterTaskTest__SetUp, RumCrashReporterTaskTest__TearDown)
     this.addTest("WhenLastViewIsInvalid_ThenDoNothing", RumCrashReporterTaskTest__WhenLastViewIsInvalid_ThenDoNothing, RumCrashReporterTaskTest__SetUp, RumCrashReporterTaskTest__TearDown)
 
@@ -40,6 +43,18 @@ sub RumCrashReporterTaskTest__SetUp()
         m.testSuite.fakeGlobalContext[IG_GetString(16) + i.toStr()] = IG_GetOneOf([IG_GetString(12), IG_GetInteger(), IG_GetFloat(), IG_GetBoolean()])
         m.testSuite.fakeGlobalUserInfo[IG_GetString(16) + i.toStr()] = IG_GetOneOf([IG_GetString(12), IG_GetInteger(), IG_GetFloat(), IG_GetBoolean()])
     end for
+
+    ' Global configuration
+    m.testSuite.global.addFields({
+        datadogIgnoredExitEvents: [
+            "EXIT_UNKNOWN",
+            "EXIT_POWER_MODE",
+            "EXIT_IDLE_AUTO_EXIT",
+            "EXIT_DIAL_DELETE",
+            "EXIT_USER_KILL",
+            "EXIT_USER_NAV"
+        ]
+    })
 
     ' Tested Task
     m.testSuite.testedTask = CreateObject("roSGNode", "datadogroku_RumCrashReporterTask")
@@ -269,6 +284,64 @@ end function
 
 '----------------------------------------------------------------
 ' Given: a RumCrashReporterTask
+'  When: last view exists, and exit reason is unknown (not in the ignore list)
+'  Then: writes an error and view events (unknown statuses are treated as crashes)
+'----------------------------------------------------------------
+function RumCrashReporterTaskTest__WhenReasonIsUnknown_ThenWriteErrorAndViewEvents() as string
+    ' Given
+    fakeUnknownExitStatus = "EXIT_SOME_NEW_FIRMWARE_STATUS"
+    fakePreviousViewEvent = {
+        _dd: {
+            document_version: IG_GetInteger()
+        },
+        application: {
+            id: IG_GetString(16)
+        },
+        context: m.global.datadogContext,
+        date: IG_GetLongInteger(),
+        service: m.fakeGlobalContext,
+        session: {
+            has_replay: false,
+            id: IG_GetString(16),
+            type: "user"
+        },
+        source: IG_GetString(16),
+        type: "view",
+        usr: m.fakeGlobalUserInfo,
+        version: IG_GetString(16),
+        view: {
+            id: IG_GetString(16),
+            url: IG_GetString(16),
+            name: IG_GetString(16),
+            time_spent: IG_GetInteger(),
+            action: { count: IG_GetInteger() },
+            error: { count: IG_GetInteger() },
+            resource: { count: IG_GetInteger() }
+        }
+    }
+    previousInstanceId = IG_GetString(32)
+    lastViewFilePath = datadogroku_lastViewEventFilePath(previousInstanceId)
+    WriteAsciiFile(lastViewFilePath, FormatJson(fakePreviousViewEvent))
+    m.testedTask.lastExitOrTerminationReason = fakeUnknownExitStatus
+
+    ' When
+    m.testedTask.control = "RUN"
+    sleep(100)
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    Assert.that(updates).hasSize(2)
+    errorEvent = ParseJson(updates[0])
+    Assert.that(errorEvent).isNotInvalid()
+    Assert.that(errorEvent.error.type).isEqualTo(fakeUnknownExitStatus)
+    Assert.that(errorEvent.error.is_crash).isEqualTo(true)
+
+    Assert.that(lastViewFilePath).doesNotExist()
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a RumCrashReporterTask
 '  When: last view exists for current instance
 '  Then: ignore and does nothing
 '----------------------------------------------------------------
@@ -329,10 +402,124 @@ end function
 
 '----------------------------------------------------------------
 ' Given: a RumCrashReporterTask
-'  When: last view exists for current instance
+'  When: exit reason is in the default ignore list
 '  Then: ignore and does nothing
 '----------------------------------------------------------------
-function RumCrashReporterTaskTest__WhenExitreasonInvalid_ThenDoNothing() as string
+function RumCrashReporterTaskTest__WhenExitreasonIsIgnored_ThenDoNothing() as string
+    ' Given
+    fakeIgnoredExitStatus = IG_GetOneOf([
+        "EXIT_UNKNOWN",
+        "EXIT_POWER_MODE",
+        "EXIT_IDLE_AUTO_EXIT",
+        "EXIT_DIAL_DELETE",
+        "EXIT_USER_KILL",
+        "EXIT_USER_NAV"
+    ])
+    fakePreviousViewEvent = {
+        _dd: {
+            document_version: IG_GetInteger()
+        },
+        application: {
+            id: IG_GetString(16)
+        },
+        context: m.global.datadogContext,
+        date: IG_GetLongInteger(),
+        service: m.fakeGlobalContext,
+        session: {
+            has_replay: false,
+            id: IG_GetString(16),
+            type: "user"
+        },
+        source: IG_GetString(16),
+        type: "view",
+        usr: m.fakeGlobalUserInfo,
+        version: IG_GetString(16),
+        view: {
+            id: IG_GetString(16),
+            url: IG_GetString(16),
+            name: IG_GetString(16),
+            time_spent: IG_GetInteger(),
+            action: { count: IG_GetInteger() },
+            error: { count: IG_GetInteger() },
+            resource: { count: IG_GetInteger() }
+        }
+    }
+    previousInstanceId = IG_GetString(32)
+    lastViewFilePath = datadogroku_lastViewEventFilePath(previousInstanceId)
+    WriteAsciiFile(lastViewFilePath, FormatJson(fakePreviousViewEvent))
+    m.testedTask.lastExitOrTerminationReason = fakeIgnoredExitStatus
+
+    ' When
+    m.testedTask.control = "RUN"
+    sleep(100)
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    Assert.that(updates).hasSize(0)
+    Assert.that(lastViewFilePath).doesNotExist()
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a RumCrashReporterTask with custom ignored exit events configured
+'  When: exit reason is in the custom ignore list
+'  Then: ignore and does nothing
+'----------------------------------------------------------------
+function RumCrashReporterTaskTest__WhenExitreasonIsCustomIgnored_ThenDoNothing() as string
+    ' Given
+    fakeCustomIgnoredStatus = "EXIT_BRIGHTSCRIPT_CRASH"
+    m.global.datadogIgnoredExitEvents = [fakeCustomIgnoredStatus]
+    fakePreviousViewEvent = {
+        _dd: {
+            document_version: IG_GetInteger()
+        },
+        application: {
+            id: IG_GetString(16)
+        },
+        context: m.global.datadogContext,
+        date: IG_GetLongInteger(),
+        service: m.fakeGlobalContext,
+        session: {
+            has_replay: false,
+            id: IG_GetString(16),
+            type: "user"
+        },
+        source: IG_GetString(16),
+        type: "view",
+        usr: m.fakeGlobalUserInfo,
+        version: IG_GetString(16),
+        view: {
+            id: IG_GetString(16),
+            url: IG_GetString(16),
+            name: IG_GetString(16),
+            time_spent: IG_GetInteger(),
+            action: { count: IG_GetInteger() },
+            error: { count: IG_GetInteger() },
+            resource: { count: IG_GetInteger() }
+        }
+    }
+    previousInstanceId = IG_GetString(32)
+    lastViewFilePath = datadogroku_lastViewEventFilePath(previousInstanceId)
+    WriteAsciiFile(lastViewFilePath, FormatJson(fakePreviousViewEvent))
+    m.testedTask.lastExitOrTerminationReason = fakeCustomIgnoredStatus
+
+    ' When
+    m.testedTask.control = "RUN"
+    sleep(100)
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    Assert.that(updates).hasSize(0)
+    Assert.that(lastViewFilePath).doesNotExist()
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a RumCrashReporterTask
+'  When: exit reason is an empty string
+'  Then: does not write a crash report but still deletes the last view file
+'----------------------------------------------------------------
+function RumCrashReporterTaskTest__WhenExitreasonIsEmpty_ThenDoNothing() as string
     ' Given
     fakePreviousViewEvent = {
         _dd: {
@@ -366,7 +553,7 @@ function RumCrashReporterTaskTest__WhenExitreasonInvalid_ThenDoNothing() as stri
     previousInstanceId = IG_GetString(32)
     lastViewFilePath = datadogroku_lastViewEventFilePath(previousInstanceId)
     WriteAsciiFile(lastViewFilePath, FormatJson(fakePreviousViewEvent))
-    m.testedTask.lastExitOrTerminationReason = IG_GetString(16)
+    m.testedTask.lastExitOrTerminationReason = ""
 
     ' When
     m.testedTask.control = "RUN"


### PR DESCRIPTION
### What does this PR do?

This PR is to respond the request from this GH [issue](https://github.com/DataDog/dd-sdk-roku/issues/113) by adding a new configuration of add an ignored list of exit events.

The full exit events can be found in Roku [document](https://developer.roku.com/en-gb/docs/developer-program/getting-started/architecture/dev-environment.md#lastexitorterminationreason-parameter).


### Motivation

RUM-14356

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

