### PR TITLE
[159] Set operation timestamp at time of event

### DIFF
--- a/dist/components/rum/RumSessionScope.brs
+++ b/dist/components/rum/RumSessionScope.brs
@@ -181,7 +181,12 @@ end sub
 ' @param writer (object) the writer node (see WriterTask component)
 ' ----------------------------------------------------------------
 sub sendVitalEvent(event as object, stepType as string, writer as object)
-    timestamp& = getTimestamp()
+    ' Use the timestamp given as it is more accurate to when the operation started.
+    if (event.timestamp <> invalid)
+        timestamp& = event.timestamp
+    else
+        timestamp& = getTimestamp()
+    end if
     rumContext = getRumContext(invalid)
     ' Get view context if available
     if (m.top.activeView <> invalid)

--- a/dist/source/rum/rumRawEvents.brs
+++ b/dist/source/rum/rumRawEvents.brs
@@ -117,15 +117,28 @@ function addTelemetryDebugEvent(message as string) as object
 end function
 
 ' ----------------------------------------------------------------
+' @return (object) timestamp in milliseconds since EPOCH
+' ----------------------------------------------------------------
+function getOperationTimestamp() as longinteger
+    date = CreateObject("roDateTime")
+    seconds& = date.AsSeconds() ' number of seconds since EPOCH
+    millis& = date.GetMilliseconds() ' number of millisecond in current second [0-999]
+    timestamp& = (seconds& * 1000) + millis&
+    return timestamp&
+end function
+
+' ----------------------------------------------------------------
 ' @param name (string) the operation name (e.g.: "Login", "Checkout")
 ' @param operationKey (dynamic) the operation key for distinguishing parallel operations, or invalid for unkeyed
 ' @param context (object) an assocarray of custom attributes to add to the event
 ' @return (object) an event describing a startFeatureOperation action
 ' ----------------------------------------------------------------
 function startFeatureOperationEvent(name as string, operationKey as dynamic, context as object) as object
+    ' Set the timestamp as soon as you notify the operation event. This will result in more accurate timing.
     return {
         eventType: "startFeatureOperation"
         name: name
+        timestamp: getOperationTimestamp()
         operationKey: operationKey
         vitalId: CreateObject("roDeviceInfo").GetRandomUUID()
         context: context
@@ -139,9 +152,11 @@ end function
 ' @return (object) an event describing a succeedFeatureOperation action
 ' ----------------------------------------------------------------
 function succeedFeatureOperationEvent(name as string, operationKey as dynamic, context as object) as object
+    ' Set the timestamp as soon as you notify the operation event. This will result in more accurate timing.
     return {
         eventType: "stopFeatureOperation"
         name: name
+        timestamp: getOperationTimestamp()
         operationKey: operationKey
         vitalId: CreateObject("roDeviceInfo").GetRandomUUID()
         context: context
@@ -156,9 +171,11 @@ end function
 ' @return (object) an event describing a failFeatureOperation action
 ' ----------------------------------------------------------------
 function failFeatureOperationEvent(name as string, operationKey as dynamic, failureReason as string, context as object) as object
+    ' Set the timestamp as soon as you notify the operation event. This will result in more accurate timing.
     return {
         eventType: "stopFeatureOperation"
         name: name
+        timestamp: getOperationTimestamp()
         operationKey: operationKey
         failureReason: failureReason
         vitalId: CreateObject("roDeviceInfo").GetRandomUUID()

--- a/library/components/rum/RumSessionScope.bs
+++ b/library/components/rum/RumSessionScope.bs
@@ -162,7 +162,13 @@ end sub
 ' @param writer (object) the writer node (see WriterTask component)
 ' ----------------------------------------------------------------
 sub sendVitalEvent(event as object, stepType as string, writer as object)
-    timestamp& = getTimestamp()
+    ' Use the timestamp given as it is more accurate to when the operation started.
+    if (event.timestamp <> invalid)
+        timestamp& = event.timestamp
+    else
+        timestamp& = getTimestamp()
+    end if
+
     rumContext = getRumContext(invalid)
 
     ' Get view context if available

--- a/library/source/rum/rumRawEvents.bs
+++ b/library/source/rum/rumRawEvents.bs
@@ -118,15 +118,28 @@ function addTelemetryDebugEvent(message as string) as object
 end function
 
 ' ----------------------------------------------------------------
+' @return (object) timestamp in milliseconds since EPOCH
+' ----------------------------------------------------------------
+function getOperationTimestamp() as longinteger
+    date = CreateObject("roDateTime")
+    seconds& = date.AsSeconds() ' number of seconds since EPOCH
+    millis& = date.GetMilliseconds() ' number of millisecond in current second [0-999]
+    timestamp& = (seconds& * 1000) + millis&
+    return timestamp&
+end function
+
+' ----------------------------------------------------------------
 ' @param name (string) the operation name (e.g.: "Login", "Checkout")
 ' @param operationKey (dynamic) the operation key for distinguishing parallel operations, or invalid for unkeyed
 ' @param context (object) an assocarray of custom attributes to add to the event
 ' @return (object) an event describing a startFeatureOperation action
 ' ----------------------------------------------------------------
 function startFeatureOperationEvent(name as string, operationKey as dynamic, context as object) as object
+    ' Set the timestamp as soon as you notify the operation event. This will result in more accurate timing.
     return {
         eventType: RawEvent.startFeatureOperation,
         name: name,
+        timestamp: getOperationTimestamp(),
         operationKey: operationKey,
         vitalId: CreateObject("roDeviceInfo").GetRandomUUID(),
         context: context
@@ -140,9 +153,11 @@ end function
 ' @return (object) an event describing a succeedFeatureOperation action
 ' ----------------------------------------------------------------
 function succeedFeatureOperationEvent(name as string, operationKey as dynamic, context as object) as object
+    ' Set the timestamp as soon as you notify the operation event. This will result in more accurate timing.
     return {
         eventType: RawEvent.stopFeatureOperation,
         name: name,
+        timestamp: getOperationTimestamp(),
         operationKey: operationKey,
         vitalId: CreateObject("roDeviceInfo").GetRandomUUID(),
         context: context
@@ -157,9 +172,11 @@ end function
 ' @return (object) an event describing a failFeatureOperation action
 ' ----------------------------------------------------------------
 function failFeatureOperationEvent(name as string, operationKey as dynamic, failureReason as string, context as object) as object
+    ' Set the timestamp as soon as you notify the operation event. This will result in more accurate timing.
     return {
         eventType: RawEvent.stopFeatureOperation,
         name: name,
+        timestamp: getOperationTimestamp(),
         operationKey: operationKey,
         failureReason: failureReason,
         vitalId: CreateObject("roDeviceInfo").GetRandomUUID(),


### PR DESCRIPTION
### What does this PR do?

In instrumenting timing for video playback start, we observed the start times were not accurate. This PR addresses issue #159. 

### Motivation

These code changes make operation timestamps report accurately in the Operations dashboard. 

### Additional Notes

None. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

