### PR TITLE
Ensure the uploader task is started once all required interface fields are set

### DIFF
--- a/library/components/core/MultiTrackUploaderTask.bs
+++ b/library/components/core/MultiTrackUploaderTask.bs
@@ -18,7 +18,7 @@ import "pkg:/source/timeUtils.bs"
 ' ----------------------------------------------------------------
 sub init()
     m.top.functionName = "uploaderLoop"
-    m.top.control = "RUN"
+    ' Callers must set fields, then set control to "RUN"
 end sub
 
 ' ----------------------------------------------------------------

--- a/library/components/logs/LogsAgent.bs
+++ b/library/components/logs/LogsAgent.bs
@@ -198,6 +198,7 @@ sub ensureUploader()
     }
     uploader.tracks = tracks
     uploader.clientToken = m.top.clientToken
+    uploader.control = "RUN"
     m.top.uploader = uploader
 end sub
 

--- a/library/components/rum/RumAgent.bs
+++ b/library/components/rum/RumAgent.bs
@@ -479,6 +479,7 @@ sub ensureUploader()
         tracks: tracks,
         clientToken: m.clientToken
     })
+    m.uploader.control = "RUN"
     
 end sub
 

--- a/library/source/datadogSdk.bs
+++ b/library/source/datadogSdk.bs
@@ -55,6 +55,7 @@ sub initialize(configuration as object, global as object)
         ddLogInfo("No uploader, creating one")
         datadogUploader = CreateObject("roSGNode", "MultiTrackUploaderTask")
         datadogUploader.clientToken = configuration.clientToken
+        datadogUploader.control = "RUN"
         global.addFields({ datadogUploader: datadogUploader })
     end if
     


### PR DESCRIPTION
### What does this PR do?

This is a code suggestion that serves as a possible fix for issue #154.  

### Motivation

The race condition described in #154 can result from the code pattern used in the Datadog SDK for starting tasks from the `init()` function. This pattern may lead to race conditions. I'd like to propose a new way as a remedy. The idea is to set all the task's interface fields before the task runs. This PR outlines the best practice for doing this. 

### Additional Notes

This is simply a proof. This change breaks the unit tests written for MultiTrackUploaderTask. I can circle back and debug that. But I wanted to communicate this code change in a timely manner. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

