### PR TITLE
Fix `internalLogger.decToHex` function

### DIFF
--- a/dist/source/internalLogger.brs
+++ b/dist/source/internalLogger.brs
@@ -136,34 +136,7 @@ end function
 ' @return (string) the hexadecimal string
 ' ----------------------------------------------------------------
 function decToHex(number as integer) as string
-    hexTab = [
-        "0"
-        "1"
-        "2"
-        "3"
-        "4"
-        "5"
-        "6"
-        "7"
-        "8"
-        "9"
-        "A"
-        "B"
-        "C"
-        "D"
-        "E"
-        "F"
-    ]
-    hex = ""
-    while (number > 0)
-        hex = hexTab[number mod 16] + hex
-        number = number / 16
-    end while
-    if (hex = "")
-        return "0"
-    else
-        return hex
-    end if
+    return UCase(StrI(number, 16).trim())
 end function
 
 function __isDev() as boolean

--- a/library/source/internalLogger.bs
+++ b/library/source/internalLogger.bs
@@ -140,18 +140,7 @@ end function
 ' @return (string) the hexadecimal string
 ' ----------------------------------------------------------------
 function decToHex(number as integer) as string
-    hexTab = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F"]
-    hex = ""
-    while (number > 0)
-        hex = hexTab [number mod 16] + hex
-        number = number / 16
-    end while
-
-    if (hex = "")
-        return "0"
-    else
-        return hex
-    end if
+    return UCase(StrI(number, 16).trim())
 end function
 
 function __isDev() as boolean

--- a/test/components/TestRunner.bs
+++ b/test/components/TestRunner.bs
@@ -12,6 +12,7 @@ import "pkg:/source/testFramework/UTF.brs"
 import "pkg:/source/asserts/Asserts.bs"
 
 import "pkg:/source/tests/Test__fileUtils.bs"
+import "pkg:/source/tests/Test__internalLogger.bs"
 import "pkg:/source/tests/Test__timeUtils.bs"
 import "pkg:/source/tests/Test__datadog.bs"
 import "pkg:/source/tests/Test__DdUrlTransfer.bs"
@@ -55,6 +56,7 @@ sub runTests()
         TestSuite__Datadog,
         TestSuite__DdUrlTransfer,
         TestSuite__FileUtils,
+        TestSuite__InternalLogger,
         TestSuite__TimeUtils,
         TestSuite__MultiTrackUploaderTask,
         TestSuite__WriterTask,

--- a/test/source/tests/Test__internalLogger.bs
+++ b/test/source/tests/Test__internalLogger.bs
@@ -1,0 +1,48 @@
+' Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+' This product includes software developed at Datadog (https://www.datadoghq.com/).
+' Copyright 2022-Today Datadog, Inc.
+
+'----------------------------------------------------------------
+' Main setup function.
+' @return A configured TestSuite object.
+'----------------------------------------------------------------
+function TestSuite__InternalLogger() as object
+    this = BaseTestSuite()
+    this.Name = "InternalLogger"
+
+    this.addTest("WhenDecToHex_ThenConvertsToHexString", InternalLoggerTest__WhenDecToHex_ThenConvertsToHexString)
+
+    return this
+end function
+
+'----------------------------------------------------------------
+'
+'----------------------------------------------------------------
+function InternalLoggerTest__WhenDecToHex_ThenConvertsToHexString() as string
+    ' Given
+    hardcoded = [
+        { dec: 0, hex: "0" },
+        { dec: 9, hex: "9" },
+        { dec: 10, hex: "A" },
+        { dec: 11, hex: "B" },
+        { dec: 15, hex: "F" },
+        { dec: 16, hex: "10" },
+        { dec: 255, hex: "FF" },
+        { dec: 256, hex: "100" },
+        { dec: 210000275, hex: "C845993" },
+        { dec: 210000280, hex: "C845998" },
+        { dec: 210000285, hex: "C84599D" },
+        ' max signed 32-bit integer
+        { dec: 2147483647, hex: "7FFFFFFF" },
+    ]
+
+    for each testcase in hardcoded
+        ' When
+        result = datadogroku_decToHex(testcase.dec)
+
+        ' Then
+        Assert.that(result).isEqualTo(testcase.hex, "Failed to convert " + testcase.dec.toStr() + " to hex " + testcase.hex + " (was " + result + ")")
+    end for
+
+    return ""
+end function


### PR DESCRIPTION
### What does this PR do?

- Simplifies and fixes the decimal to hexadecimal helper function, which had a bug because it was using `/` instead of `\` division.
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

