### PR TITLE
RUM-16276: Cache `site` and batch `sendCrash` writes in `RumAgent`

### DIFF
--- a/dist/components/rum/RumAgent.brs
+++ b/dist/components/rum/RumAgent.brs
@@ -198,18 +198,21 @@ end sub
 sub sendCrash(lastExitOrTerminationReason as string)
     ensureSetup()
     crashReporter = CreateObject("roSGNode", "RumCrashReporterTask")
-    crashReporter.writer = m.writer
     if (m.osVersionMajor.toInt() >= 13)
         appManager = createObject("roAppManager")
         lastExitInfo = appManager.GetLastExitInfo()
-        exitCode = lastExitInfo.exit_code
-        crashReporter.lastExitOrTerminationReason = lastExitInfo.exit_code
-        crashReporter.lastExitConsoleLog = lastExitInfo.console_log
+        exitReason = lastExitInfo.exit_code
+        consoleLog = lastExitInfo.console_log
     else
-        crashReporter.lastExitOrTerminationReason = lastExitOrTerminationReason
-        crashReporter.lastExitConsoleLog = ""
+        exitReason = lastExitOrTerminationReason
+        consoleLog = ""
     end if
-    crashReporter.instanceId = m.instanceId
+    crashReporter.setFields({
+        writer: m.writer
+        lastExitOrTerminationReason: exitReason
+        lastExitConsoleLog: consoleLog
+        instanceId: m.instanceId
+    })
     crashReporter.control = "RUN"
 end sub
 
@@ -469,7 +472,7 @@ sub ensureUploader()
             end if
         end function)(m)
     tracks[trackId] = {
-        url: getIntakeUrl(m.top.site, "rum")
+        url: getIntakeUrl(m.site, "rum")
         trackType: "rum"
         payloadPrefix: ""
         payloadPostfix: ""

--- a/library/components/rum/RumAgent.bs
+++ b/library/components/rum/RumAgent.bs
@@ -202,18 +202,21 @@ end sub
 sub sendCrash(lastExitOrTerminationReason as string)
     ensureSetup()
     crashReporter = CreateObject("roSGNode", "RumCrashReporterTask")
-    crashReporter.writer = m.writer
     if (m.osVersionMajor.toInt() >= 13)
         appManager = createObject("roAppManager")
         lastExitInfo = appManager.GetLastExitInfo()
-        exitCode = lastExitInfo.exit_code
-        crashReporter.lastExitOrTerminationReason = lastExitInfo.exit_code
-        crashReporter.lastExitConsoleLog = lastExitInfo.console_log
+        exitReason = lastExitInfo.exit_code
+        consoleLog = lastExitInfo.console_log
     else
-        crashReporter.lastExitOrTerminationReason = lastExitOrTerminationReason
-        crashReporter.lastExitConsoleLog = ""
+        exitReason = lastExitOrTerminationReason
+        consoleLog = ""
     end if
-    crashReporter.instanceId = m.instanceId
+    crashReporter.setFields({
+        writer: m.writer,
+        lastExitOrTerminationReason: exitReason,
+        lastExitConsoleLog: consoleLog,
+        instanceId: m.instanceId
+    })
     crashReporter.control = "RUN"
 end sub
 
@@ -468,7 +471,7 @@ sub ensureUploader()
     trackId = "rum_" + m.top.threadInfo().node.address
     tracks = m.uploader.tracks ?? {}
     tracks[trackId] = {
-        url: getIntakeUrl(m.top.site, TrackType.rum),
+        url: getIntakeUrl(m.site, TrackType.rum),
         trackType: TrackType.rum,
         payloadPrefix: "",
         payloadPostfix: "",

--- a/test/source/tests/rum/Test__RumAgent.bs
+++ b/test/source/tests/rum/Test__RumAgent.bs
@@ -98,7 +98,7 @@ sub RumAgentTest__SetUpNoMock()
     m.testSuite.fakeDeviceName = IG_GetString(16)
     m.testSuite.fakeOsVersion = IG_GetString(16)
     m.testSuite.fakeOsVersionMajor = IG_GetString(16)
-    m.testSuite.fakeSite = IG_GetString(10) + "." + IG_GetString(3)
+    m.testSuite.fakeSite = IG_GetOneOf(["us1", "us3", "us5", "eu1"])
     m.testSuite.fakeClientToken = "pub" + IG_GetString(32)
     m.testSuite.fakeApplicationId = IG_GetString(32)
     m.testSuite.fakeService = IG_GetString(32)
@@ -469,8 +469,7 @@ function RumAgentTest__WhenHandlingEvent_ThenInitDependencies() as string
     m.testedNode.uploader = invalid
     m.testedNode.writer = invalid
     m.testedNode.rumScope = invalid
-    site = IG_GetOneOf(["us1", "us3", "us5", "eu1"])
-    m.testedNode.site = site
+    site = m.fakeSite
     expectedUrl = datadogroku_getIntakeUrl(site, "rum")
     expectedTrackName = "rum_" + m.testedNode.threadInfo().node.address
 


### PR DESCRIPTION
### What does this PR do?

- Reuse cached `m.site` in `RumAgent`.
- Bundle `sendCrash` into a single `setFields` call in `RumAgent`.

### Motivation

Reduce rendezvous occurrences everytime an event is sent.

### Additional Notes

When clicking on "Add custom action" in the sample app, we can see that:

**Before:** 19 rendezvous
<img width="1468" height="760" alt="image" src="https://github.com/user-attachments/assets/a67bd5d9-ccef-4a5d-b101-aa9e0fe36344" />

**After:** 15 rendezvous
<img width="1536" height="780" alt="image" src="https://github.com/user-attachments/assets/b0b830d0-c13e-4429-8ff2-f41820649e67" />

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

