### PR TITLE
RUM-16284: Cache `lastExitConsoleLog` in `RumCrashReporterTask`

### DIFF
--- a/dist/components/rum/RumAgent.brs
+++ b/dist/components/rum/RumAgent.brs
@@ -91,7 +91,7 @@ sub setup()
     m.configuration = fields.configuration
     ' 2. Create internal scopes
     m.instanceId = CreateObject("roDeviceInfo").GetRandomUUID()
-    ddLogWarning("RumAgent.instanceId:" + m.instanceId)
+    ddLogVerbose("RumAgent.instanceId:" + m.instanceId)
     m.global.addFields({
         datadogRumContext: {
             applicationId: m.applicationId

--- a/dist/components/rum/RumCrashReporterTask.brs
+++ b/dist/components/rum/RumCrashReporterTask.brs
@@ -43,7 +43,9 @@ sub sendCrashReport()
             end if
         end for
     end if
-    if (not keep)
+    if (keep)
+        m.lastExitConsoleLog = m.top.lastExitConsoleLog
+    else
         ddLogInfo("Last exit status " + m.lastExitOrTerminationReason + " is not a crash, ignoring")
     end if
     folderPath = trackFolderPath("rum")
@@ -103,7 +105,7 @@ sub sendCrashReportFromViewEventFile(filepath as string)
         application: {
             id: lastViewEvent.application.id
         }
-        context: m.global.datadogContext
+        context: lastViewEvent.context
         date: timestamp&
         error: {
             id: CreateObject("roDeviceInfo").GetRandomUUID()
@@ -111,7 +113,7 @@ sub sendCrashReportFromViewEventFile(filepath as string)
             message: "Channel stopped unexpectedly"
             source: "source"
             source_type: agentSource()
-            stack: m.top.lastExitConsoleLog
+            stack: m.lastExitConsoleLog
             type: m.lastExitOrTerminationReason
         }
         service: lastViewEvent.service

--- a/library/components/rum/RumAgent.bs
+++ b/library/components/rum/RumAgent.bs
@@ -97,7 +97,7 @@ sub setup()
 
     ' 2. Create internal scopes
     m.instanceId = CreateObject("roDeviceInfo").GetRandomUUID()
-    ddLogWarning("RumAgent.instanceId:" + m.instanceId)
+    ddLogVerbose("RumAgent.instanceId:" + m.instanceId)
     m.global.addFields({
         datadogRumContext: {
             applicationId: m.applicationId,

--- a/library/components/rum/RumCrashReporterTask.bs
+++ b/library/components/rum/RumCrashReporterTask.bs
@@ -40,7 +40,9 @@ sub sendCrashReport()
         end for
     end if
 
-    if (not keep)
+    if (keep)
+        m.lastExitConsoleLog = m.top.lastExitConsoleLog
+    else
         ddLogInfo("Last exit status " + m.lastExitOrTerminationReason + " is not a crash, ignoring")
     end if
 
@@ -95,7 +97,7 @@ sub sendCrashReportFromViewEventFile(filepath as string)
         application: {
             id: lastViewEvent.application.id
         },
-        context: m.global.datadogContext,
+        context: lastViewEvent.context,
         date: timestamp&,
         error: {
             id: CreateObject("roDeviceInfo").GetRandomUUID(),
@@ -103,7 +105,7 @@ sub sendCrashReportFromViewEventFile(filepath as string)
             message: "Channel stopped unexpectedly",
             source: "source",
             source_type: agentSource(),
-            stack: m.top.lastExitConsoleLog,
+            stack: m.lastExitConsoleLog,
             type: m.lastExitOrTerminationReason
         },
         service: lastViewEvent.service,

--- a/test/source/tests/rum/Test__RumCrashReporterTask.bs
+++ b/test/source/tests/rum/Test__RumCrashReporterTask.bs
@@ -150,6 +150,7 @@ function RumCrashReporterTaskTest__WhenReasonIsValid_ThenWriteErrorAndViewEvents
     Assert.that(errorEvent.error.stack).isEqualTo("")
     Assert.that(errorEvent.error.is_crash).isEqualTo(true)
     Assert.that(errorEvent.error.type).isEqualTo(fakeExitStatus)
+    Assert.that(errorEvent.context).isEqualTo(fakePreviousViewEvent.context)
 
     viewEvent = ParseJson(updates[1])
     Assert.that(viewEvent).isNotInvalid()
@@ -257,6 +258,7 @@ function RumCrashReporterTaskTest__WhenReasonIsValid_ThenWriteErrorWithStackAndV
     Assert.that(errorEvent.error.stack).isEqualTo(fakeConsoleLog)
     Assert.that(errorEvent.error.is_crash).isEqualTo(true)
     Assert.that(errorEvent.error.type).isEqualTo(fakeExitStatus)
+    Assert.that(errorEvent.context).isEqualTo(fakePreviousViewEvent.context)
 
     viewEvent = ParseJson(updates[1])
     Assert.that(viewEvent).isNotInvalid()
@@ -336,6 +338,7 @@ function RumCrashReporterTaskTest__WhenReasonIsUnknown_ThenWriteErrorAndViewEven
     Assert.that(errorEvent).isNotInvalid()
     Assert.that(errorEvent.error.type).isEqualTo(fakeUnknownExitStatus)
     Assert.that(errorEvent.error.is_crash).isEqualTo(true)
+    Assert.that(errorEvent.context).isEqualTo(fakePreviousViewEvent.context)
 
     Assert.that(lastViewFilePath).doesNotExist()
     return ""


### PR DESCRIPTION
### What does this PR do?

- Cache `lastExitConsoleLog` in `RumCrashReporterTask` to reduce rendezvous.
- Reuse `lastViewEvent.context`, reducing rendezvous occurrences and aligning the behavior with the other SDKs.
- Change `ddLogWarning` to `ddLogVerbose` to reduce warnings noise.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

