### PR TITLE
feat: add anonymous_id user enrichment to RUM and Logs

### DIFF
--- a/dist/components/core/MultiTrackUploaderTask.xml
+++ b/dist/components/core/MultiTrackUploaderTask.xml
@@ -11,5 +11,6 @@
     <script type="text/brightscript" uri="pkg:/source/internalLogger.brs" />
     <script type="text/brightscript" uri="pkg:/source/fileUtils.brs" />
     <script type="text/brightscript" uri="pkg:/source/datadogSdk.brs" />
+    <script type="text/brightscript" uri="pkg:/source/identityStorage.brs" />
     <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
 </component>

--- a/dist/components/core/WriterTask.xml
+++ b/dist/components/core/WriterTask.xml
@@ -11,5 +11,6 @@
     <script type="text/brightscript" uri="pkg:/source/internalLogger.brs" />
     <script type="text/brightscript" uri="pkg:/source/fileUtils.brs" />
     <script type="text/brightscript" uri="pkg:/source/datadogSdk.brs" />
+    <script type="text/brightscript" uri="pkg:/source/identityStorage.brs" />
     <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
 </component>

--- a/dist/components/logs/LogsAgent.brs
+++ b/dist/components/logs/LogsAgent.brs
@@ -131,7 +131,7 @@ sub sendLog(status as object, message as string, attributes as object)
         message: message
         status: status
         service: m.top.service
-        usr: m.global.datadogUserInfo
+        usr: getDatadogUserInfo(m.global)
         device: {
             type: "tv"
             name: m.top.deviceName

--- a/dist/components/logs/LogsAgent.xml
+++ b/dist/components/logs/LogsAgent.xml
@@ -27,5 +27,6 @@
     <script type="text/brightscript" uri="pkg:/source/logs/logStatus.brs" />
     <script type="text/brightscript" uri="pkg:/source/internalLogger.brs" />
     <script type="text/brightscript" uri="pkg:/source/datadogSdk.brs" />
+    <script type="text/brightscript" uri="pkg:/source/identityStorage.brs" />
     <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
 </component>

--- a/dist/components/rum/RumActionScope.brs
+++ b/dist/components/rum/RumActionScope.brs
@@ -149,7 +149,7 @@ sub sendAction(writer as object)
         }
         source: agentSource()
         type: "action"
-        usr: m.global.datadogUserInfo
+        usr: getDatadogUserInfo(m.global)
         version: context.applicationVersion
         view: {
             id: context.viewId

--- a/dist/components/rum/RumActionScope.xml
+++ b/dist/components/rum/RumActionScope.xml
@@ -11,5 +11,6 @@
     <script type="text/brightscript" uri="pkg:/source/rum/rumHelper.brs" />
     <script type="text/brightscript" uri="pkg:/source/fileUtils.brs" />
     <script type="text/brightscript" uri="pkg:/source/datadogSdk.brs" />
+    <script type="text/brightscript" uri="pkg:/source/identityStorage.brs" />
     <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
 </component>

--- a/dist/components/rum/RumAgent.xml
+++ b/dist/components/rum/RumAgent.xml
@@ -50,5 +50,6 @@
     <script type="text/brightscript" uri="pkg:/source/fileUtils.brs" />
     <script type="text/brightscript" uri="pkg:/source/internalLogger.brs" />
     <script type="text/brightscript" uri="pkg:/source/datadogSdk.brs" />
+    <script type="text/brightscript" uri="pkg:/source/identityStorage.brs" />
     <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
 </component>

--- a/dist/components/rum/RumCrashReporterTask.xml
+++ b/dist/components/rum/RumCrashReporterTask.xml
@@ -11,6 +11,7 @@
     <script type="text/brightscript" uri="pkg:/source/fileUtils.brs" />
     <script type="text/brightscript" uri="pkg:/source/internalLogger.brs" />
     <script type="text/brightscript" uri="pkg:/source/timeUtils.brs" />
+    <script type="text/brightscript" uri="pkg:/source/identityStorage.brs" />
     <script type="text/brightscript" uri="pkg:/source/rum/rumHelper.brs" />
     <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
 </component>

--- a/dist/components/rum/RumSessionScope.brs
+++ b/dist/components/rum/RumSessionScope.brs
@@ -139,6 +139,10 @@ sub renewSession(timestamp& as longinteger)
     else
         m.sessionState = "not_tracked"
     end if
+    trackAnonymousUser = m.global.datadogTrackAnonymousUser
+    if (trackAnonymousUser = invalid)
+        trackAnonymousUser = true
+    end if
     datadogRumContext = (function(m)
             __bsConsequent = m.global.datadogRumContext
             if __bsConsequent <> invalid then
@@ -148,6 +152,9 @@ sub renewSession(timestamp& as longinteger)
             end if
         end function)(m)
     datadogRumContext.sessionId = m.sessionId
+    if (trackAnonymousUser and (datadogRumContext.anonymousId = invalid or datadogRumContext.anonymousId = ""))
+        datadogRumContext.anonymousId = CreateObject("roDeviceInfo").GetRandomUUID()
+    end if
     m.global.setField("datadogRumContext", datadogRumContext)
 end sub
 
@@ -243,7 +250,7 @@ sub sendVitalEvent(event as object, stepType as string, writer as object)
         }
         source: agentSource()
         type: "vital"
-        usr: m.global.datadogUserInfo
+        usr: getDatadogUserInfo(m.global)
         version: rumContext.applicationVersion
         view: {
             id: viewId

--- a/dist/components/rum/RumSessionScope.brs
+++ b/dist/components/rum/RumSessionScope.brs
@@ -2,6 +2,7 @@
 ' This product includes software developed at Datadog (https://www.datadoghq.com/).
 ' Copyright 2022-Today Datadog, Inc.
 'import "pkg:/source/datadogSdk.bs"
+'import "pkg:/source/identityStorage.bs"
 'import "pkg:/source/internalLogger.bs"
 'import "pkg:/source/timeUtils.bs"
 'import "pkg:/source/rum/rumHelper.bs"
@@ -153,7 +154,13 @@ sub renewSession(timestamp& as longinteger)
         end function)(m)
     datadogRumContext.sessionId = m.sessionId
     if (trackAnonymousUser and (datadogRumContext.anonymousId = invalid or datadogRumContext.anonymousId = ""))
-        datadogRumContext.anonymousId = CreateObject("roDeviceInfo").GetRandomUUID()
+        persistedAnonymousId = readDatadogAnonymousId()
+        if (persistedAnonymousId <> "")
+            datadogRumContext.anonymousId = persistedAnonymousId
+        else
+            datadogRumContext.anonymousId = CreateObject("roDeviceInfo").GetRandomUUID()
+            writeDatadogAnonymousId(datadogRumContext.anonymousId)
+        end if
     end if
     m.global.setField("datadogRumContext", datadogRumContext)
 end sub

--- a/dist/components/rum/RumSessionScope.xml
+++ b/dist/components/rum/RumSessionScope.xml
@@ -12,5 +12,6 @@
     <script type="text/brightscript" uri="pkg:/source/rum/rumRawEvents.brs" />
     <script type="text/brightscript" uri="pkg:/source/rum/rumHelper.brs" />
     <script type="text/brightscript" uri="pkg:/source/fileUtils.brs" />
+    <script type="text/brightscript" uri="pkg:/source/identityStorage.brs" />
     <script type="text/brightscript" uri="pkg:/source/datadogSdk.brs" />
 </component>

--- a/dist/components/rum/RumTelemetryScope.xml
+++ b/dist/components/rum/RumTelemetryScope.xml
@@ -10,5 +10,6 @@
     <script type="text/brightscript" uri="pkg:/source/fileUtils.brs" />
     <script type="text/brightscript" uri="pkg:/source/internalLogger.brs" />
     <script type="text/brightscript" uri="pkg:/source/datadogSdk.brs" />
+    <script type="text/brightscript" uri="pkg:/source/identityStorage.brs" />
     <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
 </component>

--- a/dist/components/rum/RumViewScope.brs
+++ b/dist/components/rum/RumViewScope.brs
@@ -211,7 +211,7 @@ sub sendError(message as string, errorType as string, backtrace as dynamic, cont
         }
         source: agentSource()
         type: "error"
-        usr: m.global.datadogUserInfo
+        usr: getDatadogUserInfo(m.global)
         version: rumContext.applicationVersion
         view: {
             id: m.viewId
@@ -313,7 +313,7 @@ sub sendCustomAction(target as string, context as object, writer as object)
         }
         source: agentSource()
         type: "action"
-        usr: m.global.datadogUserInfo
+        usr: getDatadogUserInfo(m.global)
         version: rumContext.applicationVersion
         view: {
             id: m.viewId
@@ -400,7 +400,7 @@ sub sendResource(resource as object, context as object, writer as object)
         }
         source: agentSource()
         type: "resource"
-        usr: m.global.datadogUserInfo
+        usr: getDatadogUserInfo(m.global)
         version: rumContext.applicationVersion
         view: {
             id: m.viewId
@@ -493,7 +493,7 @@ sub sendResourceError(status as string, url as dynamic, method as dynamic, conte
         }
         source: agentSource()
         type: "error"
-        usr: m.global.datadogUserInfo
+        usr: getDatadogUserInfo(m.global)
         version: rumContext.applicationVersion
         view: {
             id: m.viewId
@@ -547,7 +547,7 @@ sub sendViewUpdate(context as object, writer as object)
         }
         source: agentSource()
         type: "view"
-        usr: m.global.datadogUserInfo
+        usr: getDatadogUserInfo(m.global)
         version: rumContext.applicationVersion
         view: {
             id: m.viewId

--- a/dist/components/rum/RumViewScope.xml
+++ b/dist/components/rum/RumViewScope.xml
@@ -13,4 +13,5 @@
     <script type="text/brightscript" uri="pkg:/source/rum/rumHelper.brs" />
     <script type="text/brightscript" uri="pkg:/source/fileUtils.brs" />
     <script type="text/brightscript" uri="pkg:/source/datadogSdk.brs" />
+    <script type="text/brightscript" uri="pkg:/source/identityStorage.brs" />
 </component>

--- a/dist/source/datadogSdk.brs
+++ b/dist/source/datadogSdk.brs
@@ -1,6 +1,7 @@
 ' Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 ' This product includes software developed at Datadog (https://www.datadoghq.com/).
 ' Copyright 2022-Today Datadog, Inc.
+'import "pkg:/source/identityStorage.bs"
 
 ' ----------------------------------------------------------------
 ' Initializes the SDK
@@ -150,6 +151,17 @@ sub initialize(configuration as object, global as object)
     if (configuration.ignoredExitEvents <> invalid and configuration.ignoredExitEvents.count() = 0)
         ddLogWarning("configuration.ignoredExitEvents is empty; all exit statuses will be reported as crashes.")
     end if
+    trackAnonymousUser = (function(configuration)
+            __bsConsequent = configuration.trackAnonymousUser
+            if __bsConsequent <> invalid then
+                return __bsConsequent
+            else
+                return true
+            end if
+        end function)(configuration)
+    if (not trackAnonymousUser)
+        clearDatadogAnonymousId()
+    end if
     global.addFields({
         datadogTraceAgent: {
             traceSampleRate: (function(configuration)
@@ -177,14 +189,7 @@ sub initialize(configuration as object, global as object)
                     end if
                 end function)(configuration)
         }
-        datadogTrackAnonymousUser: (function(configuration)
-                __bsConsequent = configuration.trackAnonymousUser
-                if __bsConsequent <> invalid then
-                    return __bsConsequent
-                else
-                    return true
-                end if
-            end function)(configuration)
+        datadogTrackAnonymousUser: trackAnonymousUser
         datadogIgnoredExitEvents: (function(configuration)
                 __bsConsequent = configuration.ignoredExitEvents
                 if __bsConsequent <> invalid then

--- a/dist/source/datadogSdk.brs
+++ b/dist/source/datadogSdk.brs
@@ -24,7 +24,8 @@
 '           - "datadog": Datadog's `x-datadog-*` headers (cf: https://docs.datadoghq.com/real_user_monitoring/connect_rum_and_traces)
 '  - traceContextInjection (string) defines whether the trace context should be injected into all requests or only sampled ones.
 '  - trackAnonymousUser (boolean, optional) when `true` (default), enriches `usr` payloads with `anonymous_id`
-'     derived from the session context when not explicitly set by the user.
+'     derived from the session context when not explicitly set by the user. The id is persisted in the Roku
+'     registry (section `"datadog"`, key `"anonymous_id"`) so it survives channel relaunches.
 '  - ignoredExitEvents (array, optional) an array of exit status strings to ignore when detecting crashes.
 '     Any exit status NOT in this list will be reported as a crash. Defaults to:
 '     ["EXIT_UNKNOWN", "EXIT_POWER_MODE", "EXIT_IDLE_AUTO_EXIT", "EXIT_DIAL_DELETE", "EXIT_USER_KILL", "EXIT_USER_NAV"]

--- a/dist/source/datadogSdk.brs
+++ b/dist/source/datadogSdk.brs
@@ -23,6 +23,8 @@
 '           - "tracecontext": W3C Trace Context header (cf: https://www.w3.org/TR/trace-context/)
 '           - "datadog": Datadog's `x-datadog-*` headers (cf: https://docs.datadoghq.com/real_user_monitoring/connect_rum_and_traces)
 '  - traceContextInjection (string) defines whether the trace context should be injected into all requests or only sampled ones.
+'  - trackAnonymousUser (boolean, optional) when `true` (default), enriches `usr` payloads with `anonymous_id`
+'     derived from the session context when not explicitly set by the user.
 '  - ignoredExitEvents (array, optional) an array of exit status strings to ignore when detecting crashes.
 '     Any exit status NOT in this list will be reported as a crash. Defaults to:
 '     ["EXIT_UNKNOWN", "EXIT_POWER_MODE", "EXIT_IDLE_AUTO_EXIT", "EXIT_DIAL_DELETE", "EXIT_USER_KILL", "EXIT_USER_NAV"]
@@ -174,6 +176,14 @@ sub initialize(configuration as object, global as object)
                     end if
                 end function)(configuration)
         }
+        datadogTrackAnonymousUser: (function(configuration)
+                __bsConsequent = configuration.trackAnonymousUser
+                if __bsConsequent <> invalid then
+                    return __bsConsequent
+                else
+                    return true
+                end if
+            end function)(configuration)
         datadogIgnoredExitEvents: (function(configuration)
                 __bsConsequent = configuration.ignoredExitEvents
                 if __bsConsequent <> invalid then
@@ -256,6 +266,47 @@ end function
 ' ----------------------------------------------------------------
 function channelVersion() as string
     return CreateObject("roAppInfo").GetVersion()
+end function
+
+' ----------------------------------------------------------------
+' Returns user info enriched with an anonymous id when applicable.
+' Mirrors browser SDK behavior: don't override user-provided `anonymous_id`.
+' @param global (object) the global node available from scenegraph nodes
+' @return (object) user info object for event payloads
+' ----------------------------------------------------------------
+function getDatadogUserInfo(global as object) as object
+    userInfo = (function(global)
+            __bsConsequent = global.datadogUserInfo
+            if __bsConsequent <> invalid then
+                return __bsConsequent
+            else
+                return {}
+            end if
+        end function)(global)
+    trackAnonymousUser = global.datadogTrackAnonymousUser
+    if (trackAnonymousUser = invalid)
+        trackAnonymousUser = true
+    end if
+    if (not trackAnonymousUser)
+        return userInfo
+    end if
+    if (userInfo.anonymous_id <> invalid and userInfo.anonymous_id <> "")
+        return userInfo
+    end if
+    rumContext = global.datadogRumContext
+    if (rumContext = invalid)
+        return userInfo
+    end if
+    anonymousId = rumContext.anonymousId
+    if (anonymousId = invalid or anonymousId = "")
+        return userInfo
+    end if
+    enrichedUserInfo = {}
+    for each key in userInfo
+        enrichedUserInfo[key] = userInfo[key]
+    end for
+    enrichedUserInfo.anonymous_id = anonymousId
+    return enrichedUserInfo
 end function
 
 ' ----------------------------------------------------------------

--- a/dist/source/identityStorage.brs
+++ b/dist/source/identityStorage.brs
@@ -1,0 +1,35 @@
+' Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+' This product includes software developed at Datadog (https://www.datadoghq.com/).
+' Copyright 2022-Today Datadog, Inc.
+'import "pkg:/source/internalLogger.bs"
+' ****************************************************************
+' * Persistent storage for SDK identity values (anonymous_id, ...).
+' * Backed by the per-channel Roku registry.
+' ****************************************************************
+
+' ----------------------------------------------------------------
+' Reads the persisted Datadog anonymous id from the Roku registry.
+' @return (string) the stored value, or "" when absent.
+' ----------------------------------------------------------------
+function readDatadogAnonymousId() as string
+    section = CreateObject("roRegistrySection", "datadog")
+    if (section = invalid or not section.Exists("anonymous_id"))
+        return ""
+    end if
+    return section.Read("anonymous_id")
+end function
+
+' ----------------------------------------------------------------
+' Persists the Datadog anonymous id to the Roku registry so it
+' survives channel relaunches (browser-cookie equivalent).
+' @param anonymousId (string) the value to store.
+' ----------------------------------------------------------------
+sub writeDatadogAnonymousId(anonymousId as string)
+    section = CreateObject("roRegistrySection", "datadog")
+    if (section = invalid)
+        ddLogWarning("Unable to persist anonymous_id: registry section unavailable")
+        return
+    end if
+    section.Write("anonymous_id", anonymousId)
+    section.Flush()
+end sub

--- a/dist/source/identityStorage.brs
+++ b/dist/source/identityStorage.brs
@@ -33,3 +33,17 @@ sub writeDatadogAnonymousId(anonymousId as string)
     section.Write("anonymous_id", anonymousId)
     section.Flush()
 end sub
+
+' ----------------------------------------------------------------
+' Removes any persisted Datadog anonymous id from the Roku registry.
+' Called when anonymous user tracking is disabled, so the identifier
+' does not outlive the integrator's consent state.
+' ----------------------------------------------------------------
+sub clearDatadogAnonymousId()
+    section = CreateObject("roRegistrySection", "datadog")
+    if (section = invalid or not section.Exists("anonymous_id"))
+        return
+    end if
+    section.Delete("anonymous_id")
+    section.Flush()
+end sub

--- a/library/components/logs/LogsAgent.bs
+++ b/library/components/logs/LogsAgent.bs
@@ -133,7 +133,7 @@ sub sendLog(status as LogStatus, message as string, attributes as object)
         message: message,
         status: status,
         service: m.top.service,
-        usr: m.global.datadogUserInfo,
+        usr: getDatadogUserInfo(m.global),
         device: {
             type: "tv",
             name: m.top.deviceName,

--- a/library/components/rum/RumActionScope.bs
+++ b/library/components/rum/RumActionScope.bs
@@ -145,7 +145,7 @@ sub sendAction(writer as object)
         },
         source: agentSource(),
         type: "action",
-        usr: m.global.datadogUserInfo,
+        usr: getDatadogUserInfo(m.global),
         version: context.applicationVersion,
         view: {
             id: context.viewId,

--- a/library/components/rum/RumSessionScope.bs
+++ b/library/components/rum/RumSessionScope.bs
@@ -3,6 +3,7 @@
 ' Copyright 2022-Today Datadog, Inc.
 
 import "pkg:/source/datadogSdk.bs"
+import "pkg:/source/identityStorage.bs"
 import "pkg:/source/internalLogger.bs"
 import "pkg:/source/timeUtils.bs"
 import "pkg:/source/rum/rumHelper.bs"
@@ -133,7 +134,13 @@ sub renewSession(timestamp& as longinteger)
     datadogRumContext = m.global.datadogRumContext ?? {}
     datadogRumContext.sessionId = m.sessionId
     if (trackAnonymousUser and (datadogRumContext.anonymousId = invalid or datadogRumContext.anonymousId = ""))
-        datadogRumContext.anonymousId = CreateObject("roDeviceInfo").GetRandomUUID()
+        persistedAnonymousId = readDatadogAnonymousId()
+        if (persistedAnonymousId <> "")
+            datadogRumContext.anonymousId = persistedAnonymousId
+        else
+            datadogRumContext.anonymousId = CreateObject("roDeviceInfo").GetRandomUUID()
+            writeDatadogAnonymousId(datadogRumContext.anonymousId)
+        end if
     end if
     m.global.setField("datadogRumContext", datadogRumContext)
 end sub

--- a/library/components/rum/RumSessionScope.bs
+++ b/library/components/rum/RumSessionScope.bs
@@ -125,8 +125,16 @@ sub renewSession(timestamp& as longinteger)
         m.sessionState = RumSessionState.not_tracked
     end if
 
+    trackAnonymousUser = m.global.datadogTrackAnonymousUser
+    if (trackAnonymousUser = invalid)
+        trackAnonymousUser = true
+    end if
+
     datadogRumContext = m.global.datadogRumContext ?? {}
     datadogRumContext.sessionId = m.sessionId
+    if (trackAnonymousUser and (datadogRumContext.anonymousId = invalid or datadogRumContext.anonymousId = ""))
+        datadogRumContext.anonymousId = CreateObject("roDeviceInfo").GetRandomUUID()
+    end if
     m.global.setField("datadogRumContext", datadogRumContext)
 end sub
 
@@ -211,7 +219,7 @@ sub sendVitalEvent(event as object, stepType as string, writer as object)
         },
         source: agentSource(),
         type: "vital",
-        usr: m.global.datadogUserInfo,
+        usr: getDatadogUserInfo(m.global),
         version: rumContext.applicationVersion,
         view: {
             id: viewId,

--- a/library/components/rum/RumViewScope.bs
+++ b/library/components/rum/RumViewScope.bs
@@ -198,7 +198,7 @@ sub sendError(message as string, errorType as string, backtrace as dynamic, cont
         },
         source: agentSource(),
         type: "error",
-        usr: m.global.datadogUserInfo,
+        usr: getDatadogUserInfo(m.global),
         version: rumContext.applicationVersion,
         view: {
             id: m.viewId,
@@ -300,7 +300,7 @@ sub sendCustomAction(target as string, context as object, writer as object)
         },
         source: agentSource(),
         type: "action",
-        usr: m.global.datadogUserInfo,
+        usr: getDatadogUserInfo(m.global),
         version: rumContext.applicationVersion,
         view: {
             id: m.viewId,
@@ -381,7 +381,7 @@ sub sendResource(resource as object, context as object, writer as object)
         },
         source: agentSource(),
         type: "resource",
-        usr: m.global.datadogUserInfo,
+        usr: getDatadogUserInfo(m.global),
         version: rumContext.applicationVersion,
         view: {
             id: m.viewId,
@@ -461,7 +461,7 @@ sub sendResourceError(status as string, url as dynamic, method as dynamic, conte
         },
         source: agentSource(),
         type: "error",
-        usr: m.global.datadogUserInfo,
+        usr: getDatadogUserInfo(m.global),
         version: rumContext.applicationVersion,
         view: {
             id: m.viewId,
@@ -517,7 +517,7 @@ sub sendViewUpdate(context as object, writer as object)
         },
         source: agentSource(),
         type: "view",
-        usr: m.global.datadogUserInfo,
+        usr: getDatadogUserInfo(m.global),
         version: rumContext.applicationVersion,
         view: {
             id: m.viewId,

--- a/library/source/datadogSdk.bs
+++ b/library/source/datadogSdk.bs
@@ -2,6 +2,8 @@
 ' This product includes software developed at Datadog (https://www.datadoghq.com/).
 ' Copyright 2022-Today Datadog, Inc.
 
+import "pkg:/source/identityStorage.bs"
+
 ' ----------------------------------------------------------------
 ' Initializes the SDK
 ' @param configuration (object) an Associative Array with the following fields
@@ -110,13 +112,18 @@ sub initialize(configuration as object, global as object)
         ddLogWarning("configuration.ignoredExitEvents is empty; all exit statuses will be reported as crashes.")
     end if
 
+    trackAnonymousUser = configuration.trackAnonymousUser ?? true
+    if (not trackAnonymousUser)
+        clearDatadogAnonymousId()
+    end if
+
     global.addFields({
         datadogTraceAgent: {
             traceSampleRate: configuration.traceSampleRate ?? 100,
             tracingHeaderTypes: configuration.tracingHeaderTypes ?? {},
             traceContextInjection: configuration.traceContextInjection ?? TraceContextInjection.Sampled
         },
-        datadogTrackAnonymousUser: configuration.trackAnonymousUser ?? true,
+        datadogTrackAnonymousUser: trackAnonymousUser,
         datadogIgnoredExitEvents: configuration.ignoredExitEvents ?? [
             "EXIT_UNKNOWN",
             "EXIT_POWER_MODE",

--- a/library/source/datadogSdk.bs
+++ b/library/source/datadogSdk.bs
@@ -24,7 +24,8 @@
 '           - "datadog": Datadog's `x-datadog-*` headers (cf: https://docs.datadoghq.com/real_user_monitoring/connect_rum_and_traces)
 '  - traceContextInjection (string) defines whether the trace context should be injected into all requests or only sampled ones.
 '  - trackAnonymousUser (boolean, optional) when `true` (default), enriches `usr` payloads with `anonymous_id`
-'     derived from the session context when not explicitly set by the user.
+'     derived from the session context when not explicitly set by the user. The id is persisted in the Roku
+'     registry (section `"datadog"`, key `"anonymous_id"`) so it survives channel relaunches.
 '  - ignoredExitEvents (array, optional) an array of exit status strings to ignore when detecting crashes.
 '     Any exit status NOT in this list will be reported as a crash. Defaults to:
 '     ["EXIT_UNKNOWN", "EXIT_POWER_MODE", "EXIT_IDLE_AUTO_EXIT", "EXIT_DIAL_DELETE", "EXIT_USER_KILL", "EXIT_USER_NAV"]

--- a/library/source/datadogSdk.bs
+++ b/library/source/datadogSdk.bs
@@ -23,6 +23,8 @@
 '           - "tracecontext": W3C Trace Context header (cf: https://www.w3.org/TR/trace-context/)
 '           - "datadog": Datadog's `x-datadog-*` headers (cf: https://docs.datadoghq.com/real_user_monitoring/connect_rum_and_traces)
 '  - traceContextInjection (string) defines whether the trace context should be injected into all requests or only sampled ones.
+'  - trackAnonymousUser (boolean, optional) when `true` (default), enriches `usr` payloads with `anonymous_id`
+'     derived from the session context when not explicitly set by the user.
 '  - ignoredExitEvents (array, optional) an array of exit status strings to ignore when detecting crashes.
 '     Any exit status NOT in this list will be reported as a crash. Defaults to:
 '     ["EXIT_UNKNOWN", "EXIT_POWER_MODE", "EXIT_IDLE_AUTO_EXIT", "EXIT_DIAL_DELETE", "EXIT_USER_KILL", "EXIT_USER_NAV"]
@@ -113,6 +115,7 @@ sub initialize(configuration as object, global as object)
             tracingHeaderTypes: configuration.tracingHeaderTypes ?? {},
             traceContextInjection: configuration.traceContextInjection ?? TraceContextInjection.Sampled
         },
+        datadogTrackAnonymousUser: configuration.trackAnonymousUser ?? true,
         datadogIgnoredExitEvents: configuration.ignoredExitEvents ?? [
             "EXIT_UNKNOWN",
             "EXIT_POWER_MODE",
@@ -228,6 +231,45 @@ end function
 ' ----------------------------------------------------------------
 function channelVersion() as string
     return CreateObject("roAppInfo").GetVersion()
+end function
+
+' ----------------------------------------------------------------
+' Returns user info enriched with an anonymous id when applicable.
+' Mirrors browser SDK behavior: don't override user-provided `anonymous_id`.
+' @param global (object) the global node available from scenegraph nodes
+' @return (object) user info object for event payloads
+' ----------------------------------------------------------------
+function getDatadogUserInfo(global as object) as object
+    userInfo = global.datadogUserInfo ?? {}
+    trackAnonymousUser = global.datadogTrackAnonymousUser
+    if (trackAnonymousUser = invalid)
+        trackAnonymousUser = true
+    end if
+
+    if (not trackAnonymousUser)
+        return userInfo
+    end if
+
+    if (userInfo.anonymous_id <> invalid and userInfo.anonymous_id <> "")
+        return userInfo
+    end if
+
+    rumContext = global.datadogRumContext
+    if (rumContext = invalid)
+        return userInfo
+    end if
+
+    anonymousId = rumContext.anonymousId
+    if (anonymousId = invalid or anonymousId = "")
+        return userInfo
+    end if
+
+    enrichedUserInfo = {}
+    for each key in userInfo
+        enrichedUserInfo[key] = userInfo[key]
+    end for
+    enrichedUserInfo.anonymous_id = anonymousId
+    return enrichedUserInfo
 end function
 
 ' ----------------------------------------------------------------

--- a/library/source/identityStorage.bs
+++ b/library/source/identityStorage.bs
@@ -35,3 +35,17 @@ sub writeDatadogAnonymousId(anonymousId as string)
     section.Write("anonymous_id", anonymousId)
     section.Flush()
 end sub
+
+' ----------------------------------------------------------------
+' Removes any persisted Datadog anonymous id from the Roku registry.
+' Called when anonymous user tracking is disabled, so the identifier
+' does not outlive the integrator's consent state.
+' ----------------------------------------------------------------
+sub clearDatadogAnonymousId()
+    section = CreateObject("roRegistrySection", "datadog")
+    if (section = invalid or not section.Exists("anonymous_id"))
+        return
+    end if
+    section.Delete("anonymous_id")
+    section.Flush()
+end sub

--- a/library/source/identityStorage.bs
+++ b/library/source/identityStorage.bs
@@ -1,0 +1,37 @@
+' Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+' This product includes software developed at Datadog (https://www.datadoghq.com/).
+' Copyright 2022-Today Datadog, Inc.
+
+import "pkg:/source/internalLogger.bs"
+
+' ****************************************************************
+' * Persistent storage for SDK identity values (anonymous_id, ...).
+' * Backed by the per-channel Roku registry.
+' ****************************************************************
+
+' ----------------------------------------------------------------
+' Reads the persisted Datadog anonymous id from the Roku registry.
+' @return (string) the stored value, or "" when absent.
+' ----------------------------------------------------------------
+function readDatadogAnonymousId() as string
+    section = CreateObject("roRegistrySection", "datadog")
+    if (section = invalid or not section.Exists("anonymous_id"))
+        return ""
+    end if
+    return section.Read("anonymous_id")
+end function
+
+' ----------------------------------------------------------------
+' Persists the Datadog anonymous id to the Roku registry so it
+' survives channel relaunches (browser-cookie equivalent).
+' @param anonymousId (string) the value to store.
+' ----------------------------------------------------------------
+sub writeDatadogAnonymousId(anonymousId as string)
+    section = CreateObject("roRegistrySection", "datadog")
+    if (section = invalid)
+        ddLogWarning("Unable to persist anonymous_id: registry section unavailable")
+        return
+    end if
+    section.Write("anonymous_id", anonymousId)
+    section.Flush()
+end sub

--- a/test/source/tests/Test__datadog.bs
+++ b/test/source/tests/Test__datadog.bs
@@ -26,6 +26,9 @@ function TestSuite__Datadog() as object
     this.addTest("WhenInitialize_WithNoIgnoredExitEvents_ThenDefaultIsSetInGlobal", DatadogTest__WhenInitialize_WithNoIgnoredExitEvents_ThenDefaultIsSetInGlobal)
     this.addTest("WhenInitialize_WithCustomIgnoredExitEvents_ThenCustomIsSetInGlobal", DatadogTest__WhenInitialize_WithCustomIgnoredExitEvents_ThenCustomIsSetInGlobal)
     this.addTest("WhenInitialize_WithEmptyIgnoredExitEvents_ThenEmptyListIsSetInGlobal", DatadogTest__WhenInitialize_WithEmptyIgnoredExitEvents_ThenEmptyListIsSetInGlobal)
+    this.addTest("WhenGetDatadogUserInfo_ThenIncludesAnonymousIdFromRumContext", DatadogTest__WhenGetDatadogUserInfo_ThenIncludesAnonymousIdFromRumContext)
+    this.addTest("WhenGetDatadogUserInfo_WithExistingAnonymousId_ThenKeepUserValue", DatadogTest__WhenGetDatadogUserInfo_WithExistingAnonymousId_ThenKeepUserValue)
+    this.addTest("WhenGetDatadogUserInfo_WithTrackAnonymousUserDisabled_ThenDoNotEnrich", DatadogTest__WhenGetDatadogUserInfo_WithTrackAnonymousUserDisabled_ThenDoNotEnrich)
 
     this.addTest("WhenGetEndpointStaging_ThenCreateEndpoint", DatadogTest__WhenGetEndpointStaging_ThenCreateEndpoint)
 
@@ -196,6 +199,71 @@ function DatadogTest__WhenGetEndpointRumUnknown_ThenCreateEndpoint() as string
 
     ' Then
     Assert.that(endpoint).isEqualTo("")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: global user info without anonymous_id and a rum anonymousId
+'  When: retrieving Datadog user info for payloads
+'  Then: enrich with anonymous_id
+'----------------------------------------------------------------
+function DatadogTest__WhenGetDatadogUserInfo_ThenIncludesAnonymousIdFromRumContext() as string
+    ' Given
+    fakeAnonymousId = IG_GetString(32)
+    fakeGlobal = {
+        datadogUserInfo: { id: IG_GetString(16) },
+        datadogRumContext: { anonymousId: fakeAnonymousId },
+        datadogTrackAnonymousUser: true
+    }
+
+    ' When
+    userInfo = datadogroku_getDatadogUserInfo(fakeGlobal)
+
+    ' Then
+    Assert.that(userInfo.id).isEqualTo(fakeGlobal.datadogUserInfo.id)
+    Assert.that(userInfo.anonymous_id).isEqualTo(fakeAnonymousId)
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: global user info with explicit anonymous_id and rum anonymousId
+'  When: retrieving Datadog user info for payloads
+'  Then: keeps explicit user value
+'----------------------------------------------------------------
+function DatadogTest__WhenGetDatadogUserInfo_WithExistingAnonymousId_ThenKeepUserValue() as string
+    ' Given
+    fakeGlobal = {
+        datadogUserInfo: { id: IG_GetString(16), anonymous_id: "user-defined-anon" },
+        datadogRumContext: { anonymousId: IG_GetString(32) },
+        datadogTrackAnonymousUser: true
+    }
+
+    ' When
+    userInfo = datadogroku_getDatadogUserInfo(fakeGlobal)
+
+    ' Then
+    Assert.that(userInfo.anonymous_id).isEqualTo("user-defined-anon")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: anonymous tracking disabled
+'  When: retrieving Datadog user info for payloads
+'  Then: does not add anonymous_id
+'----------------------------------------------------------------
+function DatadogTest__WhenGetDatadogUserInfo_WithTrackAnonymousUserDisabled_ThenDoNotEnrich() as string
+    ' Given
+    fakeGlobal = {
+        datadogUserInfo: { id: IG_GetString(16) },
+        datadogRumContext: { anonymousId: IG_GetString(32) },
+        datadogTrackAnonymousUser: false
+    }
+
+    ' When
+    userInfo = datadogroku_getDatadogUserInfo(fakeGlobal)
+
+    ' Then
+    Assert.that(userInfo.anonymous_id).isInvalid()
     return ""
 end function
 
@@ -404,4 +472,3 @@ function DatadogTest__WhenInitialize_WithEmptyIgnoredExitEvents_ThenEmptyListIsS
     Assert.that(actualIgnoredExitEvents).hasSize(0)
     return ""
 end function
-

--- a/test/source/tests/Test__datadog.bs
+++ b/test/source/tests/Test__datadog.bs
@@ -26,6 +26,7 @@ function TestSuite__Datadog() as object
     this.addTest("WhenInitialize_WithNoIgnoredExitEvents_ThenDefaultIsSetInGlobal", DatadogTest__WhenInitialize_WithNoIgnoredExitEvents_ThenDefaultIsSetInGlobal)
     this.addTest("WhenInitialize_WithCustomIgnoredExitEvents_ThenCustomIsSetInGlobal", DatadogTest__WhenInitialize_WithCustomIgnoredExitEvents_ThenCustomIsSetInGlobal)
     this.addTest("WhenInitialize_WithEmptyIgnoredExitEvents_ThenEmptyListIsSetInGlobal", DatadogTest__WhenInitialize_WithEmptyIgnoredExitEvents_ThenEmptyListIsSetInGlobal)
+    this.addTest("WhenInitialize_WithTrackAnonymousUserDisabled_ThenClearPersistedAnonymousId", DatadogTest__WhenInitialize_WithTrackAnonymousUserDisabled_ThenClearPersistedAnonymousId)
     this.addTest("WhenGetDatadogUserInfo_ThenIncludesAnonymousIdFromRumContext", DatadogTest__WhenGetDatadogUserInfo_ThenIncludesAnonymousIdFromRumContext)
     this.addTest("WhenGetDatadogUserInfo_WithExistingAnonymousId_ThenKeepUserValue", DatadogTest__WhenGetDatadogUserInfo_WithExistingAnonymousId_ThenKeepUserValue)
     this.addTest("WhenGetDatadogUserInfo_WithTrackAnonymousUserDisabled_ThenDoNotEnrich", DatadogTest__WhenGetDatadogUserInfo_WithTrackAnonymousUserDisabled_ThenDoNotEnrich)
@@ -470,5 +471,36 @@ function DatadogTest__WhenInitialize_WithEmptyIgnoredExitEvents_ThenEmptyListIsS
     actualIgnoredExitEvents = fakeGlobal.getField("datadogIgnoredExitEvents")
     Assert.that(actualIgnoredExitEvents).isNotInvalid()
     Assert.that(actualIgnoredExitEvents).hasSize(0)
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a previously persisted anonymous id in the registry
+'  When: initializing the SDK with `trackAnonymousUser: false`
+'  Then: the persisted id is removed from the registry, honoring
+'        the integrator's consent-withdrawal signal
+'----------------------------------------------------------------
+function DatadogTest__WhenInitialize_WithTrackAnonymousUserDisabled_ThenClearPersistedAnonymousId() as string
+    ' Given
+    fakeAnonymousId = IG_GetString(32)
+    section = CreateObject("roRegistrySection", "datadog")
+    section.Write("anonymous_id", fakeAnonymousId)
+    section.Flush()
+    configuration = {
+        clientToken: IG_GetString(16),
+        applicationId: IG_GetString(16),
+        site: "us1",
+        env: IG_GetString(16),
+        trackAnonymousUser: false
+    }
+
+    ' When
+    fakeGlobal = CreateObject("roSGNode", "ContentNode")
+    datadogroku_initialize(configuration, fakeGlobal)
+
+    ' Then
+    Assert.that(fakeGlobal.getField("datadogTrackAnonymousUser")).isFalse()
+    persistedSection = CreateObject("roRegistrySection", "datadog")
+    Assert.that(persistedSection.Exists("anonymous_id")).isFalse()
     return ""
 end function

--- a/test/source/tests/logs/Test__LogsAgent.bs
+++ b/test/source/tests/logs/Test__LogsAgent.bs
@@ -14,6 +14,8 @@ function TestSuite__LogsAgent() as object
     this.addTest("WhenLogOkWithCustomAttributes_ThenWriteLog", LogsAgentTest__WhenLogOkWithCustomAttributes_ThenWriteLog, LogsAgentTest__SetUp, LogsAgentTest__TearDown)
     this.addTest("WhenLogOkWithGlobalAttributes_ThenWriteLog", LogsAgentTest__WhenLogOkWithGlobalAttributes_ThenWriteLog, LogsAgentTest__SetUp, LogsAgentTest__TearDown)
     this.addTest("WhenLogOkWithUserInfo_ThenWriteLog", LogsAgentTest__WhenLogOkWithUserInfo_ThenWriteLog, LogsAgentTest__SetUp, LogsAgentTest__TearDown)
+    this.addTest("WhenLogOkWithAnonymousIdInRumContext_ThenWriteLogWithUserAnonymousId", LogsAgentTest__WhenLogOkWithAnonymousIdInRumContext_ThenWriteLogWithUserAnonymousId, LogsAgentTest__SetUp, LogsAgentTest__TearDown)
+    this.addTest("WhenLogOkWithExistingUserAnonymousId_ThenPreserveUserAnonymousId", LogsAgentTest__WhenLogOkWithExistingUserAnonymousId_ThenPreserveUserAnonymousId, LogsAgentTest__SetUp, LogsAgentTest__TearDown)
     this.addTest("WhenLogOkWithRumContext_ThenWriteLog", LogsAgentTest__WhenLogOkWithRumContext_ThenWriteLog, LogsAgentTest__SetUp, LogsAgentTest__TearDown)
 
     this.addTest("WhenLogDebug_ThenWriteLog", LogsAgentTest__WhenLogDebug_ThenWriteLog, LogsAgentTest__SetUp, LogsAgentTest__TearDown)
@@ -331,6 +333,61 @@ function LogsAgentTest__WhenLogOkWithUserInfo_ThenWriteLog() as string
     Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
     Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     Assert.that(logEvent.usr).isEqualTo(m.fakeGlobalUserInfo)
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a LogsAgent with user info and rum anonymous id
+'  When: call the log ok
+'  Then: writes a log with usr.anonymous_id
+'----------------------------------------------------------------
+function LogsAgentTest__WhenLogOkWithAnonymousIdInRumContext_ThenWriteLogWithUserAnonymousId() as string
+    ' Given
+    fakeMessage = IG_GetString(32)
+    m.global.setField("datadogUserInfo", m.fakeGlobalUserInfo)
+    fakeRumContext = {
+        anonymousId: IG_GetString(32),
+        actionId: m.fakeRumContext.actionId,
+        applicationId: m.fakeRumContext.applicationId,
+        sessionId: m.fakeRumContext.sessionId,
+        viewId: m.fakeRumContext.viewId
+    }
+    m.global.setField("datadogRumContext", fakeRumContext)
+
+    ' When
+    m.testedNode@.logOk(fakeMessage, {})
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    logEvent = ParseJson(updates[0])
+    Assert.that(logEvent.usr.id).isEqualTo(m.fakeGlobalUserInfo.id)
+    Assert.that(logEvent.usr.anonymous_id).isEqualTo(fakeRumContext.anonymousId)
+    Assert.that(m.global.datadogUserInfo.anonymous_id).isInvalid()
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a LogsAgent with user and rum anonymous ids
+'  When: call the log ok
+'  Then: preserves user-provided anonymous_id
+'----------------------------------------------------------------
+function LogsAgentTest__WhenLogOkWithExistingUserAnonymousId_ThenPreserveUserAnonymousId() as string
+    ' Given
+    fakeMessage = IG_GetString(32)
+    fakeUserAnonymousId = IG_GetString(32)
+    m.fakeGlobalUserInfo.anonymous_id = fakeUserAnonymousId
+    m.global.setField("datadogUserInfo", m.fakeGlobalUserInfo)
+    m.global.setField("datadogRumContext", {
+        anonymousId: IG_GetString(32)
+    })
+
+    ' When
+    m.testedNode@.logOk(fakeMessage, {})
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    logEvent = ParseJson(updates[0])
+    Assert.that(logEvent.usr.anonymous_id).isEqualTo(fakeUserAnonymousId)
     return ""
 end function
 

--- a/test/source/tests/rum/Test__RumSessionScope.bs
+++ b/test/source/tests/rum/Test__RumSessionScope.bs
@@ -152,6 +152,7 @@ function RumSessionScopeTest__WhenInit_ThenUpdateGlobalRumContext() as string
 
     ' Then
     Assert.that(context.sessionId).isEqualTo(m.global.datadogRumContext.sessionId)
+    Assert.that(m.global.datadogRumContext.anonymousId).isNotEmpty()
     return ""
 end function
 
@@ -176,6 +177,7 @@ function RumSessionScopeTest__WhenRenewSessionWithInvalidRumContext_ThenDoesNotC
     Assert.that(context.sessionId).isNotEmpty()
     Assert.that(m.global.datadogRumContext).isNotInvalid()
     Assert.that(m.global.datadogRumContext.sessionId).isEqualTo(context.sessionId)
+    Assert.that(m.global.datadogRumContext.anonymousId).isNotEmpty()
     return ""
 end function
 

--- a/test/source/tests/rum/Test__RumSessionScope.bs
+++ b/test/source/tests/rum/Test__RumSessionScope.bs
@@ -11,6 +11,8 @@ function TestSuite__RumSessionScope() as object
     this.Name = "RumSessionScope"
 
     this.addTest("WhenInit_ThenUpdateGlobalRumContext", RumSessionScopeTest__WhenInit_ThenUpdateGlobalRumContext, RumSessionScopeTest__SetUp, RumSessionScopeTest__TearDown)
+    this.addTest("WhenRenewSession_WithEmptyRegistry_ThenGenerateAndPersist", RumSessionScopeTest__WhenRenewSession_WithEmptyRegistry_ThenGenerateAndPersist, RumSessionScopeTest__SetUpNoSession, RumSessionScopeTest__TearDown)
+    this.addTest("WhenRenewSession_WithRegistryValue_ThenReuseIt", RumSessionScopeTest__WhenRenewSession_WithRegistryValue_ThenReuseIt, RumSessionScopeTest__SetUpNoSession, RumSessionScopeTest__TearDown)
     this.addTest("WhenRenewSessionWithInvalidRumContext_ThenDoesNotCrash", RumSessionScopeTest__WhenRenewSessionWithInvalidRumContext_ThenDoesNotCrash, RumSessionScopeTest__SetUpNoSession, RumSessionScopeTest__TearDown)
     this.addTest("WhenGetContext_ThenReturnsContext", RumSessionScopeTest__WhenGetContext_ThenReturnsContext, RumSessionScopeTest__SetUp, RumSessionScopeTest__TearDown)
     this.addTest("WhenHandleStartViewEvent_ThenCreateViewScope", RumSessionScopeTest__WhenHandleStartViewEvent_ThenCreateViewScope, RumSessionScopeTest__SetUp, RumSessionScopeTest__TearDown)
@@ -139,6 +141,11 @@ sub RumSessionScopeTest__TearDown()
     m.testSuite.Delete("mockWriter")
     m.testSuite.Delete("mockParentScope")
     m.testSuite.Delete("testedScope")
+    section = CreateObject("roRegistrySection", "datadog")
+    if (section <> invalid and section.Exists("anonymous_id"))
+        section.Delete("anonymous_id")
+        section.Flush()
+    end if
 end sub
 
 '----------------------------------------------------------------
@@ -153,6 +160,49 @@ function RumSessionScopeTest__WhenInit_ThenUpdateGlobalRumContext() as string
     ' Then
     Assert.that(context.sessionId).isEqualTo(m.global.datadogRumContext.sessionId)
     Assert.that(m.global.datadogRumContext.anonymousId).isNotEmpty()
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: an empty registry section
+'  When: renewing session for the first time
+'  Then: generates a new anonymous id and persists it to the registry
+'----------------------------------------------------------------
+function RumSessionScopeTest__WhenRenewSession_WithEmptyRegistry_ThenGenerateAndPersist() as string
+    ' Given: empty registry (TearDown cleared it, but ensure for safety)
+    section = CreateObject("roRegistrySection", "datadog")
+    if (section.Exists("anonymous_id"))
+        section.Delete("anonymous_id")
+        section.Flush()
+    end if
+
+    ' When
+    m.testedScope@.handleEvent({ mock: "event", eventType: "resetSession" }, { mock: "writer" })
+
+    ' Then
+    Assert.that(m.global.datadogRumContext.anonymousId).isNotEmpty()
+    persistedSection = CreateObject("roRegistrySection", "datadog")
+    Assert.that(persistedSection.Read("anonymous_id")).isEqualTo(m.global.datadogRumContext.anonymousId)
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a value pre-existing in the registry from a prior channel launch
+'  When: renewing session
+'  Then: reuses the persisted anonymous id rather than generating a new one
+'----------------------------------------------------------------
+function RumSessionScopeTest__WhenRenewSession_WithRegistryValue_ThenReuseIt() as string
+    ' Given
+    fakeAnonymousId = IG_GetString(32)
+    section = CreateObject("roRegistrySection", "datadog")
+    section.Write("anonymous_id", fakeAnonymousId)
+    section.Flush()
+
+    ' When
+    m.testedScope@.handleEvent({ mock: "event", eventType: "resetSession" }, { mock: "writer" })
+
+    ' Then
+    Assert.that(m.global.datadogRumContext.anonymousId).isEqualTo(fakeAnonymousId)
     return ""
 end function
 


### PR DESCRIPTION
### What does this PR do?

Adds browser-SDK-style `anonymous_id` enrichment to the Roku SDK so RUM and Logs events can be tied back to a stable, anonymous device identity across both sessions and channel launches.

- New `trackAnonymousUser` init configuration flag (default `true`).
- On RUM session renewal, if no in-memory anonymous id is present, read it from the Roku registry (section `"datadog"`, key `"anonymous_id"`). On a miss, generate a new UUID via `roDeviceInfo.GetRandomUUID()` and persist it back to the registry. This mirrors browser-sdk's cookie behavior — the id survives channel relaunches and reboots, scoped per-channel.
- When `trackAnonymousUser: false` is passed at init, any previously persisted `anonymous_id` is removed from the registry so the identifier does not outlive the integrator's consent signal.
- New `getDatadogUserInfo(global)` helper enriches `usr` payloads with `anonymous_id` only when not already set by the user, and only when tracking is enabled.
- All `usr:` payload builders in Logs and RUM (view, action, error, resource, vital) now go through the helper.
- New `library/source/identityStorage.bs` module wraps registry read/write/delete so future identity values can be persisted the same way.

### Motivation

Mirror the behavior already shipped in [`browser-sdk`](https://github.com/DataDog/browser-sdk) so anonymous Roku sessions are attributable and consistent with other Datadog SDKs. The same precedence rules apply: a user-provided `anonymous_id` always wins over the SDK-generated one, and explicit user opt-out (`trackAnonymousUser: false`) disables enrichment entirely and clears any persisted id. Persistence in the Roku registry is the closest analogue to a browser cookie: per-channel-sandboxed, survives reboots.

### Additional Notes

- Tests added in `test/source/tests/Test__datadog.bs` cover the three precedence cases (enrich, preserve user value, opt-out) plus registry cleanup on `trackAnonymousUser: false`.
- Tests in `test/source/tests/logs/Test__LogsAgent.bs` verify the helper is wired into log payloads.
- Tests in `test/source/tests/rum/Test__RumSessionScope.bs` cover registry reuse (`WhenRenewSession_WithRegistryValue_ThenReuseIt`) and first-launch generation/persistence (`WhenRenewSession_WithEmptyRegistry_ThenGenerateAndPersist`). The shared `TearDown` clears the registry key for isolation.
- `dist/` is regenerated and included in the commits, consistent with the repo's existing workflow.
- No linked Issue yet — happy to open one if the team prefers per CONTRIBUTING.md.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)