### PR TITLE
feat: add anonymous_id user enrichment to RUM and Logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,28 @@ To identify user sessions, use the `datadogUserInfo` global field, after initial
     m.global.setField("datadogUserInfo", { id: 42, name: "Abcd Efg", email: "abcd.efg@example.com"})
 ```
 
+#### Anonymous user tracking
+
+By default, the SDK generates a stable `anonymous_id` per device on first launch and persists it in the Roku registry so it survives channel relaunches. Every RUM and Logs event's `usr` payload is enriched with this id, which lets you correlate sessions from the same device even when no logged-in user is identified.
+
+If you supply your own `anonymous_id` via `datadogUserInfo` it takes precedence over the SDK-generated one:
+
+```brightscript
+    m.global.setField("datadogUserInfo", { anonymous_id: "your-pseudonymous-id" })
+```
+
+To opt out entirely (for example, to honor a consent signal), pass `trackAnonymousUser: false` at init time. This disables enrichment and clears any previously persisted id from the registry:
+
+```brightscript
+    datadogroku_initialize({
+        clientToken: "…",
+        applicationId: "…",
+        site: "us1",
+        env: "prod",
+        trackAnonymousUser: false
+    }, m.global)
+```
+
 ### Track custom global attributes
 
 In addition to the default attributes captured by the SDK automatically, you can choose to add additional contextual information, such as custom attributes, to your Logs and RUM events to enrich your observability within Datadog. Custom attributes allow you to filter and group information about observed user behavior (for example by cart value, merchant tier, or ad campaign) with code-level information (such as backend services, session timeline, error logs, and network health).

--- a/dist/components/core/MultiTrackUploaderTask.xml
+++ b/dist/components/core/MultiTrackUploaderTask.xml
@@ -11,5 +11,6 @@
     <script type="text/brightscript" uri="pkg:/source/internalLogger.brs" />
     <script type="text/brightscript" uri="pkg:/source/fileUtils.brs" />
     <script type="text/brightscript" uri="pkg:/source/datadogSdk.brs" />
+    <script type="text/brightscript" uri="pkg:/source/identityStorage.brs" />
     <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
 </component>

--- a/dist/components/core/WriterTask.xml
+++ b/dist/components/core/WriterTask.xml
@@ -11,5 +11,6 @@
     <script type="text/brightscript" uri="pkg:/source/internalLogger.brs" />
     <script type="text/brightscript" uri="pkg:/source/fileUtils.brs" />
     <script type="text/brightscript" uri="pkg:/source/datadogSdk.brs" />
+    <script type="text/brightscript" uri="pkg:/source/identityStorage.brs" />
     <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
 </component>

--- a/dist/components/logs/LogsAgent.brs
+++ b/dist/components/logs/LogsAgent.brs
@@ -131,7 +131,7 @@ sub sendLog(status as object, message as string, attributes as object)
         message: message
         status: status
         service: m.service
-        usr: m.userInfo
+        usr: getDatadogUserInfo(m.userInfo, m.anonymousId)
         device: {
             type: "tv"
             name: m.deviceName
@@ -222,6 +222,16 @@ sub setupIfNeeded()
     m.userInfo = m.global.datadogUserInfo
     m.ddContext = m.global.datadogContext
     m.rumContext = m.global.datadogRumContext
+    ' Resolved once at init and immutable afterwards, so read it a single time
+    ' rather than on every log event.
+    m.anonymousId = (function(m)
+            __bsConsequent = m.global.datadogAnonymousId
+            if __bsConsequent <> invalid then
+                return __bsConsequent
+            else
+                return ""
+            end if
+        end function)(m)
     m.isConfigured = true
 end sub
 

--- a/dist/components/logs/LogsAgent.xml
+++ b/dist/components/logs/LogsAgent.xml
@@ -26,5 +26,6 @@
     <script type="text/brightscript" uri="pkg:/source/logs/logStatus.brs" />
     <script type="text/brightscript" uri="pkg:/source/internalLogger.brs" />
     <script type="text/brightscript" uri="pkg:/source/datadogSdk.brs" />
+    <script type="text/brightscript" uri="pkg:/source/identityStorage.brs" />
     <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
 </component>

--- a/dist/components/rum/RumActionScope.brs
+++ b/dist/components/rum/RumActionScope.brs
@@ -29,6 +29,16 @@ sub init()
         end function)(m)
     datadogRumContext.actionId = m.actionId
     m.global.setField("datadogRumContext", datadogRumContext)
+    ' Resolved once at init and immutable afterwards; cache it to avoid a
+    ' cross-thread global read on every event sent from this Task thread.
+    m.anonymousId = (function(m)
+            __bsConsequent = m.global.datadogAnonymousId
+            if __bsConsequent <> invalid then
+                return __bsConsequent
+            else
+                return ""
+            end if
+        end function)(m)
 end sub
 
 ' ----------------------------------------------------------------
@@ -153,7 +163,7 @@ sub sendAction(writer as object)
         }
         source: agentSource()
         type: "action"
-        usr: m.global.datadogUserInfo
+        usr: getDatadogUserInfo(m.global.datadogUserInfo, m.anonymousId)
         version: context.applicationVersion
         view: {
             id: context.viewId

--- a/dist/components/rum/RumActionScope.xml
+++ b/dist/components/rum/RumActionScope.xml
@@ -11,5 +11,6 @@
     <script type="text/brightscript" uri="pkg:/source/rum/rumHelper.brs" />
     <script type="text/brightscript" uri="pkg:/source/fileUtils.brs" />
     <script type="text/brightscript" uri="pkg:/source/datadogSdk.brs" />
+    <script type="text/brightscript" uri="pkg:/source/identityStorage.brs" />
     <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
 </component>

--- a/dist/components/rum/RumAgent.xml
+++ b/dist/components/rum/RumAgent.xml
@@ -48,5 +48,6 @@
     <script type="text/brightscript" uri="pkg:/source/fileUtils.brs" />
     <script type="text/brightscript" uri="pkg:/source/internalLogger.brs" />
     <script type="text/brightscript" uri="pkg:/source/datadogSdk.brs" />
+    <script type="text/brightscript" uri="pkg:/source/identityStorage.brs" />
     <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
 </component>

--- a/dist/components/rum/RumCrashReporterTask.xml
+++ b/dist/components/rum/RumCrashReporterTask.xml
@@ -11,6 +11,7 @@
     <script type="text/brightscript" uri="pkg:/source/fileUtils.brs" />
     <script type="text/brightscript" uri="pkg:/source/internalLogger.brs" />
     <script type="text/brightscript" uri="pkg:/source/timeUtils.brs" />
+    <script type="text/brightscript" uri="pkg:/source/identityStorage.brs" />
     <script type="text/brightscript" uri="pkg:/source/rum/rumHelper.brs" />
     <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
 </component>

--- a/dist/components/rum/RumSessionScope.brs
+++ b/dist/components/rum/RumSessionScope.brs
@@ -16,6 +16,16 @@
 ' Initialize the component
 ' ----------------------------------------------------------------
 sub init()
+    ' Resolved once at init and immutable afterwards; cache it to avoid a
+    ' cross-thread global read on every event sent from this Task thread.
+    m.anonymousId = (function(m)
+            __bsConsequent = m.global.datadogAnonymousId
+            if __bsConsequent <> invalid then
+                return __bsConsequent
+            else
+                return ""
+            end if
+        end function)(m)
 end sub
 
 ' ----------------------------------------------------------------
@@ -251,7 +261,7 @@ sub sendVitalEvent(event as object, stepType as string, writer as object)
         }
         source: agentSource()
         type: "vital"
-        usr: m.global.datadogUserInfo
+        usr: getDatadogUserInfo(m.global.datadogUserInfo, m.anonymousId)
         version: rumContext.applicationVersion
         view: {
             id: viewId

--- a/dist/components/rum/RumSessionScope.xml
+++ b/dist/components/rum/RumSessionScope.xml
@@ -13,4 +13,5 @@
     <script type="text/brightscript" uri="pkg:/source/rum/rumHelper.brs" />
     <script type="text/brightscript" uri="pkg:/source/fileUtils.brs" />
     <script type="text/brightscript" uri="pkg:/source/datadogSdk.brs" />
+    <script type="text/brightscript" uri="pkg:/source/identityStorage.brs" />
 </component>

--- a/dist/components/rum/RumTelemetryScope.xml
+++ b/dist/components/rum/RumTelemetryScope.xml
@@ -10,5 +10,6 @@
     <script type="text/brightscript" uri="pkg:/source/fileUtils.brs" />
     <script type="text/brightscript" uri="pkg:/source/internalLogger.brs" />
     <script type="text/brightscript" uri="pkg:/source/datadogSdk.brs" />
+    <script type="text/brightscript" uri="pkg:/source/identityStorage.brs" />
     <script type="text/brightscript" uri="pkg:/source/bslib.brs" />
 </component>

--- a/dist/components/rum/RumViewScope.brs
+++ b/dist/components/rum/RumViewScope.brs
@@ -42,6 +42,16 @@ sub init()
             end if
         end function)(datadogRumContext)
     m.global.setField("datadogRumContext", datadogRumContext)
+    ' Resolved once at init and immutable afterwards; cache it to avoid a
+    ' cross-thread global read on every event sent from this Task thread.
+    m.anonymousId = (function(m)
+            __bsConsequent = m.global.datadogAnonymousId
+            if __bsConsequent <> invalid then
+                return __bsConsequent
+            else
+                return ""
+            end if
+        end function)(m)
 end sub
 
 ' ----------------------------------------------------------------
@@ -211,7 +221,7 @@ sub sendError(message as string, errorType as string, backtrace as dynamic, cont
         }
         source: agentSource()
         type: "error"
-        usr: m.global.datadogUserInfo
+        usr: getDatadogUserInfo(m.global.datadogUserInfo, m.anonymousId)
         version: rumContext.applicationVersion
         view: {
             id: m.viewId
@@ -313,7 +323,7 @@ sub sendCustomAction(target as string, context as object, writer as object)
         }
         source: agentSource()
         type: "action"
-        usr: m.global.datadogUserInfo
+        usr: getDatadogUserInfo(m.global.datadogUserInfo, m.anonymousId)
         version: rumContext.applicationVersion
         view: {
             id: m.viewId
@@ -408,7 +418,7 @@ sub sendResource(resource as object, context as object, writer as object)
         }
         source: agentSource()
         type: "resource"
-        usr: m.global.datadogUserInfo
+        usr: getDatadogUserInfo(m.global.datadogUserInfo, m.anonymousId)
         version: rumContext.applicationVersion
         view: {
             id: m.viewId
@@ -501,7 +511,7 @@ sub sendResourceError(status as string, url as dynamic, method as dynamic, conte
         }
         source: agentSource()
         type: "error"
-        usr: m.global.datadogUserInfo
+        usr: getDatadogUserInfo(m.global.datadogUserInfo, m.anonymousId)
         version: rumContext.applicationVersion
         view: {
             id: m.viewId
@@ -555,7 +565,7 @@ sub sendViewUpdate(context as object, writer as object)
         }
         source: agentSource()
         type: "view"
-        usr: m.global.datadogUserInfo
+        usr: getDatadogUserInfo(m.global.datadogUserInfo, m.anonymousId)
         version: rumContext.applicationVersion
         view: {
             id: m.viewId

--- a/dist/components/rum/RumViewScope.xml
+++ b/dist/components/rum/RumViewScope.xml
@@ -13,4 +13,5 @@
     <script type="text/brightscript" uri="pkg:/source/rum/rumHelper.brs" />
     <script type="text/brightscript" uri="pkg:/source/fileUtils.brs" />
     <script type="text/brightscript" uri="pkg:/source/datadogSdk.brs" />
+    <script type="text/brightscript" uri="pkg:/source/identityStorage.brs" />
 </component>

--- a/dist/source/datadogSdk.brs
+++ b/dist/source/datadogSdk.brs
@@ -1,6 +1,7 @@
 ' Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 ' This product includes software developed at Datadog (https://www.datadoghq.com/).
 ' Copyright 2022-Today Datadog, Inc.
+'import "pkg:/source/identityStorage.bs"
 
 ' ----------------------------------------------------------------
 ' Initializes the SDK
@@ -25,6 +26,11 @@
 '           - "tracecontext": W3C Trace Context header (cf: https://www.w3.org/TR/trace-context/)
 '           - "datadog": Datadog's `x-datadog-*` headers (cf: https://docs.datadoghq.com/real_user_monitoring/connect_rum_and_traces)
 '  - traceContextInjection (string) defines whether the trace context should be injected into all requests or only sampled ones.
+'  - trackAnonymousUser (boolean, optional) when `true` (default), enriches `usr` payloads with `anonymous_id`
+'     when the integrator hasn't supplied one via `datadogUserInfo`. The id is resolved at init time
+'     (read from the Roku registry — section `"datadog"`, key `"anonymous_id"` — or freshly generated and
+'     persisted on first launch) so it survives channel relaunches. Setting this to `false` clears any
+'     previously persisted id and disables enrichment.
 '  - ignoredExitEvents (array, optional) an array of exit status strings to ignore when detecting crashes.
 '     Any exit status NOT in this list will be reported as a crash. Defaults to:
 '     ["EXIT_UNKNOWN", "EXIT_POWER_MODE", "EXIT_IDLE_AUTO_EXIT", "EXIT_DIAL_DELETE", "EXIT_USER_KILL", "EXIT_USER_NAV"]
@@ -70,6 +76,30 @@ sub initialize(configuration as object, global as object)
         ddLogError("Trying to initialize the Datadog SDK without a Client Token, please check your configuration.")
         return
     end if
+    ' Resolve the anonymous id synchronously, before the RUM/Logs agents start,
+    ' so every consumer (including the RumAgent task) can read it without a race.
+    trackAnonymousUser = (function(configuration)
+            __bsConsequent = configuration.trackAnonymousUser
+            if __bsConsequent <> invalid then
+                return __bsConsequent
+            else
+                return true
+            end if
+        end function)(configuration)
+    anonymousId = ""
+    if (trackAnonymousUser)
+        anonymousId = readDatadogAnonymousId()
+        if (anonymousId = "")
+            anonymousId = CreateObject("roDeviceInfo").GetRandomUUID()
+            writeDatadogAnonymousId(anonymousId)
+        end if
+    else
+        clearDatadogAnonymousId()
+    end if
+    global.addFields({
+        datadogTrackAnonymousUser: trackAnonymousUser
+        datadogAnonymousId: anonymousId
+    })
     datadogUploader = global.datadogUploader
     if (datadogUploader = invalid)
         ddLogInfo("No uploader, creating one")
@@ -264,6 +294,35 @@ end function
 ' ----------------------------------------------------------------
 function channelVersion() as string
     return CreateObject("roAppInfo").GetVersion()
+end function
+
+' ----------------------------------------------------------------
+' Returns user info enriched with an anonymous id when applicable.
+' Mirrors browser SDK behavior: don't override user-provided `anonymous_id`.
+' Callers pass already-read values so this never touches the global node
+' itself: on a Task thread (e.g. RUM scopes) every `m.global` field read is a
+' cross-thread rendezvous, so `anonymousId` (resolved once at init and
+' immutable thereafter) is cached by the caller rather than re-read per event.
+' @param userInfo (object) the user info supplied via `datadogUserInfo` (may be invalid)
+' @param anonymousId (string) the resolved anonymous id, or "" when tracking is disabled
+' @return (object) user info object for event payloads
+' ----------------------------------------------------------------
+function getDatadogUserInfo(userInfo as object, anonymousId as string) as object
+    if (userInfo = invalid)
+        userInfo = {}
+    end if
+    if (userInfo.anonymous_id <> invalid and userInfo.anonymous_id <> "")
+        return userInfo
+    end if
+    if (anonymousId = invalid or anonymousId = "")
+        return userInfo
+    end if
+    enrichedUserInfo = {}
+    for each key in userInfo
+        enrichedUserInfo[key] = userInfo[key]
+    end for
+    enrichedUserInfo.anonymous_id = anonymousId
+    return enrichedUserInfo
 end function
 
 ' ----------------------------------------------------------------

--- a/dist/source/identityStorage.brs
+++ b/dist/source/identityStorage.brs
@@ -1,0 +1,49 @@
+' Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+' This product includes software developed at Datadog (https://www.datadoghq.com/).
+' Copyright 2022-Today Datadog, Inc.
+'import "pkg:/source/internalLogger.bs"
+' ****************************************************************
+' * Persistent storage for SDK identity values (anonymous_id, ...).
+' * Backed by the per-channel Roku registry.
+' ****************************************************************
+
+' ----------------------------------------------------------------
+' Reads the persisted Datadog anonymous id from the Roku registry.
+' @return (string) the stored value, or "" when absent.
+' ----------------------------------------------------------------
+function readDatadogAnonymousId() as string
+    section = CreateObject("roRegistrySection", "datadog")
+    if (section = invalid or not section.Exists("anonymous_id"))
+        return ""
+    end if
+    return section.Read("anonymous_id")
+end function
+
+' ----------------------------------------------------------------
+' Persists the Datadog anonymous id to the Roku registry so it
+' survives channel relaunches (browser-cookie equivalent).
+' @param anonymousId (string) the value to store.
+' ----------------------------------------------------------------
+sub writeDatadogAnonymousId(anonymousId as string)
+    section = CreateObject("roRegistrySection", "datadog")
+    if (section = invalid)
+        ddLogWarning("Unable to persist anonymous_id: registry section unavailable")
+        return
+    end if
+    section.Write("anonymous_id", anonymousId)
+    section.Flush()
+end sub
+
+' ----------------------------------------------------------------
+' Removes any persisted Datadog anonymous id from the Roku registry.
+' Called when anonymous user tracking is disabled, so the identifier
+' does not outlive the integrator's consent state.
+' ----------------------------------------------------------------
+sub clearDatadogAnonymousId()
+    section = CreateObject("roRegistrySection", "datadog")
+    if (section = invalid or not section.Exists("anonymous_id"))
+        return
+    end if
+    section.Delete("anonymous_id")
+    section.Flush()
+end sub

--- a/library/components/logs/LogsAgent.bs
+++ b/library/components/logs/LogsAgent.bs
@@ -133,7 +133,7 @@ sub sendLog(status as LogStatus, message as string, attributes as object)
         message: message,
         status: status,
         service: m.service,
-        usr: m.userInfo,
+        usr: getDatadogUserInfo(m.userInfo, m.anonymousId),
         device: {
             type: "tv",
             name: m.deviceName,
@@ -213,6 +213,9 @@ sub setupIfNeeded()
     m.userInfo = m.global.datadogUserInfo
     m.ddContext = m.global.datadogContext
     m.rumContext = m.global.datadogRumContext
+    ' Resolved once at init and immutable afterwards, so read it a single time
+    ' rather than on every log event.
+    m.anonymousId = m.global.datadogAnonymousId ?? ""
 
     m.isConfigured = true
 end sub

--- a/library/components/rum/RumActionScope.bs
+++ b/library/components/rum/RumActionScope.bs
@@ -24,6 +24,9 @@ sub init()
     datadogRumContext = m.global.datadogRumContext ?? {}
     datadogRumContext.actionId = m.actionId
     m.global.setField("datadogRumContext", datadogRumContext)
+    ' Resolved once at init and immutable afterwards; cache it to avoid a
+    ' cross-thread global read on every event sent from this Task thread.
+    m.anonymousId = m.global.datadogAnonymousId ?? ""
 end sub
 
 ' ----------------------------------------------------------------
@@ -149,7 +152,7 @@ sub sendAction(writer as object)
         },
         source: agentSource(),
         type: "action",
-        usr: m.global.datadogUserInfo,
+        usr: getDatadogUserInfo(m.global.datadogUserInfo, m.anonymousId),
         version: context.applicationVersion,
         view: {
             id: context.viewId,

--- a/library/components/rum/RumSessionScope.bs
+++ b/library/components/rum/RumSessionScope.bs
@@ -18,6 +18,9 @@ import "pkg:/source/rum/rumSessionState.bs"
 ' Initialize the component
 ' ----------------------------------------------------------------
 sub init()
+    ' Resolved once at init and immutable afterwards; cache it to avoid a
+    ' cross-thread global read on every event sent from this Task thread.
+    m.anonymousId = m.global.datadogAnonymousId ?? ""
 end sub
 
 ' ----------------------------------------------------------------
@@ -212,7 +215,7 @@ sub sendVitalEvent(event as object, stepType as string, writer as object)
         },
         source: agentSource(),
         type: "vital",
-        usr: m.global.datadogUserInfo,
+        usr: getDatadogUserInfo(m.global.datadogUserInfo, m.anonymousId),
         version: rumContext.applicationVersion,
         view: {
             id: viewId,

--- a/library/components/rum/RumViewScope.bs
+++ b/library/components/rum/RumViewScope.bs
@@ -30,6 +30,9 @@ sub init()
     datadogRumContext.viewId = m.viewId
     m.instanceId = datadogRumContext.instanceId ?? ""
     m.global.setField("datadogRumContext", datadogRumContext)
+    ' Resolved once at init and immutable afterwards; cache it to avoid a
+    ' cross-thread global read on every event sent from this Task thread.
+    m.anonymousId = m.global.datadogAnonymousId ?? ""
 end sub
 
 ' ----------------------------------------------------------------
@@ -198,7 +201,7 @@ sub sendError(message as string, errorType as string, backtrace as dynamic, cont
         },
         source: agentSource(),
         type: "error",
-        usr: m.global.datadogUserInfo,
+        usr: getDatadogUserInfo(m.global.datadogUserInfo, m.anonymousId),
         version: rumContext.applicationVersion,
         view: {
             id: m.viewId,
@@ -300,7 +303,7 @@ sub sendCustomAction(target as string, context as object, writer as object)
         },
         source: agentSource(),
         type: "action",
-        usr: m.global.datadogUserInfo,
+        usr: getDatadogUserInfo(m.global.datadogUserInfo, m.anonymousId),
         version: rumContext.applicationVersion,
         view: {
             id: m.viewId,
@@ -389,7 +392,7 @@ sub sendResource(resource as object, context as object, writer as object)
         },
         source: agentSource(),
         type: "resource",
-        usr: m.global.datadogUserInfo,
+        usr: getDatadogUserInfo(m.global.datadogUserInfo, m.anonymousId),
         version: rumContext.applicationVersion,
         view: {
             id: m.viewId,
@@ -469,7 +472,7 @@ sub sendResourceError(status as string, url as dynamic, method as dynamic, conte
         },
         source: agentSource(),
         type: "error",
-        usr: m.global.datadogUserInfo,
+        usr: getDatadogUserInfo(m.global.datadogUserInfo, m.anonymousId),
         version: rumContext.applicationVersion,
         view: {
             id: m.viewId,
@@ -525,7 +528,7 @@ sub sendViewUpdate(context as object, writer as object)
         },
         source: agentSource(),
         type: "view",
-        usr: m.global.datadogUserInfo,
+        usr: getDatadogUserInfo(m.global.datadogUserInfo, m.anonymousId),
         version: rumContext.applicationVersion,
         view: {
             id: m.viewId,

--- a/library/globals.md
+++ b/library/globals.md
@@ -1,6 +1,8 @@
-## This file tracks all the global states/nodes that are used by the Datadog SDK for Roku
+## This file tracks all the global states/nodes that are used by the Datadog SDK for Roku
 
 datadogUserInfo
 datadogContext
 datadogRumContext
 datadogUploader
+datadogAnonymousId
+datadogTrackAnonymousUser

--- a/library/source/datadogSdk.bs
+++ b/library/source/datadogSdk.bs
@@ -2,6 +2,8 @@
 ' This product includes software developed at Datadog (https://www.datadoghq.com/).
 ' Copyright 2022-Today Datadog, Inc.
 
+import "pkg:/source/identityStorage.bs"
+
 ' ----------------------------------------------------------------
 ' Initializes the SDK
 ' @param configuration (object) an Associative Array with the following fields
@@ -25,6 +27,11 @@
 '           - "tracecontext": W3C Trace Context header (cf: https://www.w3.org/TR/trace-context/)
 '           - "datadog": Datadog's `x-datadog-*` headers (cf: https://docs.datadoghq.com/real_user_monitoring/connect_rum_and_traces)
 '  - traceContextInjection (string) defines whether the trace context should be injected into all requests or only sampled ones.
+'  - trackAnonymousUser (boolean, optional) when `true` (default), enriches `usr` payloads with `anonymous_id`
+'     when the integrator hasn't supplied one via `datadogUserInfo`. The id is resolved at init time
+'     (read from the Roku registry — section `"datadog"`, key `"anonymous_id"` — or freshly generated and
+'     persisted on first launch) so it survives channel relaunches. Setting this to `false` clears any
+'     previously persisted id and disables enrichment.
 '  - ignoredExitEvents (array, optional) an array of exit status strings to ignore when detecting crashes.
 '     Any exit status NOT in this list will be reported as a crash. Defaults to:
 '     ["EXIT_UNKNOWN", "EXIT_POWER_MODE", "EXIT_IDLE_AUTO_EXIT", "EXIT_DIAL_DELETE", "EXIT_USER_KILL", "EXIT_USER_NAV"]
@@ -51,6 +58,24 @@ sub initialize(configuration as object, global as object)
         ddLogError("Trying to initialize the Datadog SDK without a Client Token, please check your configuration.")
         return
     end if
+
+    ' Resolve the anonymous id synchronously, before the RUM/Logs agents start,
+    ' so every consumer (including the RumAgent task) can read it without a race.
+    trackAnonymousUser = configuration.trackAnonymousUser ?? true
+    anonymousId = ""
+    if (trackAnonymousUser)
+        anonymousId = readDatadogAnonymousId()
+        if (anonymousId = "")
+            anonymousId = CreateObject("roDeviceInfo").GetRandomUUID()
+            writeDatadogAnonymousId(anonymousId)
+        end if
+    else
+        clearDatadogAnonymousId()
+    end if
+    global.addFields({
+        datadogTrackAnonymousUser: trackAnonymousUser,
+        datadogAnonymousId: anonymousId
+    })
 
     datadogUploader = global.datadogUploader
     if (datadogUploader = invalid)
@@ -232,6 +257,38 @@ end function
 ' ----------------------------------------------------------------
 function channelVersion() as string
     return CreateObject("roAppInfo").GetVersion()
+end function
+
+' ----------------------------------------------------------------
+' Returns user info enriched with an anonymous id when applicable.
+' Mirrors browser SDK behavior: don't override user-provided `anonymous_id`.
+' Callers pass already-read values so this never touches the global node
+' itself: on a Task thread (e.g. RUM scopes) every `m.global` field read is a
+' cross-thread rendezvous, so `anonymousId` (resolved once at init and
+' immutable thereafter) is cached by the caller rather than re-read per event.
+' @param userInfo (object) the user info supplied via `datadogUserInfo` (may be invalid)
+' @param anonymousId (string) the resolved anonymous id, or "" when tracking is disabled
+' @return (object) user info object for event payloads
+' ----------------------------------------------------------------
+function getDatadogUserInfo(userInfo as object, anonymousId as string) as object
+    if (userInfo = invalid)
+        userInfo = {}
+    end if
+
+    if (userInfo.anonymous_id <> invalid and userInfo.anonymous_id <> "")
+        return userInfo
+    end if
+
+    if (anonymousId = invalid or anonymousId = "")
+        return userInfo
+    end if
+
+    enrichedUserInfo = {}
+    for each key in userInfo
+        enrichedUserInfo[key] = userInfo[key]
+    end for
+    enrichedUserInfo.anonymous_id = anonymousId
+    return enrichedUserInfo
 end function
 
 ' ----------------------------------------------------------------

--- a/library/source/identityStorage.bs
+++ b/library/source/identityStorage.bs
@@ -1,0 +1,51 @@
+' Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+' This product includes software developed at Datadog (https://www.datadoghq.com/).
+' Copyright 2022-Today Datadog, Inc.
+
+import "pkg:/source/internalLogger.bs"
+
+' ****************************************************************
+' * Persistent storage for SDK identity values (anonymous_id, ...).
+' * Backed by the per-channel Roku registry.
+' ****************************************************************
+
+' ----------------------------------------------------------------
+' Reads the persisted Datadog anonymous id from the Roku registry.
+' @return (string) the stored value, or "" when absent.
+' ----------------------------------------------------------------
+function readDatadogAnonymousId() as string
+    section = CreateObject("roRegistrySection", "datadog")
+    if (section = invalid or not section.Exists("anonymous_id"))
+        return ""
+    end if
+    return section.Read("anonymous_id")
+end function
+
+' ----------------------------------------------------------------
+' Persists the Datadog anonymous id to the Roku registry so it
+' survives channel relaunches (browser-cookie equivalent).
+' @param anonymousId (string) the value to store.
+' ----------------------------------------------------------------
+sub writeDatadogAnonymousId(anonymousId as string)
+    section = CreateObject("roRegistrySection", "datadog")
+    if (section = invalid)
+        ddLogWarning("Unable to persist anonymous_id: registry section unavailable")
+        return
+    end if
+    section.Write("anonymous_id", anonymousId)
+    section.Flush()
+end sub
+
+' ----------------------------------------------------------------
+' Removes any persisted Datadog anonymous id from the Roku registry.
+' Called when anonymous user tracking is disabled, so the identifier
+' does not outlive the integrator's consent state.
+' ----------------------------------------------------------------
+sub clearDatadogAnonymousId()
+    section = CreateObject("roRegistrySection", "datadog")
+    if (section = invalid or not section.Exists("anonymous_id"))
+        return
+    end if
+    section.Delete("anonymous_id")
+    section.Flush()
+end sub

--- a/test/components/TestRunner.bs
+++ b/test/components/TestRunner.bs
@@ -15,6 +15,7 @@ import "pkg:/source/tests/Test__fileUtils.bs"
 import "pkg:/source/tests/Test__internalLogger.bs"
 import "pkg:/source/tests/Test__timeUtils.bs"
 import "pkg:/source/tests/Test__datadog.bs"
+import "pkg:/source/tests/Test__identityStorage.bs"
 import "pkg:/source/tests/Test__DdUrlTransfer.bs"
 import "pkg:/source/tests/core/Test__MultitrackUploaderTask.bs"
 import "pkg:/source/tests/core/Test__WriterTask.bs"
@@ -24,12 +25,12 @@ import "pkg:/source/tests/rum/Test__RumAgent.bs"
 import "pkg:/source/tests/rum/Test__RumApplicationScope.bs"
 import "pkg:/source/tests/rum/Test__RumSessionScope.bs"
 import "pkg:/source/tests/rum/Test__RumViewScope.bs"
-import "pkg:/source/tests/rum/Test__RumViewScope.bs"
 import "pkg:/source/tests/rum/Test__RumTelemetryScope.bs"
 import "pkg:/source/tests/rum/Test__RumCrashReporterTask.bs"
 
 import "pkg:/source/roku_modules/datadogroku/datadogSdk.brs"
 import "pkg:/source/roku_modules/datadogroku/fileUtils.brs"
+import "pkg:/source/roku_modules/datadogroku/identityStorage.brs"
 import "pkg:/source/roku_modules/datadogroku/internalLogger.brs"
 import "pkg:/source/roku_modules/datadogroku/timeUtils.brs"
 import "pkg:/source/roku_modules/datadogroku/wrapper/DdUrlTransfer.brs"
@@ -54,6 +55,7 @@ sub runTests()
     Runner.SetFunctions([
         ' Core
         TestSuite__Datadog,
+        TestSuite__IdentityStorage,
         TestSuite__DdUrlTransfer,
         TestSuite__FileUtils,
         TestSuite__InternalLogger,

--- a/test/source/tests/Test__datadog.bs
+++ b/test/source/tests/Test__datadog.bs
@@ -26,6 +26,13 @@ function TestSuite__Datadog() as object
     this.addTest("WhenInitialize_WithNoIgnoredExitEvents_ThenDefaultIsSetInGlobal", DatadogTest__WhenInitialize_WithNoIgnoredExitEvents_ThenDefaultIsSetInGlobal)
     this.addTest("WhenInitialize_WithCustomIgnoredExitEvents_ThenCustomIsSetInGlobal", DatadogTest__WhenInitialize_WithCustomIgnoredExitEvents_ThenCustomIsSetInGlobal)
     this.addTest("WhenInitialize_WithEmptyIgnoredExitEvents_ThenEmptyListIsSetInGlobal", DatadogTest__WhenInitialize_WithEmptyIgnoredExitEvents_ThenEmptyListIsSetInGlobal)
+    this.addTest("WhenInitialize_WithTrackAnonymousUserDisabled_ThenClearPersistedAnonymousId", DatadogTest__WhenInitialize_WithTrackAnonymousUserDisabled_ThenClearPersistedAnonymousId)
+    this.addTest("WhenInitialize_WithEmptyRegistry_ThenGenerateAndPersistAnonymousId", DatadogTest__WhenInitialize_WithEmptyRegistry_ThenGenerateAndPersistAnonymousId)
+    this.addTest("WhenInitialize_WithRegistryValue_ThenReuseAnonymousId", DatadogTest__WhenInitialize_WithRegistryValue_ThenReuseAnonymousId)
+    this.addTest("WhenGetDatadogUserInfo_ThenIncludesAnonymousIdFromGlobal", DatadogTest__WhenGetDatadogUserInfo_ThenIncludesAnonymousIdFromGlobal)
+    this.addTest("WhenGetDatadogUserInfo_WithExistingAnonymousId_ThenKeepUserValue", DatadogTest__WhenGetDatadogUserInfo_WithExistingAnonymousId_ThenKeepUserValue)
+    this.addTest("WhenGetDatadogUserInfo_WithEmptyAnonymousId_ThenDoNotEnrich", DatadogTest__WhenGetDatadogUserInfo_WithEmptyAnonymousId_ThenDoNotEnrich)
+    this.addTest("WhenGetDatadogUserInfo_WithInvalidUserInfo_ThenEnrichEmpty", DatadogTest__WhenGetDatadogUserInfo_WithInvalidUserInfo_ThenEnrichEmpty)
 
     this.addTest("WhenGetEndpointStaging_ThenCreateEndpoint", DatadogTest__WhenGetEndpointStaging_ThenCreateEndpoint)
 
@@ -196,6 +203,78 @@ function DatadogTest__WhenGetEndpointRumUnknown_ThenCreateEndpoint() as string
 
     ' Then
     Assert.that(endpoint).isEqualTo("")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: user info without anonymous_id and a resolved anonymous id
+'  When: retrieving Datadog user info for payloads
+'  Then: enrich a copy with anonymous_id, leaving the input untouched
+'----------------------------------------------------------------
+function DatadogTest__WhenGetDatadogUserInfo_ThenIncludesAnonymousIdFromGlobal() as string
+    ' Given
+    fakeAnonymousId = IG_GetString(32)
+    fakeUserInfo = { id: IG_GetString(16) }
+
+    ' When
+    userInfo = datadogroku_getDatadogUserInfo(fakeUserInfo, fakeAnonymousId)
+
+    ' Then
+    Assert.that(userInfo.id).isEqualTo(fakeUserInfo.id)
+    Assert.that(userInfo.anonymous_id).isEqualTo(fakeAnonymousId)
+    ' the original must not be mutated (shared global state)
+    Assert.that(fakeUserInfo.anonymous_id).isInvalid()
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: user info with an explicit anonymous_id and a resolved anonymous id
+'  When: retrieving Datadog user info for payloads
+'  Then: keeps explicit user value
+'----------------------------------------------------------------
+function DatadogTest__WhenGetDatadogUserInfo_WithExistingAnonymousId_ThenKeepUserValue() as string
+    ' Given
+    fakeUserInfo = { id: IG_GetString(16), anonymous_id: "user-defined-anon" }
+
+    ' When
+    userInfo = datadogroku_getDatadogUserInfo(fakeUserInfo, IG_GetString(32))
+
+    ' Then
+    Assert.that(userInfo.anonymous_id).isEqualTo("user-defined-anon")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: anonymous tracking disabled (empty anonymous id)
+'  When: retrieving Datadog user info for payloads
+'  Then: does not add anonymous_id
+'----------------------------------------------------------------
+function DatadogTest__WhenGetDatadogUserInfo_WithEmptyAnonymousId_ThenDoNotEnrich() as string
+    ' Given
+    fakeUserInfo = { id: IG_GetString(16) }
+
+    ' When
+    userInfo = datadogroku_getDatadogUserInfo(fakeUserInfo, "")
+
+    ' Then
+    Assert.that(userInfo.anonymous_id).isInvalid()
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: invalid user info (never set by the integrator)
+'  When: retrieving Datadog user info for payloads
+'  Then: returns an object enriched with the anonymous id, no crash
+'----------------------------------------------------------------
+function DatadogTest__WhenGetDatadogUserInfo_WithInvalidUserInfo_ThenEnrichEmpty() as string
+    ' Given
+    fakeAnonymousId = IG_GetString(32)
+
+    ' When
+    userInfo = datadogroku_getDatadogUserInfo(invalid, fakeAnonymousId)
+
+    ' Then
+    Assert.that(userInfo.anonymous_id).isEqualTo(fakeAnonymousId)
     return ""
 end function
 
@@ -401,3 +480,99 @@ function DatadogTest__WhenInitialize_WithEmptyIgnoredExitEvents_ThenEmptyListIsS
     return ""
 end function
 
+'----------------------------------------------------------------
+' Given: a previously persisted anonymous id in the registry
+'  When: initializing the SDK with `trackAnonymousUser: false`
+'  Then: the persisted id is removed from the registry, honoring
+'        the integrator's consent-withdrawal signal
+'----------------------------------------------------------------
+function DatadogTest__WhenInitialize_WithTrackAnonymousUserDisabled_ThenClearPersistedAnonymousId() as string
+    ' Given
+    fakeAnonymousId = IG_GetString(32)
+    section = CreateObject("roRegistrySection", "datadog")
+    section.Write("anonymous_id", fakeAnonymousId)
+    section.Flush()
+    configuration = {
+        clientToken: IG_GetString(16),
+        applicationId: IG_GetString(16),
+        site: "us1",
+        env: IG_GetString(16),
+        trackAnonymousUser: false
+    }
+
+    ' When
+    fakeGlobal = CreateObject("roSGNode", "ContentNode")
+    datadogroku_initialize(configuration, fakeGlobal)
+
+    ' Then
+    Assert.that(fakeGlobal.getField("datadogTrackAnonymousUser")).isFalse()
+    persistedSection = CreateObject("roRegistrySection", "datadog")
+    Assert.that(persistedSection.Exists("anonymous_id")).isFalse()
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: an empty registry section
+'  When: initializing the SDK with anonymous tracking enabled
+'  Then: generates a new anonymous id and persists it to the registry
+'----------------------------------------------------------------
+function DatadogTest__WhenInitialize_WithEmptyRegistry_ThenGenerateAndPersistAnonymousId() as string
+    ' Given
+    section = CreateObject("roRegistrySection", "datadog")
+    if (section.Exists("anonymous_id"))
+        section.Delete("anonymous_id")
+        section.Flush()
+    end if
+    configuration = {
+        clientToken: IG_GetString(16),
+        applicationId: IG_GetString(16),
+        site: "us1",
+        env: IG_GetString(16)
+    }
+
+    ' When
+    fakeGlobal = CreateObject("roSGNode", "ContentNode")
+    datadogroku_initialize(configuration, fakeGlobal)
+
+    ' Then
+    generatedAnonymousId = fakeGlobal.getField("datadogAnonymousId")
+    Assert.that(generatedAnonymousId).isNotEmpty()
+    persistedSection = CreateObject("roRegistrySection", "datadog")
+    Assert.that(persistedSection.Read("anonymous_id")).isEqualTo(generatedAnonymousId)
+
+    ' Cleanup
+    persistedSection.Delete("anonymous_id")
+    persistedSection.Flush()
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a value pre-existing in the registry from a prior channel launch
+'  When: initializing the SDK with anonymous tracking enabled
+'  Then: reuses the persisted anonymous id rather than generating a new one
+'----------------------------------------------------------------
+function DatadogTest__WhenInitialize_WithRegistryValue_ThenReuseAnonymousId() as string
+    ' Given
+    fakeAnonymousId = IG_GetString(32)
+    section = CreateObject("roRegistrySection", "datadog")
+    section.Write("anonymous_id", fakeAnonymousId)
+    section.Flush()
+    configuration = {
+        clientToken: IG_GetString(16),
+        applicationId: IG_GetString(16),
+        site: "us1",
+        env: IG_GetString(16)
+    }
+
+    ' When
+    fakeGlobal = CreateObject("roSGNode", "ContentNode")
+    datadogroku_initialize(configuration, fakeGlobal)
+
+    ' Then
+    Assert.that(fakeGlobal.getField("datadogAnonymousId")).isEqualTo(fakeAnonymousId)
+
+    ' Cleanup
+    section.Delete("anonymous_id")
+    section.Flush()
+    return ""
+end function

--- a/test/source/tests/Test__identityStorage.bs
+++ b/test/source/tests/Test__identityStorage.bs
@@ -1,0 +1,101 @@
+' Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+' This product includes software developed at Datadog (https://www.datadoghq.com/).
+' Copyright 2022-Today Datadog, Inc.
+
+'----------------------------------------------------------------
+' Main setup function.
+' @return (object) a configured TestSuite object.
+'----------------------------------------------------------------
+function TestSuite__IdentityStorage() as object
+    this = BaseTestSuite()
+    this.Name = "IdentityStorage"
+
+    this.addTest("WhenWriteAnonymousId_ThenReadReturnsValue", IdentityStorageTest__WhenWriteAnonymousId_ThenReadReturnsValue, IdentityStorageTest__SetUp, IdentityStorageTest__TearDown)
+    this.addTest("WhenRegistryEmpty_ThenReadReturnsEmptyString", IdentityStorageTest__WhenRegistryEmpty_ThenReadReturnsEmptyString, IdentityStorageTest__SetUp, IdentityStorageTest__TearDown)
+    this.addTest("WhenClearAnonymousId_ThenValueRemoved", IdentityStorageTest__WhenClearAnonymousId_ThenValueRemoved, IdentityStorageTest__SetUp, IdentityStorageTest__TearDown)
+    this.addTest("WhenClearWithEmptyRegistry_ThenDoesNotCrash", IdentityStorageTest__WhenClearWithEmptyRegistry_ThenDoesNotCrash, IdentityStorageTest__SetUp, IdentityStorageTest__TearDown)
+
+    return this
+end function
+
+'----------------------------------------------------------------
+' Removes any leftover anonymous_id so each test starts from a known state.
+'----------------------------------------------------------------
+sub IdentityStorageTest__RemoveAnonymousId()
+    section = CreateObject("roRegistrySection", "datadog")
+    if (section.Exists("anonymous_id"))
+        section.Delete("anonymous_id")
+        section.Flush()
+    end if
+end sub
+
+sub IdentityStorageTest__SetUp()
+    IdentityStorageTest__RemoveAnonymousId()
+end sub
+
+sub IdentityStorageTest__TearDown()
+    IdentityStorageTest__RemoveAnonymousId()
+end sub
+
+'----------------------------------------------------------------
+' Given: an anonymous id written to the registry
+'  When: reading it back
+'  Then: returns the stored value
+'----------------------------------------------------------------
+function IdentityStorageTest__WhenWriteAnonymousId_ThenReadReturnsValue() as string
+    ' Given
+    fakeAnonymousId = IG_GetString(32)
+
+    ' When
+    datadogroku_writeDatadogAnonymousId(fakeAnonymousId)
+
+    ' Then
+    Assert.that(datadogroku_readDatadogAnonymousId()).isEqualTo(fakeAnonymousId)
+    section = CreateObject("roRegistrySection", "datadog")
+    Assert.that(section.Read("anonymous_id")).isEqualTo(fakeAnonymousId)
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: no persisted anonymous id
+'  When: reading it
+'  Then: returns an empty string
+'----------------------------------------------------------------
+function IdentityStorageTest__WhenRegistryEmpty_ThenReadReturnsEmptyString() as string
+    ' Then
+    Assert.that(datadogroku_readDatadogAnonymousId()).isEqualTo("")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a persisted anonymous id
+'  When: clearing it
+'  Then: the value is removed from the registry
+'----------------------------------------------------------------
+function IdentityStorageTest__WhenClearAnonymousId_ThenValueRemoved() as string
+    ' Given
+    datadogroku_writeDatadogAnonymousId(IG_GetString(32))
+
+    ' When
+    datadogroku_clearDatadogAnonymousId()
+
+    ' Then
+    section = CreateObject("roRegistrySection", "datadog")
+    Assert.that(section.Exists("anonymous_id")).isFalse()
+    Assert.that(datadogroku_readDatadogAnonymousId()).isEqualTo("")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: no persisted anonymous id
+'  When: clearing it
+'  Then: does not crash (idempotent)
+'----------------------------------------------------------------
+function IdentityStorageTest__WhenClearWithEmptyRegistry_ThenDoesNotCrash() as string
+    ' When
+    datadogroku_clearDatadogAnonymousId()
+
+    ' Then
+    Assert.that(datadogroku_readDatadogAnonymousId()).isEqualTo("")
+    return ""
+end function

--- a/test/source/tests/logs/Test__LogsAgent.bs
+++ b/test/source/tests/logs/Test__LogsAgent.bs
@@ -14,6 +14,8 @@ function TestSuite__LogsAgent() as object
     this.addTest("WhenLogOkWithCustomAttributes_ThenWriteLog", LogsAgentTest__WhenLogOkWithCustomAttributes_ThenWriteLog, LogsAgentTest__SetUp, LogsAgentTest__TearDown)
     this.addTest("WhenLogOkWithGlobalAttributes_ThenWriteLog", LogsAgentTest__WhenLogOkWithGlobalAttributes_ThenWriteLog, LogsAgentTest__SetUp, LogsAgentTest__TearDown)
     this.addTest("WhenLogOkWithUserInfo_ThenWriteLog", LogsAgentTest__WhenLogOkWithUserInfo_ThenWriteLog, LogsAgentTest__SetUp, LogsAgentTest__TearDown)
+    this.addTest("WhenLogOkWithAnonymousIdInGlobal_ThenWriteLogWithUserAnonymousId", LogsAgentTest__WhenLogOkWithAnonymousIdInGlobal_ThenWriteLogWithUserAnonymousId, LogsAgentTest__SetUp, LogsAgentTest__TearDown)
+    this.addTest("WhenLogOkWithExistingUserAnonymousId_ThenPreserveUserAnonymousId", LogsAgentTest__WhenLogOkWithExistingUserAnonymousId_ThenPreserveUserAnonymousId, LogsAgentTest__SetUp, LogsAgentTest__TearDown)
     this.addTest("WhenLogOkWithRumContext_ThenWriteLog", LogsAgentTest__WhenLogOkWithRumContext_ThenWriteLog, LogsAgentTest__SetUp, LogsAgentTest__TearDown)
 
     this.addTest("WhenLogDebug_ThenWriteLog", LogsAgentTest__WhenLogDebug_ThenWriteLog, LogsAgentTest__SetUp, LogsAgentTest__TearDown)
@@ -98,10 +100,11 @@ sub LogsAgentTest__SetUp()
         m.testSuite.fakeGlobalContext[IG_GetString(16) + i.toStr()] = IG_GetOneOf([IG_GetString(12), IG_GetInteger(), IG_GetFloat(), IG_GetBoolean()])
         m.testSuite.fakeGlobalUserInfo[IG_GetString(16) + i.toStr()] = IG_GetOneOf([IG_GetString(12), IG_GetInteger(), IG_GetFloat(), IG_GetBoolean()])
     end for
-    m.testSuite.global.addFields({ datadogContext: {}, datadogUserInfo: {}, datadogRumContext: {} })
+    m.testSuite.global.addFields({ datadogContext: {}, datadogUserInfo: {}, datadogRumContext: {}, datadogAnonymousId: "" })
     m.testSuite.global.setField("datadogContext", {})
     m.testSuite.global.setField("datadogUserInfo", {})
     m.testSuite.global.setField("datadogRumContext", {})
+    m.testSuite.global.setField("datadogAnonymousId", "")
 
     ' Tested Task
     m.testSuite.testedNode = CreateObject("roSGNode", "datadogroku_LogsAgent")
@@ -144,10 +147,11 @@ sub LogsAgentTest__SetUpNoMock()
         m.testSuite.fakeGlobalContext[IG_GetString(16) + i.toStr()] = IG_GetOneOf([IG_GetString(12), IG_GetInteger(), IG_GetFloat(), IG_GetBoolean()])
         m.testSuite.fakeGlobalUserInfo[IG_GetString(16) + i.toStr()] = IG_GetOneOf([IG_GetString(12), IG_GetInteger(), IG_GetFloat(), IG_GetBoolean()])
     end for
-    m.testSuite.global.addFields({ datadogContext: {}, datadogUserInfo: {}, datadogRumContext: {} })
+    m.testSuite.global.addFields({ datadogContext: {}, datadogUserInfo: {}, datadogRumContext: {}, datadogAnonymousId: "" })
     m.testSuite.global.setField("datadogContext", {})
     m.testSuite.global.setField("datadogUserInfo", {})
     m.testSuite.global.setField("datadogRumContext", {})
+    m.testSuite.global.setField("datadogAnonymousId", "")
 
     ' Tested Task
     m.testSuite.testedNode = CreateObject("roSGNode", "datadogroku_LogsAgent")
@@ -330,6 +334,53 @@ function LogsAgentTest__WhenLogOkWithUserInfo_ThenWriteLog() as string
     Assert.that(logEvent.logger.version).isEqualTo(datadogroku_sdkVersion())
     Assert.that(logEvent.logger.thread_name).isEqualTo("TestRunner")
     Assert.that(logEvent.usr).isEqualTo(m.fakeGlobalUserInfo)
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a LogsAgent with user info and a resolved datadogAnonymousId
+'  When: call the log ok
+'  Then: writes a log with usr.anonymous_id
+'----------------------------------------------------------------
+function LogsAgentTest__WhenLogOkWithAnonymousIdInGlobal_ThenWriteLogWithUserAnonymousId() as string
+    ' Given
+    fakeMessage = IG_GetString(32)
+    fakeAnonymousId = IG_GetString(32)
+    m.global.setField("datadogUserInfo", m.fakeGlobalUserInfo)
+    m.global.setField("datadogAnonymousId", fakeAnonymousId)
+
+    ' When
+    m.testedNode@.logOk(fakeMessage, {})
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    logEvent = ParseJson(updates[0])
+    Assert.that(logEvent.usr.id).isEqualTo(m.fakeGlobalUserInfo.id)
+    Assert.that(logEvent.usr.anonymous_id).isEqualTo(fakeAnonymousId)
+    Assert.that(m.global.datadogUserInfo.anonymous_id).isInvalid()
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a LogsAgent with both a user-provided and SDK-resolved anonymous id
+'  When: call the log ok
+'  Then: preserves user-provided anonymous_id
+'----------------------------------------------------------------
+function LogsAgentTest__WhenLogOkWithExistingUserAnonymousId_ThenPreserveUserAnonymousId() as string
+    ' Given
+    fakeMessage = IG_GetString(32)
+    fakeUserAnonymousId = IG_GetString(32)
+    m.fakeGlobalUserInfo.anonymous_id = fakeUserAnonymousId
+    m.global.setField("datadogUserInfo", m.fakeGlobalUserInfo)
+    m.global.setField("datadogAnonymousId", IG_GetString(32))
+
+    ' When
+    m.testedNode@.logOk(fakeMessage, {})
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    logEvent = ParseJson(updates[0])
+    Assert.that(logEvent.usr.anonymous_id).isEqualTo(fakeUserAnonymousId)
     return ""
 end function
 

--- a/test/source/tests/rum/Test__RumViewScope.bs
+++ b/test/source/tests/rum/Test__RumViewScope.bs
@@ -67,6 +67,7 @@ function TestSuite__RumViewScope() as object
     this.addTest("WhenHandleKeepAliveEvent_ThenWriteViewUpdate", RumViewScopeTest__WhenHandleKeepAliveEvent_ThenWriteViewUpdate, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
     this.addTest("WhenHandleKeepAliveEventWithContext_ThenWriteViewUpdate", RumViewScopeTest__WhenHandleKeepAliveEventWithContext_ThenWriteViewUpdate, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
     this.addTest("WhenHandleKeepAliveEventWithUserInfo_ThenWriteViewUpdate", RumViewScopeTest__WhenHandleKeepAliveEventWithUserInfo_ThenWriteViewUpdate, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
+    this.addTest("WhenHandleKeepAliveEventWithAnonymousId_ThenWriteViewUpdateWithAnonymousId", RumViewScopeTest__WhenHandleKeepAliveEventWithAnonymousId_ThenWriteViewUpdateWithAnonymousId, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
 
     return this
 end function
@@ -102,7 +103,7 @@ sub RumViewScopeTest__SetUp()
         m.testSuite.fakeLocalContext[IG_GetString(16) + i.toStr()] = IG_GetOneOf([IG_GetString(12), IG_GetInteger(), IG_GetFloat(), IG_GetBoolean()])
         m.testSuite.fakeGlobalUserInfo[IG_GetString(16) + i.toStr()] = IG_GetOneOf([IG_GetString(12), IG_GetInteger(), IG_GetFloat(), IG_GetBoolean()])
     end for
-    m.testSuite.global.addFields({ datadogContext: {}, datadogUserInfo: {}, datadogRumContext: {} })
+    m.testSuite.global.addFields({ datadogContext: {}, datadogUserInfo: {}, datadogRumContext: {}, datadogAnonymousId: "" })
     m.testSuite.global.setField("datadogRumContext", { instanceId: m.testSuite.fakeInstanceId })
 
     ' Filesystem
@@ -2818,5 +2819,48 @@ function RumViewScopeTest__WhenHandleKeepAliveEventWithUserInfo_ThenWriteViewUpd
     Assert.that(viewEvent.view.error.count).isEqualTo(0)
     Assert.that(viewEvent.view.resource.count).isEqualTo(0)
     Assert.that(viewEvent.usr).isEqualTo(m.fakeGlobalUserInfo)
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a RumViewScope created with a resolved datadogAnonymousId
+'  When: handling an event (keep alive)
+'  Then: enriches usr with the anonymous_id, without mutating the global
+'----------------------------------------------------------------
+function RumViewScopeTest__WhenHandleKeepAliveEventWithAnonymousId_ThenWriteViewUpdateWithAnonymousId() as string
+    ' Given
+    fakeAnonymousId = IG_GetString(32)
+    fakeParentContext = {
+        applicationId: IG_GetString(32),
+        service: IG_GetString(32),
+        sessionId: IG_GetString(32),
+        applicationVersion: IG_GetString(32),
+        deviceName: m.fakeDeviceName,
+        deviceModel: m.fakeDeviceModel,
+        osVersion: m.fakeOsVersion,
+        osVersionMajor: m.fakeOsVersionMajor
+    }
+    m.mockParentScope@.stubCall("getRumContext", {}, fakeParentContext)
+    m.global.setField("datadogUserInfo", m.fakeGlobalUserInfo)
+    m.global.setField("datadogAnonymousId", fakeAnonymousId)
+    ' anonymousId is cached at scope init, so create the scope after setting it
+    testedScope = CreateObject("roSGNode", "datadogroku_RumViewScope")
+    testedScope.parentScope = m.mockParentScope
+    testedScope.viewName = m.fakeViewName
+    testedScope.viewUrl = m.fakeViewUrl
+    testedScope.context = m.fakeInitialContext
+    fakeEvent = { mock: "event", eventType: "keepAlive" }
+
+    ' When
+    testedScope@.handleEvent(fakeEvent, m.mockWriter)
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    Assert.that(updates).hasSize(1)
+    viewEvent = ParseJson(updates[0])
+    Assert.that(viewEvent.usr.id).isEqualTo(m.fakeGlobalUserInfo.id)
+    Assert.that(viewEvent.usr.anonymous_id).isEqualTo(fakeAnonymousId)
+    ' the shared global user info must not be mutated
+    Assert.that(m.global.datadogUserInfo.anonymous_id).isInvalid()
     return ""
 end function


### PR DESCRIPTION
> Supersedes #145 by @asdftamir: opened here internally so the CI and Codex review can run.

### What does this PR do?

Adds browser-SDK-style `anonymous_id` enrichment to the Roku SDK so RUM and Logs events can be tied back to a stable, anonymous device identity across both sessions and channel launches.

- New `trackAnonymousUser` init configuration flag (default `true`).
- At init time, if no `anonymous_id` is persisted in the Roku registry (section `"datadog"`, key `"anonymous_id"`), generate one via `roDeviceInfo.GetRandomUUID()` and persist it back to the registry. This mirrors browser-sdk's cookie behavior — the id survives channel relaunches and reboots, scoped per-channel.
- When `trackAnonymousUser: false` is passed at init, any previously persisted `anonymous_id` is removed from the registry so the identifier does not outlive the integrator's consent signal.
- New `getDatadogUserInfo(global)` helper enriches `usr` payloads with `anonymous_id` only when not already set by the user, and only when tracking is enabled.
- All `usr:` payload builders in Logs and RUM (view, action, error, resource, vital) now go through the helper.
- New `library/source/identityStorage.bs` module wraps registry read/write/delete so future identity values can be persisted the same way.

### Motivation

Mirror the behavior already shipped in [`browser-sdk`](https://github.com/DataDog/browser-sdk) so anonymous Roku sessions are attributable and consistent with other Datadog SDKs. The same precedence rules apply: a user-provided `anonymous_id` always wins over the SDK-generated one, and explicit user opt-out (`trackAnonymousUser: false`) disables enrichment entirely and clears any persisted id. Persistence in the Roku registry is the closest analogue to a browser cookie: per-channel-sandboxed, survives reboots.

### Additional Notes

- Tests added in `test/source/tests/Test__datadog.bs` cover the three precedence cases (enrich, preserve user value, opt-out) plus registry cleanup on `trackAnonymousUser: false`.
- Tests in `test/source/tests/logs/Test__LogsAgent.bs` verify the helper is wired into log payloads.
- Tests in `test/source/tests/rum/Test__datadog.bs` cover registry reuse (`WhenInitialize_WithRegistryValue_ThenReuseAnonymousId`) and first-launch generation/persistence (`WhenInitialize_WithEmptyRegistry_ThenGenerateAndPersistAnonymousId`). The shared `TearDown` clears the registry key for isolation.
- `dist/` is regenerated and included in the commits, consistent with the repo's existing workflow.
- No linked Issue yet — happy to open one if the team prefers per CONTRIBUTING.md.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)