### PR TITLE
RUM-16359: Refactor `LogsAgent` setup

### DIFF
--- a/dist/components/logs/LogsAgent.brs
+++ b/dist/components/logs/LogsAgent.brs
@@ -6,8 +6,8 @@
 'import "pkg:/source/timeUtils.bs"
 'import "pkg:/source/logs/logStatus.bs"
 ' *****************************************************************
-' * RumAgent: a background component listening for internal events
-' *     to write relevant RUM Event to Datadog.
+' * LogsAgent: a component exposing logging APIs that write
+' *     Log Events to Datadog.
 ' *****************************************************************
 
 ' ----------------------------------------------------------------
@@ -124,24 +124,24 @@ end sub
 ' ----------------------------------------------------------------
 sub sendLog(status as object, message as string, attributes as object)
     timestamp& = getTimestamp()
-    ensureSetup()
+    setupIfNeeded()
     logEvent = {
         date: timestamp&
-        ddtags: "env:" + m.top.env + ",version:" + m.top.version
+        ddtags: "env:" + m.env + ",version:" + m.version
         message: message
         status: status
-        service: m.top.service
+        service: m.service
         usr: m.global.datadogUserInfo
         device: {
             type: "tv"
-            name: m.top.deviceName
-            model: m.top.deviceModel
+            name: m.deviceName
+            model: m.deviceModel
             brand: "Roku"
         }
         os: {
             name: "Roku"
-            version: m.top.osVersion
-            version_major: m.top.osVersionMajor
+            version: m.osVersion
+            version_major: m.osVersionMajor
         }
         logger: {
             thread_name: m.top.threadInfo().currentThread.name
@@ -167,37 +167,47 @@ sub sendLog(status as object, message as string, attributes as object)
             id: rumContext.actionId
         }
     end if
-    m.top.writer.writeEvent = FormatJson(logEvent)
+    m.writer.writeEvent = FormatJson(logEvent)
 end sub
 
-' ----------------------------------------------------------------
-' Ensure all dependencies are present (from DI or generated)
-' ----------------------------------------------------------------
-sub ensureSetup()
-    ensureUploader()
-    ensureWriter()
-end sub
-
-' ----------------------------------------------------------------
-' Sets the uploader node from the top node's field,
-' or instantiate one.
-' ----------------------------------------------------------------
-sub ensureUploader()
-    uploader = m.top.uploader
-    if (m.top.uploader = invalid)
-        uploader = CreateObject("roSGNode", "MultiTrackUploaderTask")
+sub setupIfNeeded()
+    if (m.isConfigured = true)
+        return
     end if
+    ' 1. Cache injected dependencies
+    fields = m.top.getFields()
+    m.uploader = fields.uploader
+    m.writer = fields.writer 'allow tests to inject a mock
+    m.service = fields.service
+    m.version = fields.version
+    m.env = fields.env
+    m.deviceName = fields.deviceName
+    m.deviceModel = fields.deviceModel
+    m.osVersion = fields.osVersion
+    m.osVersionMajor = fields.osVersionMajor
+    m.site = fields.site
+    ' 2. Configure writer
+    if (m.writer = invalid) 'skipped in tests (mock pre-injected)
+        ddLogVerbose("Creating WriterTask")
+        m.writer = CreateObject("roSGNode", "WriterTask")
+        m.top.writer = m.writer
+    end if
+    m.writer.setFields({
+        trackType: "logs"
+        payloadSeparator: ","
+    })
+    ' 3. Register our track on the shared uploader
     trackId = "logs_" + m.top.threadInfo().node.address
-    tracks = (function(uploader)
-            __bsConsequent = uploader.tracks
+    tracks = (function(m)
+            __bsConsequent = m.uploader.tracks
             if __bsConsequent <> invalid then
                 return __bsConsequent
             else
                 return {}
             end if
-        end function)(uploader)
+        end function)(m)
     tracks[trackId] = {
-        url: getIntakeUrl(m.top.site, "logs")
+        url: getIntakeUrl(m.site, "logs")
         trackType: "logs"
         payloadPrefix: "["
         payloadPostfix: "]"
@@ -206,23 +216,8 @@ sub ensureUploader()
             ddsource: agentSource()
         }
     }
-    uploader.tracks = tracks
-    uploader.clientToken = m.top.clientToken
-    uploader.control = "RUN"
-    m.top.uploader = uploader
-end sub
-
-' ----------------------------------------------------------------
-' Sets the writer node from the top node's field,
-' or instantiate one.
-' ----------------------------------------------------------------
-sub ensureWriter()
-    writer = m.top.writer
-    if (writer = invalid)
-        ddLogVerbose("Creating WriterTask")
-        writer = CreateObject("roSGNode", "WriterTask")
-    end if
-    writer.trackType = "logs"
-    writer.payloadSeparator = ","
-    m.top.writer = writer
+    m.uploader.setFields({
+        tracks: tracks
+    })
+    m.isConfigured = true
 end sub

--- a/dist/components/logs/LogsAgent.xml
+++ b/dist/components/logs/LogsAgent.xml
@@ -2,7 +2,6 @@
 <component name="LogsAgent" extends="Node" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://devtools.web.roku.com/schema/RokuSceneGraph.xsd">
     <interface>
         <field id="site" type="string" value="us1" />
-        <field id="clientToken" type="string" />
         <field id="service" type="string" />
         <field id="version" type="string" />
         <field id="env" type="string" />

--- a/dist/source/datadogSdk.brs
+++ b/dist/source/datadogSdk.brs
@@ -131,7 +131,6 @@ sub initialize(configuration as object, global as object)
                         return ""
                     end if
                 end function)(configuration)
-            clientToken: configuration.clientToken
             service: service
             version: version
             uploader: datadogUploader

--- a/library/components/logs/LogsAgent.bs
+++ b/library/components/logs/LogsAgent.bs
@@ -8,8 +8,8 @@ import "pkg:/source/timeUtils.bs"
 import "pkg:/source/logs/logStatus.bs"
 
 ' *****************************************************************
-' * RumAgent: a background component listening for internal events
-' *     to write relevant RUM Event to Datadog.
+' * LogsAgent: a component exposing logging APIs that write
+' *     Log Events to Datadog.
 ' *****************************************************************
 
 ' ----------------------------------------------------------------
@@ -126,24 +126,24 @@ end sub
 ' ----------------------------------------------------------------
 sub sendLog(status as LogStatus, message as string, attributes as object)
     timestamp& = getTimestamp()
-    ensureSetup()
+    setupIfNeeded()
     logEvent = {
         date: timestamp&,
-        ddtags: "env:" + m.top.env + ",version:" + m.top.version,
+        ddtags: "env:" + m.env + ",version:" + m.version,
         message: message,
         status: status,
-        service: m.top.service,
+        service: m.service,
         usr: m.global.datadogUserInfo,
         device: {
             type: "tv",
-            name: m.top.deviceName,
-            model: m.top.deviceModel,
+            name: m.deviceName,
+            model: m.deviceModel,
             brand: "Roku"
         },
         os: {
             name: "Roku",
-            version: m.top.osVersion,
-            version_major: m.top.osVersionMajor
+            version: m.osVersion,
+            version_major: m.osVersionMajor
         },
         logger: {
             thread_name: m.top.threadInfo().currentThread.name,
@@ -165,55 +165,49 @@ sub sendLog(status as LogStatus, message as string, attributes as object)
         logEvent["view"] = { id: rumContext.viewId }
         logEvent["user_action"] = { id: rumContext.actionId }
     end if
-    m.top.writer.writeEvent = FormatJson(logEvent)
+    m.writer.writeEvent = FormatJson(logEvent)
 end sub
 
-' ----------------------------------------------------------------
-' Ensure all dependencies are present (from DI or generated)
-' ----------------------------------------------------------------
-sub ensureSetup()
-    ensureUploader()
-    ensureWriter()
-end sub
-
-' ----------------------------------------------------------------
-' Sets the uploader node from the top node's field,
-' or instantiate one.
-' ----------------------------------------------------------------
-sub ensureUploader()
-    uploader = m.top.uploader
-    if (m.top.uploader = invalid)
-        uploader = CreateObject("roSGNode", "MultiTrackUploaderTask")
+sub setupIfNeeded()
+    if (m.isConfigured = true)
+        return
     end if
 
+    ' 1. Cache injected dependencies
+    fields = m.top.getFields()
+    m.uploader = fields.uploader
+    m.writer = fields.writer 'allow tests to inject a mock
+    m.service = fields.service
+    m.version = fields.version
+    m.env = fields.env
+    m.deviceName = fields.deviceName
+    m.deviceModel = fields.deviceModel
+    m.osVersion = fields.osVersion
+    m.osVersionMajor = fields.osVersionMajor
+    m.site = fields.site
+
+    ' 2. Configure writer
+    if (m.writer = invalid) 'skipped in tests (mock pre-injected)
+        ddLogVerbose("Creating WriterTask")
+        m.writer = CreateObject("roSGNode", "WriterTask")
+        m.top.writer = m.writer
+    end if
+    m.writer.setFields({
+        trackType: TrackType.logs,
+        payloadSeparator: ","
+    })
+
+    ' 3. Register our track on the shared uploader
     trackId = "logs_" + m.top.threadInfo().node.address
-    tracks = uploader.tracks ?? {}
+    tracks = m.uploader.tracks ?? {}
     tracks[trackId] = {
-        url: getIntakeUrl(m.top.site, TrackType.logs),
+        url: getIntakeUrl(m.site, TrackType.logs),
         trackType: TrackType.logs,
         payloadPrefix: "[",
         payloadPostfix: "]",
         contentType: "application/json",
         queryParams: { ddsource: agentSource() }
     }
-    uploader.tracks = tracks
-    uploader.clientToken = m.top.clientToken
-    uploader.control = "RUN"
-    m.top.uploader = uploader
-end sub
-
-' ----------------------------------------------------------------
-' Sets the writer node from the top node's field,
-' or instantiate one.
-' ----------------------------------------------------------------
-sub ensureWriter()
-    writer = m.top.writer
-    if (writer = invalid)
-        ddLogVerbose("Creating WriterTask")
-        writer = CreateObject("roSGNode", "WriterTask")
-    end if
-
-    writer.trackType = TrackType.logs
-    writer.payloadSeparator = ","
-    m.top.writer = writer
+    m.uploader.setFields({ tracks: tracks })
+    m.isConfigured = true
 end sub

--- a/library/components/logs/LogsAgent.xml
+++ b/library/components/logs/LogsAgent.xml
@@ -10,7 +10,6 @@ Copyright 2022-Today Datadog, Inc.
 
     <interface>
         <field id="site" type="string" value="us1"/>
-        <field id="clientToken" type="string" />
         <field id="service" type="string" />
         <field id="version" type="string" />
         <field id="env" type="string" />

--- a/library/source/datadogSdk.bs
+++ b/library/source/datadogSdk.bs
@@ -91,7 +91,6 @@ sub initialize(configuration as object, global as object)
         agent.setFields({
             site: configuration.site,
             env: configuration.env ?? "",
-            clientToken: configuration.clientToken,
             service: service,
             version: version,
             uploader: datadogUploader,

--- a/test/source/tests/Test__datadog.bs
+++ b/test/source/tests/Test__datadog.bs
@@ -280,7 +280,6 @@ function DatadogTest__WhenInitialize_ThenLogsAgentConfigurationIsSetInGlobal() a
     actualLogsAgent = fakeGlobal.getField("datadogLogsAgent")
 
     Assert.that(actualLogsAgent.site).isEqualTo(randomSite)
-    Assert.that(actualLogsAgent.clientToken).isEqualTo(randomClientToken)
     Assert.that(actualLogsAgent.service).isEqualTo(randomService)
     Assert.that(actualLogsAgent.env).isEqualTo(randomEnv)
     return ""

--- a/test/source/tests/logs/Test__LogsAgent.bs
+++ b/test/source/tests/logs/Test__LogsAgent.bs
@@ -64,7 +64,6 @@ function TestSuite__LogsAgent() as object
     this.addTest("WhenLogEmergencyWithUserInfo_ThenWriteLog", LogsAgentTest__WhenLogEmergencyWithUserInfo_ThenWriteLog, LogsAgentTest__SetUp, LogsAgentTest__TearDown)
     this.addTest("WhenLogEmergencyWithRumContext_ThenWriteLog", LogsAgentTest__WhenLogEmergencyWithRumContext_ThenWriteLog, LogsAgentTest__SetUp, LogsAgentTest__TearDown)
 
-    this.addTest("WhenDoNothing_ThenInitDependencies", LogsAgentTest__WhenDoNothing_ThenInitDependencies, LogsAgentTest__SetUpNoMock, LogsAgentTest__TearDown)
     return this
 end function
 
@@ -2026,45 +2025,5 @@ function LogsAgentTest__WhenLogEmergencyWithRumContext_ThenWriteLog() as string
     Assert.that(logEvent.session_id).isEqualTo(m.fakeRumContext.sessionId)
     Assert.that(logEvent.view.id).isEqualTo(m.fakeRumContext.viewId)
     Assert.that(logEvent.user_action.id).isEqualTo(m.fakeRumContext.actionId)
-    return ""
-end function
-
-'----------------------------------------------------------------
-' Given: a LogsAgent
-'  When: initializing
-'  Then: ensure the dependencies are created if not present
-'----------------------------------------------------------------
-function LogsAgentTest__WhenDoNothing_ThenInitDependencies() as string
-    ' Given
-    m.testedNode.uploader = invalid
-    m.testedNode.writer = invalid
-    site = IG_GetOneOf(["us1", "us3", "us5", "eu1"])
-    m.testedNode.site = site
-    expectedUrl = datadogroku_getIntakeUrl(site, "logs")
-    expectedTrackName = "logs_" + m.testedNode.threadInfo().node.address
-
-    ' When
-    m.testedNode@.logEmergency(IG_GetString(32), {})
-    sleep(100)
-
-    ' Then
-    writer = m.testedNode.writer
-    uploader = m.testedNode.uploader
-    Assert.that(writer).isNotInvalid().hasSubtype("datadogroku_WriterTask")
-    Assert.that(writer.trackType).isEqualTo("logs")
-    Assert.that(writer.payloadSeparator).isEqualTo(",")
-    Assert.that(uploader) .isNotInvalid().hasSubtype("datadogroku_MultiTrackUploaderTask")
-    Assert.that(uploader.clientToken).isEqualTo(m.fakeClientToken)
-    uploaderTracks = uploader.tracks
-    Assert.that(uploaderTracks).isNotInvalid().containsKey(expectedTrackName)
-    track = uploaderTracks[expectedTrackName]
-    Assert.that(track).isNotInvalid().contains({
-        url: expectedUrl,
-        trackType: "logs",
-        payloadPrefix: "[",
-        payloadPostfix: "]",
-        contentType: "application/json",
-        queryParams: { ddsource: "roku" }
-    })
     return ""
 end function


### PR DESCRIPTION
### What does this PR do?

- Simplify `LogsAgent` setup process by adding a `setupIfNeeded` function that only does the hard work once: when `m.isConfigured` is not `true`. 
- Remove unnecessary `clientToken` and test that was checking the old behavior.

### Motivation

The previous design with `ensureSetup` was running the `uploader` and `writer` registration on every `sendLog` call, as noted on #157. This PR fixes that and aligns with the improvements on `RumAgent` in #161.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

