### PR TITLE
Cleanup code and lint warnings

### DIFF
--- a/dist/components/core/MultiTrackUploaderTask.brs
+++ b/dist/components/core/MultiTrackUploaderTask.brs
@@ -25,7 +25,6 @@ end sub
 sub uploaderLoop()
     ddLogThread("MultiTrackUploaderTask.uploaderLoop()")
     ' Uploader's dependencies
-    m.fileSystem = CreateObject("roFileSystem")
     m.deviceInfo = CreateObject("roDeviceInfo")
     ' Cache static interface fields locally to avoid per-iteration rendezvous.
     m.waitPeriodMs = m.top.waitPeriodMs

--- a/dist/components/logs/LogsAgent.brs
+++ b/dist/components/logs/LogsAgent.brs
@@ -148,13 +148,9 @@ sub sendLog(status as object, message as string, attributes as object)
             version: sdkVersion()
         }
     }
-    for each key in attributes
-        logEvent[key] = attributes[key]
-    end for
+    logEvent.append(attributes)
     if (m.ddContext <> invalid)
-        for each key in m.ddContext
-            logEvent[key] = m.ddContext[key]
-        end for
+        logEvent.append(m.ddContext)
     end if
     rumContext = m.rumContext
     if (rumContext <> invalid)

--- a/dist/components/rum/RumCrashReporterTask.brs
+++ b/dist/components/rum/RumCrashReporterTask.brs
@@ -12,7 +12,6 @@
 ' ----------------------------------------------------------------
 sub init()
     ddLogThread("RumCrashReporterTask.init()")
-    m.port = createObject("roMessagePort")
     m.top.functionName = "sendCrashReport"
 end sub
 

--- a/dist/source/fileUtils.brs
+++ b/dist/source/fileUtils.brs
@@ -17,25 +17,6 @@ function trackFolderPath(trackType as string, version = 1 as integer) as string
 end function
 
 ' ----------------------------------------------------------------
-' Makes sure the parent folder for the given path exists (e.g. to
-' be able to write to the path)
-' @param path (string) the path to a file or folder
-' @return (string) true if the directory was created or already exists
-' ----------------------------------------------------------------
-function mkParentDirs(path as string) as boolean
-    ddLogVerbose("mkParentDirs(" + path + ")")
-    ' Early exit, path contains invalid chars
-    dirPath = CreateObject("roPath", path)
-    if (not dirPath.IsValid())
-        message = "Can't make parent directory, path is invalid: " + path
-        ddLogWarning(message)
-        return false
-    end if
-    folderData = dirPath.Split()
-    return mkDirs(folderData.parent)
-end function
-
-' ----------------------------------------------------------------
 ' Create a directory (and all intermediate directories), similar
 ' to the `mkdir -p` command in linux
 ' @param path (string) the path to a folder

--- a/dist/source/rum/rumHelper.brs
+++ b/dist/source/rum/rumHelper.brs
@@ -39,11 +39,7 @@ end function
 ' ----------------------------------------------------------------
 function mergeContext(globalContext as object, localContext as object) as object
     mergedContext = {}
-    for each key in globalContext
-        mergedContext[key] = globalContext[key]
-    end for
-    for each key in localContext
-        mergedContext[key] = localContext[key]
-    end for
+    mergedContext.append(globalContext)
+    mergedContext.append(localContext)
     return mergedContext
 end function

--- a/library/components/core/MultiTrackUploaderTask.bs
+++ b/library/components/core/MultiTrackUploaderTask.bs
@@ -28,7 +28,6 @@ sub uploaderLoop()
     ddLogThread("MultiTrackUploaderTask.uploaderLoop()")
 
     ' Uploader's dependencies
-    m.fileSystem = CreateObject("roFileSystem")
     m.deviceInfo = CreateObject("roDeviceInfo")
 
     ' Cache static interface fields locally to avoid per-iteration rendezvous.

--- a/library/components/logs/LogsAgent.bs
+++ b/library/components/logs/LogsAgent.bs
@@ -150,13 +150,9 @@ sub sendLog(status as LogStatus, message as string, attributes as object)
             version: sdkVersion()
         }
     }
-    for each key in attributes
-        logEvent[key] = attributes[key]
-    end for
+    logEvent.append(attributes)
     if (m.ddContext <> invalid)
-        for each key in m.ddContext
-            logEvent[key] = m.ddContext[key]
-        end for
+        logEvent.append(m.ddContext)
     end if
     rumContext = m.rumContext
     if (rumContext <> invalid)

--- a/library/components/rum/RumCrashReporterTask.bs
+++ b/library/components/rum/RumCrashReporterTask.bs
@@ -15,7 +15,6 @@ import "pkg:/source/rum/rumHelper.bs"
 ' ----------------------------------------------------------------
 sub init()
     ddLogThread("RumCrashReporterTask.init()")
-    m.port = createObject("roMessagePort")
     m.top.functionName = "sendCrashReport"
 end sub
 

--- a/library/source/fileUtils.bs
+++ b/library/source/fileUtils.bs
@@ -19,27 +19,6 @@ function trackFolderPath(trackType as string, version = 1 as integer) as string
 end function
 
 ' ----------------------------------------------------------------
-' Makes sure the parent folder for the given path exists (e.g. to
-' be able to write to the path)
-' @param path (string) the path to a file or folder
-' @return (string) true if the directory was created or already exists
-' ----------------------------------------------------------------
-function mkParentDirs(path as string) as boolean
-    ddLogVerbose("mkParentDirs(" + path + ")")
-
-    ' Early exit, path contains invalid chars
-    dirPath = CreateObject("roPath", path)
-    if (not dirPath.IsValid())
-        message = "Can't make parent directory, path is invalid: " + path
-        ddLogWarning(message)
-        return false
-    end if
-
-    folderData = dirPath.Split()
-    return mkDirs(folderData.parent)
-end function
-
-' ----------------------------------------------------------------
 ' Create a directory (and all intermediate directories), similar
 ' to the `mkdir -p` command in linux
 ' @param path (string) the path to a folder

--- a/library/source/rum/rumHelper.bs
+++ b/library/source/rum/rumHelper.bs
@@ -41,11 +41,7 @@ end function
 ' ----------------------------------------------------------------
 function mergeContext(globalContext as object, localContext as object) as object
     mergedContext = {}
-    for each key in globalContext
-        mergedContext[key] = globalContext[key]
-    end for
-    for each key in localContext
-        mergedContext[key] = localContext[key]
-    end for
+    mergedContext.append(globalContext)
+    mergedContext.append(localContext)
     return mergedContext
 end function

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "packageRootDir": "dist"
   },
   "devDependencies": {
-    "@rokucommunity/bslint": "0.8.38",
+    "@rokucommunity/bslint": "0.8.39",
     "brighterscript": "0.69.13",
     "ropm": "0.11.4"
   }

--- a/test/source/asserts/Asserts.bs
+++ b/test/source/asserts/Asserts.bs
@@ -288,16 +288,22 @@ class BaseAssert
     function isEmpty(msg = "" as string) as BaseAssert
         if (TF_Utils__IsArray(m.actual) or TF_Utils__IsAssociativeArray(m.actual))
             if (m.actual.count() <> 0)
+                if (msg = "")
+                    msg = "Expected " + TF_Utils__AsString(m.actual) + " to be empty but was not (found " + TF_Utils__AsString(m.actual.count()) + " items)"
+                end if
                 throw {
                     number: m.errorCode,
-                    message: "Expected " + TF_Utils__AsString(m.actual) + " to be empty but was not (found " + TF_Utils__AsString(m.actual.count()) + " items)"
+                    message: msg
                 }
             end if
         else if (TF_Utils__IsString(m.actual))
             if (m.actual.Len() <> 0)
+                if (msg = "")
+                    msg = "Expected " + TF_Utils__AsString(m.actual) + " to be empty but was not (string was '" + m.actual + "')"
+                end if
                 throw {
                     number: m.errorCode,
-                    message: "Expected " + TF_Utils__AsString(m.actual) + " to be empty but was not (string was '" + m.actual + "')"
+                    message: msg
                 }
             end if
         else
@@ -317,16 +323,22 @@ class BaseAssert
     function isNotEmpty(msg = "" as string) as BaseAssert
         if (TF_Utils__IsArray(m.actual) or TF_Utils__IsAssociativeArray(m.actual))
             if (m.actual.count() = 0)
+                if (msg = "")
+                    msg = "Expected " + TF_Utils__AsString(m.actual) + " not to be empty"
+                end if
                 throw {
                     number: m.errorCode,
-                    message: "Expected " + TF_Utils__AsString(m.actual) + " not to be empty"
+                    message: msg
                 }
             end if
         else if (TF_Utils__IsString(m.actual))
             if (m.actual.Len() = 0)
+                if (msg = "")
+                    msg = "Expected " + TF_Utils__AsString(m.actual) + " not to be empty"
+                end if
                 throw {
                     number: m.errorCode,
-                    message: "Expected " + TF_Utils__AsString(m.actual) + " not to be empty"
+                    message: msg
                 }
             end if
         else
@@ -354,16 +366,22 @@ class BaseAssert
 
         if (TF_Utils__IsArray(m.actual) or TF_Utils__IsAssociativeArray(m.actual))
             if (m.actual.count() <> expected)
+                if (msg = "")
+                    msg = "Expected " + TF_Utils__AsString(m.actual) + " to have size " + TF_Utils__AsString(expected) + " but was " + m.actual.count().toStr()
+                end if
                 throw {
                     number: m.errorCode,
-                    message: "Expected " + TF_Utils__AsString(m.actual) + " to have size " + TF_Utils__AsString(expected) + " but was " + m.actual.count().toStr()
+                    message: msg
                 }
             end if
         else if (TF_Utils__IsString(m.actual))
             if (m.actual.Len() <> expected)
+                if (msg = "")
+                    msg = "Expected " + TF_Utils__AsString(m.actual) + " to have size " + TF_Utils__AsString(expected) + " but was " + m.actual.Len().toStr()
+                end if
                 throw {
                     number: m.errorCode,
-                    message: "Expected " + TF_Utils__AsString(m.actual) + " to have size " + TF_Utils__AsString(expected) + " but was " + m.actual.Len().toStr()
+                    message: msg
                 }
             end if
         else
@@ -403,9 +421,12 @@ class BaseAssert
             end if
         end for
 
+        if (msg = "")
+            msg = "Expected " + m.actual + " to have substring " + expected
+        end if
         throw {
             number: m.errorCode,
-            message: "Expected " + m.actual + " to have substring " + expected
+            message: msg
         }
     end function
 
@@ -430,9 +451,12 @@ class BaseAssert
 
         regex = CreateObject("roRegex", expected, flags)
         if (not regex.IsMatch(m.actual))
+            if (msg = "")
+                msg = "Expected " + m.actual + " to match regex /" + expected + "/"
+            end if
             throw {
                 number: m.errorCode,
-                message: "Expected " + m.actual + " to match regex /" + expected + "/"
+                message: msg
             }
         end if
         return m
@@ -450,9 +474,12 @@ class BaseAssert
                     return m
                 end if
             end for
+            if (msg = "")
+                msg = "Expected " + TF_Utils__AsString(m.actual) + " to contain " + TF_Utils__AsString(expected)
+            end if
             throw {
                 number: m.errorCode,
-                message: "Expected " + TF_Utils__AsString(m.actual) + " to contain " + TF_Utils__AsString(expected)
+                message: msg
             }
         else if (TF_Utils__IsAssociativeArray(m.actual))
             if (not TF_Utils__IsAssociativeArray(expected))
@@ -466,9 +493,12 @@ class BaseAssert
                 expectedItem = expected[key]
                 item = m.actual[key]
                 if (not m.__areEqual(item, expectedItem))
+                    if (msg = "")
+                        msg = "Expected " + TF_Utils__AsString(m.actual) + chr(10) + "  to have an entry { " + key + ":" + TF_Utils__AsString(expectedItem) + " } but was { " + key + ":" + TF_Utils__AsString(item) + " }"
+                    end if
                     throw {
                         number: m.errorCode,
-                        message: "Expected " + TF_Utils__AsString(m.actual) + chr(10) + "  to have an entry { " + key + ":" + TF_Utils__AsString(expectedItem) + " } but was { " + key + ":" + TF_Utils__AsString(item) + " }"
+                        message: msg
                     }
                 end if
             end for
@@ -501,9 +531,12 @@ class BaseAssert
                     return m
                 end if
             end for
+            if (msg = "")
+                msg = "Expected " + TF_Utils__AsString(m.actual) + " to contain key " + TF_Utils__AsString(expected)
+            end if
             throw {
                 number: m.errorCode,
-                message: "Expected " + TF_Utils__AsString(m.actual) + " to contain key " + TF_Utils__AsString(expected)
+                message: msg
             }
         end if
 
@@ -535,9 +568,12 @@ class BaseAssert
 
         subtype = m.actual.subType()
         if (subtype <> expected)
+            if (msg = "")
+                msg = "Expected " + TF_Utils__AsString(m.actual) + " to have subtype " + expected + " but was " + subtype
+            end if
             throw {
                 number: m.errorCode,
-                message: "Expected " + TF_Utils__AsString(m.actual) + " to have subtype " + expected + " but was " + subtype
+                message: msg
             }
         end if
 
@@ -558,9 +594,12 @@ class BaseAssert
         end if
 
         if (not CreateObject("roFileSystem").Exists(m.actual))
+            if (msg = "")
+                msg = "Expected " + TF_Utils__AsString(m.actual) + " to be a file on disk, but was not"
+            end if
             throw {
                 number: m.errorCode,
-                message: "Expected " + TF_Utils__AsString(m.actual) + " to be a file on disk, but was not"
+                message: msg
             }
         end if
 
@@ -581,9 +620,12 @@ class BaseAssert
         end if
 
         if (CreateObject("roFileSystem").Exists(m.actual))
+            if (msg = "")
+                msg = "Expected " + TF_Utils__AsString(m.actual) + " to not be a file on disk, but was"
+            end if
             throw {
                 number: m.errorCode,
-                message: "Expected " + TF_Utils__AsString(m.actual) + " to not be a file on disk, but was"
+                message: msg
             }
         end if
 

--- a/test/source/tests/Test__DdUrlTransfer.bs
+++ b/test/source/tests/Test__DdUrlTransfer.bs
@@ -335,7 +335,6 @@ end function
 function DdUrlTransferTest__WhenAddSampledInHeaders_ThenHeadersHaveSessionId() as string
 
     fakeSessionId = IG_GetString(32)
-    fakeDatadogRumAgent = CreateObject("roSGNode", "datadogRoku_RumAgent") 
     fakeGlobal = createFakeGlobal(fakeSessionId)
     fakeHeaderType = IG_GetOneOf(["b3", "datadog", "b3multi", "tracecontext"])
     ddUrlTransfer = datadogroku_DdUrlTransfer(fakeGlobal)
@@ -351,7 +350,6 @@ function DdUrlTransferTest__WhenDeleteTracingHeaders_ThenDeleteOnlySessionId() a
     
     fakeSessionId = IG_GetString(32)
     fake3rdBaggage = IG_GetString(32)
-    fakeDatadogRumAgent = CreateObject("roSGNode", "datadogRoku_RumAgent") 
     fakeGlobal = createFakeGlobal(fakeSessionId)
     ddUrlTransfer = datadogroku_DdUrlTransfer(fakeGlobal)
     ddUrlTransfer.addHeader("baggage", "session.id=" + fakeSessionId)

--- a/test/source/tests/Test__datadog.bs
+++ b/test/source/tests/Test__datadog.bs
@@ -260,9 +260,7 @@ function DatadogTest__WhenInitialize_ThenLogsAgentConfigurationIsSetInGlobal() a
     randomSite = "us1" 
     randomEnv = IG_GetString(16)
     randomService = IG_GetString(16)
-    randomOsVersion = IG_GetString(8)
-    randomOsVersionMajor = IG_GetInteger()
-    
+
     configuration = {
         clientToken: randomClientToken,
         applicationId: randomAppId,

--- a/test/source/tests/Test__fileUtils.bs
+++ b/test/source/tests/Test__fileUtils.bs
@@ -15,11 +15,6 @@ function TestSuite__FileUtils() as object
     this.addTest("WhenMkDirs_ThenCreateParentDirs", FileUtilsTest__WhenMkDirs_ThenCreateParentDirs)
     this.addTest("WhenMkDirsInvalidPath_ThenDoNothing", FileUtilsTest__WhenMkDirsInvalidPath_ThenDoNothing)
 
-    this.addTest("WhenMkParentDirs_ThenCreateDir", FileUtilsTest__WhenMkParentDirs_ThenCreateDir)
-    this.addTest("WhenMkParentDirsExisting_ThenDoNothing", FileUtilsTest__WhenMkParentDirsExisting_ThenDoNothing)
-    this.addTest("WhenMkParentDirs_ThenCreateParentDirs", FileUtilsTest__WhenMkParentDirs_ThenCreateParentDirs)
-    this.addTest("WhenMkParentDirsInvalidPath_ThenDoNothing", FileUtilsTest__WhenMkParentDirsInvalidPath_ThenDoNothing)
-
     this.addTest("WhenTrackFolderPath_ThenComputePath", FileUtilsTest__WhenTrackFolderPath_ThenComputePath)
 
     this.addTest("WhenAppendAsciiFile_ThenAppendsToExistingFile", FileUtilsTest__WhenAppendAsciiFile_ThenAppendsToExistingFile)
@@ -104,90 +99,6 @@ function FileUtilsTest__WhenMkDirsInvalidPath_ThenDoNothing() as string
     ' Then
     Assert.that(result).isFalse("Expected result to be false")
     Assert.that(path).doesNotExist()
-    return ""
-end function
-
-'----------------------------------------------------------------
-' Checks that mkParentDirs creates the required directory
-'----------------------------------------------------------------
-function FileUtilsTest__WhenMkParentDirs_ThenCreateDir() as string
-    ' Given
-    path = IG_GetOneOf(["cachefs", "tmp"]) + ":/" + IG_GetString(16)
-    filePath = path + "/" + IG_GetString(16)
-    Assume.that(filePath).doesNotExist()
-
-    ' When
-    result = datadogroku_mkParentDirs(filePath)
-
-    ' Then
-    Assert.that(result).isTrue("Expected result to be true")
-    Assert.that(path).exists()
-    Assert.that(filePath).doesNotExist()
-    return ""
-end function
-
-'----------------------------------------------------------------
-' Checks that mkparentdirs does nothing if folder already exists
-'----------------------------------------------------------------
-function FileUtilsTest__WhenMkParentDirsExisting_ThenDoNothing() as string
-    ' Given
-    path = IG_GetOneOf(["cachefs", "tmp"]) + ":/" + IG_GetString(16)
-    filePath = path + "/" + IG_GetString(16)
-    Assume.that(path).doesNotExist()
-
-    ' When
-    result = datadogroku_mkParentDirs(filePath)
-    result2 = datadogroku_mkparentdirs(filePath)
-
-    ' Then
-    Assert.that(result).isTrue("Expected result to be true")
-    Assert.that(result2).isTrue("Expected result2 to be true")
-    Assert.that(path).exists()
-    Assert.that(filePath).doesNotExist()
-    return ""
-end function
-
-'----------------------------------------------------------------
-' Checks that mkParentDirs creates all intermediate directories
-'----------------------------------------------------------------
-function FileUtilsTest__WhenMkParentDirs_ThenCreateParentDirs() as string
-    ' Given
-    folderNames = IG_GetArray(["string", "string", "string", "string"])
-    path = IG_GetOneOf(["cachefs", "tmp"]) + ":"
-    for each folderName in folderNames
-        path = path + "/" + folderName
-    end for
-    filePath = path + "/" + IG_GetString(16)
-    Assume.that(path).doesNotExist()
-
-    ' When
-    result = datadogroku_mkParentDirs(filePath)
-
-    ' Then
-    Assert.that(result).isTrue("Expected result to be true")
-    Assert.that(path).exists()
-    Assert.that(filePath).doesNotExist()
-    return ""
-end function
-
-'----------------------------------------------------------------
-' Checks that mkParentDirs fails silently when an invalid path is provided
-' cf: https://developer.roku.com/en-gb/docs/developer-program/getting-started/architecture/file-system.md
-'----------------------------------------------------------------
-function FileUtilsTest__WhenMkParentDirsInvalidPath_ThenDoNothing() as string
-    ' Given
-    invalidChar = IG_GetOneOf(["<", ">", """", ":", "|", "?", "*"])
-    path = IG_GetOneOf(["foo", "bar"]) + ":/" + IG_GetString(8) + invalidChar + IG_GetString(8)
-    filePath = path + "/" + IG_GetString(16)
-    Assume.that(path).doesNotExist()
-
-    ' When
-    result = datadogroku_mkParentDirs(filePath)
-
-    ' Then
-    Assert.that(result).isFalse("Expected result to be false")
-    Assert.that(path).doesNotExist()
-    Assert.that(filePath).doesNotExist()
     return ""
 end function
 


### PR DESCRIPTION
### What does this PR do?

- Bump `rokucommunity/bslint` version `0.8.38` -> `0.8.39`, which [fixes a bug](https://github.com/rokucommunity/bslint/releases/tag/v0.8.39) regarding parameters not being flagged as unused.
- Fix several functions in `Asserts.bs` which weren't using the `msg` parameter.
- Change some `for each` occurrences with `.append` calls.
- Cleanup unused/dead code, now `npm run lint` finds 0 warnings.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

