### PR TITLE
Set operation timestamp at event creation

### DIFF
--- a/dist/components/rum/RumAgent.xml
+++ b/dist/components/rum/RumAgent.xml
@@ -43,6 +43,7 @@
     </interface>
     <script type="text/brightscript" uri="pkg:/components/rum/RumAgent.brs" />
     <script type="text/brightscript" uri="pkg:/source/rum/rumRawEvents.brs" />
+    <script type="text/brightscript" uri="pkg:/source/timeUtils.brs" />
     <script type="text/brightscript" uri="pkg:/source/rum/rumHelper.brs" />
     <script type="text/brightscript" uri="pkg:/source/fileUtils.brs" />
     <script type="text/brightscript" uri="pkg:/source/internalLogger.brs" />

--- a/dist/components/rum/RumSessionScope.brs
+++ b/dist/components/rum/RumSessionScope.brs
@@ -181,7 +181,15 @@ end sub
 ' @param writer (object) the writer node (see WriterTask component)
 ' ----------------------------------------------------------------
 sub sendVitalEvent(event as object, stepType as string, writer as object)
-    timestamp& = getTimestamp()
+    ' Prefer the call-site timestamp; sendVitalEvent runs after a cross-thread rendezvous.
+    timestamp& = (function(event, getTimestamp)
+            __bsConsequent = event.timestamp
+            if __bsConsequent <> invalid then
+                return __bsConsequent
+            else
+                return getTimestamp()
+            end if
+        end function)(event, getTimestamp)
     rumContext = getRumContext(invalid)
     ' Get view context if available
     if (m.top.activeView <> invalid)

--- a/dist/source/rum/rumRawEvents.brs
+++ b/dist/source/rum/rumRawEvents.brs
@@ -1,6 +1,7 @@
 ' Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 ' This product includes software developed at Datadog (https://www.datadoghq.com/).
 ' Copyright 2022-Today Datadog, Inc.
+'import "pkg:/source/timeUtils.bs"
 '*****************************************************************
 '* Utilities to generate internal RUM events
 '*****************************************************************
@@ -126,6 +127,7 @@ function startFeatureOperationEvent(name as string, operationKey as dynamic, con
     return {
         eventType: "startFeatureOperation"
         name: name
+        timestamp: getTimestamp()
         operationKey: operationKey
         vitalId: CreateObject("roDeviceInfo").GetRandomUUID()
         context: context
@@ -142,6 +144,7 @@ function succeedFeatureOperationEvent(name as string, operationKey as dynamic, c
     return {
         eventType: "stopFeatureOperation"
         name: name
+        timestamp: getTimestamp()
         operationKey: operationKey
         vitalId: CreateObject("roDeviceInfo").GetRandomUUID()
         context: context
@@ -159,6 +162,7 @@ function failFeatureOperationEvent(name as string, operationKey as dynamic, fail
     return {
         eventType: "stopFeatureOperation"
         name: name
+        timestamp: getTimestamp()
         operationKey: operationKey
         failureReason: failureReason
         vitalId: CreateObject("roDeviceInfo").GetRandomUUID()

--- a/library/components/rum/RumSessionScope.bs
+++ b/library/components/rum/RumSessionScope.bs
@@ -162,7 +162,8 @@ end sub
 ' @param writer (object) the writer node (see WriterTask component)
 ' ----------------------------------------------------------------
 sub sendVitalEvent(event as object, stepType as string, writer as object)
-    timestamp& = getTimestamp()
+    ' Prefer the call-site timestamp; sendVitalEvent runs after a cross-thread rendezvous.
+    timestamp& = event.timestamp ?? getTimestamp()
     rumContext = getRumContext(invalid)
 
     ' Get view context if available

--- a/library/source/rum/rumRawEvents.bs
+++ b/library/source/rum/rumRawEvents.bs
@@ -2,6 +2,8 @@
 ' This product includes software developed at Datadog (https://www.datadoghq.com/).
 ' Copyright 2022-Today Datadog, Inc.
 
+import "pkg:/source/timeUtils.bs"
+
 '*****************************************************************
 '* Utilities to generate internal RUM events
 '*****************************************************************
@@ -127,6 +129,7 @@ function startFeatureOperationEvent(name as string, operationKey as dynamic, con
     return {
         eventType: RawEvent.startFeatureOperation,
         name: name,
+        timestamp: getTimestamp(),
         operationKey: operationKey,
         vitalId: CreateObject("roDeviceInfo").GetRandomUUID(),
         context: context
@@ -143,6 +146,7 @@ function succeedFeatureOperationEvent(name as string, operationKey as dynamic, c
     return {
         eventType: RawEvent.stopFeatureOperation,
         name: name,
+        timestamp: getTimestamp(),
         operationKey: operationKey,
         vitalId: CreateObject("roDeviceInfo").GetRandomUUID(),
         context: context
@@ -160,6 +164,7 @@ function failFeatureOperationEvent(name as string, operationKey as dynamic, fail
     return {
         eventType: RawEvent.stopFeatureOperation,
         name: name,
+        timestamp: getTimestamp(),
         operationKey: operationKey,
         failureReason: failureReason,
         vitalId: CreateObject("roDeviceInfo").GetRandomUUID(),

--- a/test/source/tests/rum/Test__RumAgent.bs
+++ b/test/source/tests/rum/Test__RumAgent.bs
@@ -440,7 +440,9 @@ function RumAgentTest__WhenStartOperation_ThenDelegateToRumScope() as string
     fakeKey = IG_GetString(32)
 
     ' When
+    timestampBefore& = datadogroku_getTimestamp()
     m.testedNode@.startOperation(fakeName, fakeKey)
+    timestampAfter& = datadogroku_getTimestamp()
     sleep(30)
 
     ' Then
@@ -450,6 +452,7 @@ function RumAgentTest__WhenStartOperation_ThenDelegateToRumScope() as string
     Assert.that(capturedEvent.name).isEqualTo(fakeName)
     Assert.that(capturedEvent.operationKey).isEqualTo(fakeKey)
     Assert.that(capturedEvent.vitalId).isNotEmpty()
+    Assert.that(capturedEvent.timestamp).isInRange(timestampBefore&, timestampAfter& + 5)
     Assert.that(capturedEvent.context).isEqualTo({})
     Assert.that(calls[0].writer).hasSubtype("MockWriterTask")
     return ""
@@ -496,7 +499,9 @@ function RumAgentTest__WhenSucceedOperation_ThenDelegateToRumScope() as string
     fakeKey = IG_GetString(32)
 
     ' When
+    timestampBefore& = datadogroku_getTimestamp()
     m.testedNode@.succeedOperation(fakeName, fakeKey)
+    timestampAfter& = datadogroku_getTimestamp()
     sleep(30)
 
     ' Then
@@ -507,6 +512,7 @@ function RumAgentTest__WhenSucceedOperation_ThenDelegateToRumScope() as string
     Assert.that(capturedEvent.operationKey).isEqualTo(fakeKey)
     Assert.that(capturedEvent.vitalId).isNotEmpty()
     Assert.that(capturedEvent.failureReason).isEqualTo(invalid)
+    Assert.that(capturedEvent.timestamp).isInRange(timestampBefore&, timestampAfter& + 5)
     Assert.that(capturedEvent.context).isEqualTo({})
     Assert.that(calls[0].writer).hasSubtype("MockWriterTask")
     return ""
@@ -554,7 +560,9 @@ function RumAgentTest__WhenFailOperation_ThenDelegateToRumScope() as string
     fakeKey = IG_GetString(32)
 
     ' When
+    timestampBefore& = datadogroku_getTimestamp()
     m.testedNode@.failOperation(fakeName, "error", fakeKey)
+    timestampAfter& = datadogroku_getTimestamp()
     sleep(30)
 
     ' Then
@@ -565,6 +573,7 @@ function RumAgentTest__WhenFailOperation_ThenDelegateToRumScope() as string
     Assert.that(capturedEvent.operationKey).isEqualTo(fakeKey)
     Assert.that(capturedEvent.vitalId).isNotEmpty()
     Assert.that(capturedEvent.failureReason).isEqualTo("error")
+    Assert.that(capturedEvent.timestamp).isInRange(timestampBefore&, timestampAfter& + 5)
     Assert.that(capturedEvent.context).isEqualTo({})
     Assert.that(calls[0].writer).hasSubtype("MockWriterTask")
     return ""

--- a/test/source/tests/rum/Test__RumSessionScope.bs
+++ b/test/source/tests/rum/Test__RumSessionScope.bs
@@ -37,6 +37,7 @@ function TestSuite__RumSessionScope() as object
     this.addTest("WhenHandleStartVitalEvent_ThenWriteCorrectPayload", RumSessionScopeTest__WhenHandleStartVitalEvent_ThenWriteCorrectPayload, RumSessionScopeTest__SetUpWithView, RumSessionScopeTest__TearDown)
     this.addTest("WhenHandleSucceedVitalEvent_ThenWriteCorrectPayload", RumSessionScopeTest__WhenHandleSucceedVitalEvent_ThenWriteCorrectPayload, RumSessionScopeTest__SetUpWithView, RumSessionScopeTest__TearDown)
     this.addTest("WhenHandleFailVitalEvent_ThenWriteCorrectPayload", RumSessionScopeTest__WhenHandleFailVitalEvent_ThenWriteCorrectPayload, RumSessionScopeTest__SetUpWithView, RumSessionScopeTest__TearDown)
+    this.addTest("WhenHandleVitalEventWithExplicitTimestamp_ThenDateMatchesEventTimestamp", RumSessionScopeTest__WhenHandleVitalEventWithExplicitTimestamp_ThenDateMatchesEventTimestamp, RumSessionScopeTest__SetUpWithView, RumSessionScopeTest__TearDown)
 
     ' Developer warning behavioral tests
     this.addTest("WhenDuplicateStartSameNameAndKey_ThenBothEventsEmitted", RumSessionScopeTest__WhenDuplicateStartSameNameAndKey_ThenBothEventsEmitted, RumSessionScopeTest__SetUpWithView, RumSessionScopeTest__TearDown)
@@ -847,6 +848,36 @@ function RumSessionScopeTest__WhenHandleFailVitalEvent_ThenWriteCorrectPayload()
     Assert.that(vitalEvent.vital.step_type).isEqualTo("end")
     Assert.that(vitalEvent.vital.operation_key).isEqualTo(fakeKey)
     Assert.that(vitalEvent.vital.failure_reason).isEqualTo("error")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a RumSessionScope with an active view, and a vital event carrying an explicit timestamp
+'  When: handleEvent runs sendVitalEvent
+'  Then: vitalEvent.date is the timestamp from the event, not getTimestamp() at processing time
+'----------------------------------------------------------------
+function RumSessionScopeTest__WhenHandleVitalEventWithExplicitTimestamp_ThenDateMatchesEventTimestamp() as string
+    ' Given
+    fakeName = IG_GetString(32)
+    fakeKey = IG_GetString(32)
+    fakeVitalId = CreateObject("roDeviceInfo").GetRandomUUID()
+    ' Pick a timestamp clearly distinguishable from "now" so the assertion can only pass if
+    ' sendVitalEvent honors event.timestamp instead of calling getTimestamp() itself.
+    explicitTimestamp& = datadogroku_getTimestamp() - 5000&
+    fakeEvent = { eventType: "startFeatureOperation", name: fakeName, operationKey: fakeKey, vitalId: fakeVitalId, timestamp: explicitTimestamp&, context: {} }
+
+    existingUpdates = m.mockWriter@.getFieldUpdates("writeEvent")
+    existingCount = existingUpdates.count()
+
+    ' When
+    m.testedScope@.handleEvent(fakeEvent, m.mockWriter)
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    Assert.that(updates).hasSize(existingCount + 1)
+    vitalEvent = ParseJson(updates[existingCount])
+    Assert.that(vitalEvent).isNotInvalid()
+    Assert.that(vitalEvent.date).isEqualTo(explicitTimestamp&)
     return ""
 end function
 


### PR DESCRIPTION
### What does this PR do?

- Sets the operation timestamp at the call site for `startOperation`, `succeedOperation`, `failOperation` which better reflects when the operation actually started/ended as suggested in #159.
- Improves unit tests.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

