### PR TITLE
Fix flaky tests

### DIFF
--- a/dist/components/rum/RumSessionScope.brs
+++ b/dist/components/rum/RumSessionScope.brs
@@ -133,8 +133,8 @@ sub renewSession(timestamp& as longinteger)
     m.sessionId = CreateObject("roDeviceInfo").GetRandomUUID()
     m.sessionStartMs = timestamp&
     m.activeOperations = {}
-    rndSession = (Rnd(101) - 1) ' Rnd(n) returns a number between 1 and n (both inclusive)
-    if (rndSession < m.top.sessionSampleRate)
+    rndSession = Rnd(100) ' Rnd(n) returns a number between 1 and n (both inclusive)
+    if (rndSession <= m.top.sessionSampleRate)
         m.sessionState = "tracked"
     else
         m.sessionState = "not_tracked"

--- a/library/components/rum/RumSessionScope.bs
+++ b/library/components/rum/RumSessionScope.bs
@@ -118,8 +118,8 @@ sub renewSession(timestamp& as longinteger)
     m.sessionStartMs = timestamp&
     m.activeOperations = {}
 
-    rndSession = (Rnd(101) - 1) ' Rnd(n) returns a number between 1 and n (both inclusive)
-    if (rndSession < m.top.sessionSampleRate)
+    rndSession = Rnd(100) ' Rnd(n) returns a number between 1 and n (both inclusive)
+    if (rndSession <= m.top.sessionSampleRate)
         m.sessionState = RumSessionState.tracked
     else
         m.sessionState = RumSessionState.not_tracked

--- a/test/source/tests/rum/Test__RumCrashReporterTask.bs
+++ b/test/source/tests/rum/Test__RumCrashReporterTask.bs
@@ -69,6 +69,7 @@ end sub
 sub RumCrashReporterTaskTest__TearDown()
     m.testSuite.Delete("mockWriter")
     m.testSuite.Delete("testedTask")
+    createObject("roFileSystem").Delete(datadogroku_trackFolderPath("rum"))
 end sub
 
 '----------------------------------------------------------------

--- a/test/source/tests/rum/Test__RumSessionScope.bs
+++ b/test/source/tests/rum/Test__RumSessionScope.bs
@@ -71,6 +71,9 @@ sub RumSessionScopeTest__SetUp()
     ' Fake data
     m.testSuite.global.addFields({ datadogRumContext: {}, datadogContext: {}, datadogUserInfo: {} })
 
+    ' Filesystem
+    datadogroku_mkDirs(datadogroku_trackFolderPath("rum"))
+
     ' Tested Task
     m.testSuite.testedScope = CreateObject("roSGNode", "datadogroku_RumSessionScope")
     m.testSuite.testedScope.parentScope = m.testSuite.mockParentScope
@@ -86,6 +89,9 @@ sub RumSessionScopeTest__SetUpNoSession()
 
     ' Fake data
     m.testSuite.global.addFields({ datadogRumContext: {} })
+
+    ' Filesystem
+    datadogroku_mkDirs(datadogroku_trackFolderPath("rum"))
 
     ' Tested Task
     m.testSuite.testedScope = CreateObject("roSGNode", "datadogroku_RumSessionScope")
@@ -123,6 +129,9 @@ sub RumSessionScopeTest__SetUpWithView()
     ' Global fields (required by SDK infrastructure)
     m.testSuite.global.addFields({ datadogRumContext: {}, datadogContext: {}, datadogUserInfo: {} })
 
+    ' Filesystem
+    datadogroku_mkDirs(datadogroku_trackFolderPath("rum"))
+
     ' Create and initialize session scope
     m.testSuite.testedScope = CreateObject("roSGNode", "datadogroku_RumSessionScope")
     m.testSuite.testedScope.parentScope = m.testSuite.mockParentScope
@@ -139,6 +148,7 @@ sub RumSessionScopeTest__TearDown()
     m.testSuite.Delete("mockWriter")
     m.testSuite.Delete("mockParentScope")
     m.testSuite.Delete("testedScope")
+    createObject("roFileSystem").Delete(datadogroku_trackFolderPath("rum"))
 end sub
 
 '----------------------------------------------------------------
@@ -1125,9 +1135,9 @@ function RumSessionScopeTest__WhenCrossViewOperation_ThenEachEventCarriesCorrect
 
     ' Then
     updates = m.mockWriter@.getFieldUpdates("writeEvent")
-    Assert.that(updates).hasSize(existingCount + 2)
+    Assert.that(updates).hasSize(existingCount + 3)
     startVitalEvent = ParseJson(updates[existingCount])
-    stopVitalEvent = ParseJson(updates[existingCount + 1])
+    stopVitalEvent = ParseJson(updates[existingCount + 2])
     Assert.that(startVitalEvent).isNotInvalid()
     Assert.that(stopVitalEvent).isNotInvalid()
     Assert.that(startVitalEvent.view.url).isEqualTo(m.fakeViewUrl)

--- a/test/source/tests/rum/Test__RumViewScope.bs
+++ b/test/source/tests/rum/Test__RumViewScope.bs
@@ -27,7 +27,7 @@ function TestSuite__RumViewScope() as object
     this.addTest("WhenHandleStopViewEventTwice_ThenWriteViewEvent", RumViewScopeTest__WhenHandleStopViewEventTwice_ThenWriteViewEvent, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
     this.addTest("WhenHandleStartViewEvent_ThenWriteViewEvent", RumViewScopeTest__WhenHandleStartViewEvent_ThenWriteViewEvent, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
     this.addTest("WhenStopUnknownView_ThenDoNothing", RumViewScopeTest__WhenStopUnknownView_ThenDoNothing, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
-    this.addTest("WhenHanldeViewUpdate_ThenKeepLastKnownViewEvent", RumViewScopeTest__WhenHandleViewUpdate_ThenKeepLastKnownViewEvent, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
+    this.addTest("WhenHandleViewUpdate_ThenKeepLastKnownViewEvent", RumViewScopeTest__WhenHandleViewUpdate_ThenKeepLastKnownViewEvent, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
     this.addTest("WhenHandleViewUpdateNotTracked_ThenDiscardLastKnownViewEvent", RumViewScopeTest__WhenHandleViewUpdateNotTracked_ThenDiscardLastKnownViewEvent, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
 
     this.addTest("WhenHandleAddErrorEvent_ThenWriteViewEvent", RumViewScopeTest__WhenHandleAddErrorEvent_ThenWriteViewEvent, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
@@ -103,6 +103,9 @@ sub RumViewScopeTest__SetUp()
     m.testSuite.global.addFields({ datadogContext: {}, datadogUserInfo: {}, datadogRumContext: {} })
     m.testSuite.global.setField("datadogRumContext", { instanceId: m.testSuite.fakeInstanceId })
 
+    ' Filesystem
+    datadogroku_mkDirs(datadogroku_trackFolderPath("rum"))
+
     ' Tested Task
     m.testSuite.startTimestamp& = datadogroku_getTimestamp()
     m.testSuite.testedScope = CreateObject("roSGNode", "datadogroku_RumViewScope")
@@ -117,6 +120,7 @@ sub RumViewScopeTest__TearDown()
     m.testSuite.Delete("mockParentScope")
     m.testSuite.Delete("mockActionScope")
     m.testSuite.Delete("testedScope")
+    createObject("roFileSystem").Delete(datadogroku_trackFolderPath("rum"))
 end sub
 
 '----------------------------------------------------------------


### PR DESCRIPTION
### What does this PR do?

- Fix off-by-one in session sampling: `RumSessionScope.renewSession` was using `Rnd(101) - 1 < sampleRate`, which produces 101 outcomes for a 100-point percentage.
- Fix leaked `_last_view*` files in `Test__RumViewScope` and `Test_RumSessionScope`.
- Fix `WhenCrossViewOperation_ThenEachEventCarriesCorrectViewContext` assertion: test now expects 3 events, because `startView` correctly emits a view-close event for the previous view between the 2 vital events.

### Motivation

We want to have all tests passing.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

