### PR TITLE
RUM-12495: Support trace sampling based on Session Id

### DIFF
--- a/dist/source/wrapper/DdUrlTransfer.brs
+++ b/dist/source/wrapper/DdUrlTransfer.brs
@@ -615,14 +615,14 @@ function __DdUrlTransfer_builder()
     ' headers
     ' ----------------------------------------------------------------
     instance._traceRequest = sub()
-        rndTrace = (Rnd(101) - 1) ' Rnd(n) returns a number between 1 and n (both inclusive)
-        isSampledIn = rndTrace < m.traceSampleRate
+        sessionId = m.global.datadogRumContext?.sessionId
+        isSampledIn = m._isSampledIn(sessionId)
         headerType = getTracedHeaderType(m.roUrlTransfer.GetUrl(), m.tracingHeaderTypes)
         if (headerType <> invalid)
             ddLogInfo("Tracing request to " + m.roUrlTransfer.GetUrl() + " with headers " + headerType)
             if (isSampledIn)
                 ddLogInfo("Request trace is sampled in")
-                m._addSampledInHeaders(headerType)
+                m._addSampledInHeaders(headerType, sessionId)
             else if (m.traceContextInjection = "all")
                 ddLogInfo("Request trace is sampled out")
                 m._addSampledOutHeaders(headerType)
@@ -638,13 +638,87 @@ function __DdUrlTransfer_builder()
         m._applyHeaders()
     end sub
     ' ----------------------------------------------------------------
+    ' (Internal) decides if the current trace is sampled in.
+    ' Uses session ID (deterministic) when available, random fallback otherwise.
+    ' ----------------------------------------------------------------
+    instance._isSampledIn = function(sessionId as dynamic) as boolean
+        if (m.traceSampleRate >= 100)
+            return true
+        end if
+        if (m.traceSampleRate <= 0)
+            return false
+        end if
+        if (sessionId <> invalid and sessionId.len() > 0)
+            seed& = m._parseUuidLastSegment(sessionId)
+            return m._isDeterministicSampledIn(seed&, m.traceSampleRate)
+        end if
+        ' Fallback: no session — use random (same as legacy behavior)
+        return Rnd(100) <= m.traceSampleRate
+    end function
+    ' ----------------------------------------------------------------
+    ' (Internal) extracts the last segment of a UUID as a LongInteger seed.
+    ' UUID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx (last segment = 12 hex chars = 48 bits)
+    ' Assumes last segment is exactly 12 hex chars (standard UUID v4 format).
+    ' ----------------------------------------------------------------
+    instance._parseUuidLastSegment = function(uuid as string) as longinteger
+        parts = uuid.split("-")
+        if (parts.count() < 5)
+            return 0&
+        end if
+        seg = parts[4] ' 12 hex chars
+        highBits& = val(Left(seg, 6), 16) ' upper 24 bits
+        lowBits& = val(Right(seg, 6), 16) ' lower 24 bits
+        return highBits& * 16777216& + lowBits& ' 16^6 = 0x1000000
+    end function
+    ' ----------------------------------------------------------------
+    ' (Internal) Knuth multiplicative hash — matches Android DeterministicSampler
+    ' / iOS DeterministicSampler.
+    ' Returns true if seed hashes into the sampled bucket for the given sampleRate (0-100).
+    ' ----------------------------------------------------------------
+    instance._isDeterministicSampledIn = function(seed& as longinteger, sampleRate as double) as boolean
+        ' Knuth multiplicative hash — matches Android DeterministicSampler / iOS DeterministicSampler.
+        ' KNUTH = 1111111111111111111 split into 16-bit chunks to avoid BrightScript's
+        ' LongInteger * LongInteger overflow: large products use double arithmetic
+        ' instead of wrapping at 64 bits, producing wrong results.
+        ' Each partial product s_i * k_j <= 65535^2 < 2^32 — no overflow.
+        k0& = 29127& ' bits  0-15 of 1111111111111111111
+        k1& = 11204& ' bits 16-31
+        k2& = 30123& ' bits 32-47
+        k3& = 3947& ' bits 48-63
+        s0& = seed& AND 65535&
+        s1& = (seed& >> 16&) AND 65535&
+        s2& = (seed& >> 32&) AND 65535&
+        s3& = (seed& >> 48&) AND 65535&
+        c0& = s0& * k0&
+        c1& = s0& * k1& + s1& * k0&
+        c2& = s0& * k2& + s1& * k1& + s2& * k0&
+        c3& = s0& * k3& + s1& * k2& + s2& * k1& + s3& * k0&
+        carry& = c0& >> 16&
+        r0& = c0& AND 65535&
+        sum1& = c1& + carry&
+        r1& = sum1& AND 65535&
+        carry& = sum1& >> 16&
+        sum2& = c2& + carry&
+        r2& = sum2& AND 65535&
+        carry& = sum2& >> 16&
+        r3& = (c3& + carry&) AND 65535&
+        ' Build the unsigned 64-bit hash as a double directly from the 16-bit digits.
+        ' All inputs are non-negative, so no sign correction is needed.
+        hashDouble# = CDbl(r3&) * 281474976710656.0 + CDbl(r2&) * 4294967296.0 + CDbl(r1&) * 65536.0 + CDbl(r0&)
+        MAX_UINT64# = 1.8446744073709552e+19 ' 2^64
+        threshold# = MAX_UINT64# * sampleRate / 100.0#
+        return hashDouble# < threshold#
+    end function
+    ' ----------------------------------------------------------------
     ' (Internal) adds the relevant headers for distributed tracing,
     ' matching the given type
     ' @param headerType (string) the header type to use
     ' ----------------------------------------------------------------
-    instance._addSampledInHeaders = sub(headerType as object)
+    instance._addSampledInHeaders = sub(headerType as object, sessionId as dynamic)
         m._deleteTracingHeaders()
-        m.AddHeader("baggage", "session.id=" + m.global.datadogRumContext.sessionId)
+        if (sessionId <> invalid and sessionId.len() > 0)
+            m.AddHeader("baggage", "session.id=" + sessionId)
+        end if
         if (headerType = "datadog")
             ' Datadog uses a complex system for compatibility purposes
             ddId = generateUniqueIdDd()

--- a/library/source/wrapper/DdUrlTransfer.bs
+++ b/library/source/wrapper/DdUrlTransfer.bs
@@ -650,14 +650,14 @@ class DdUrlTransfer
     ' headers
     ' ----------------------------------------------------------------
     sub _traceRequest()
-        rndTrace = (Rnd(101) - 1) ' Rnd(n) returns a number between 1 and n (both inclusive)
-        isSampledIn = rndTrace < m.traceSampleRate
+        sessionId = m.global.datadogRumContext?.sessionId
+        isSampledIn = m._isSampledIn(sessionId)
         headerType = getTracedHeaderType(m.roUrlTransfer.GetUrl(), m.tracingHeaderTypes)
         if (headerType <> invalid)
             ddLogInfo("Tracing request to " + m.roUrlTransfer.GetUrl() + " with headers " + headerType)
             if (isSampledIn)
                 ddLogInfo("Request trace is sampled in")
-                m._addSampledInHeaders(headerType)
+                m._addSampledInHeaders(headerType, sessionId)
             else if (m.traceContextInjection = TraceContextInjection.All)
                 ddLogInfo("Request trace is sampled out")
                 m._addSampledOutHeaders(headerType)
@@ -674,13 +674,97 @@ class DdUrlTransfer
     end sub
 
     ' ----------------------------------------------------------------
+    ' (Internal) decides if the current trace is sampled in.
+    ' Uses session ID (deterministic) when available, random fallback otherwise.
+    ' ----------------------------------------------------------------
+    function _isSampledIn(sessionId as dynamic) as boolean
+        if (m.traceSampleRate >= 100)
+            return true
+        end if
+        if (m.traceSampleRate <= 0)
+            return false
+        end if
+
+        if (sessionId <> invalid and sessionId.len() > 0)
+            seed& = m._parseUuidLastSegment(sessionId)
+            return m._isDeterministicSampledIn(seed&, m.traceSampleRate)
+        end if
+
+        ' Fallback: no session — use random (same as legacy behavior)
+        return Rnd(100) <= m.traceSampleRate
+    end function
+
+    ' ----------------------------------------------------------------
+    ' (Internal) extracts the last segment of a UUID as a LongInteger seed.
+    ' UUID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx (last segment = 12 hex chars = 48 bits)
+    ' Assumes last segment is exactly 12 hex chars (standard UUID v4 format).
+    ' ----------------------------------------------------------------
+    function _parseUuidLastSegment(uuid as string) as longinteger
+        parts = uuid.split("-")
+        if (parts.count() < 5)
+            return 0&
+        end if
+        seg = parts[4] ' 12 hex chars
+        highBits& = val(Left(seg, 6), 16) ' upper 24 bits
+        lowBits& = val(Right(seg, 6), 16) ' lower 24 bits
+        return highBits& * 16777216& + lowBits& ' 16^6 = 0x1000000
+    end function
+
+    ' ----------------------------------------------------------------
+    ' (Internal) Knuth multiplicative hash — matches Android DeterministicSampler
+    ' / iOS DeterministicSampler.
+    ' Returns true if seed hashes into the sampled bucket for the given sampleRate (0-100).
+    ' ----------------------------------------------------------------
+    function _isDeterministicSampledIn(seed& as longinteger, sampleRate as double) as boolean
+        ' Knuth multiplicative hash — matches Android DeterministicSampler / iOS DeterministicSampler.
+        ' KNUTH = 1111111111111111111 split into 16-bit chunks to avoid BrightScript's
+        ' LongInteger * LongInteger overflow: large products use double arithmetic
+        ' instead of wrapping at 64 bits, producing wrong results.
+        ' Each partial product s_i * k_j <= 65535^2 < 2^32 — no overflow.
+        k0& = 29127& ' bits  0-15 of 1111111111111111111
+        k1& = 11204& ' bits 16-31
+        k2& = 30123& ' bits 32-47
+        k3& = 3947&  ' bits 48-63
+
+        s0& = seed& AND 65535&
+        s1& = (seed& >> 16&) AND 65535&
+        s2& = (seed& >> 32&) AND 65535&
+        s3& = (seed& >> 48&) AND 65535&
+
+        c0& = s0& * k0&
+        c1& = s0& * k1& + s1& * k0&
+        c2& = s0& * k2& + s1& * k1& + s2& * k0&
+        c3& = s0& * k3& + s1& * k2& + s2& * k1& + s3& * k0&
+
+        carry& = c0& >> 16&
+        r0& = c0& AND 65535&
+        sum1& = c1& + carry&
+        r1& = sum1& AND 65535&
+        carry& = sum1& >> 16&
+        sum2& = c2& + carry&
+        r2& = sum2& AND 65535&
+        carry& = sum2& >> 16&
+        r3& = (c3& + carry&) AND 65535&
+
+        ' Build the unsigned 64-bit hash as a double directly from the 16-bit digits.
+        ' All inputs are non-negative, so no sign correction is needed.
+        hashDouble# = CDbl(r3&) * 281474976710656.0 + CDbl(r2&) * 4294967296.0 + CDbl(r1&) * 65536.0 + CDbl(r0&)
+
+        MAX_UINT64# = 1.8446744073709552e+19 ' 2^64
+        threshold# = MAX_UINT64# * sampleRate / 100.0#
+        return hashDouble# < threshold#
+    end function
+
+    ' ----------------------------------------------------------------
     ' (Internal) adds the relevant headers for distributed tracing,
     ' matching the given type
     ' @param headerType (string) the header type to use
     ' ----------------------------------------------------------------
-    sub _addSampledInHeaders(headerType as TracingHeaderType)
+    sub _addSampledInHeaders(headerType as TracingHeaderType, sessionId as dynamic)
         m._deleteTracingHeaders()
-        m.AddHeader("baggage","session.id=" + m.global.datadogRumContext.sessionId)
+        if (sessionId <> invalid and sessionId.len() > 0)
+            m.AddHeader("baggage","session.id=" + sessionId)
+        end if
         if (headerType = TracingHeaderType.datadog)
             ' Datadog uses a complex system for compatibility purposes
             ddId = generateUniqueIdDd()

--- a/test/source/tests/Test__DdUrlTransfer.bs
+++ b/test/source/tests/Test__DdUrlTransfer.bs
@@ -34,6 +34,18 @@ function TestSuite__DdUrlTransfer() as object
     this.addTest("WhenSampledIn_ThenHaveSampleInHeaders", DdUrlTransferTest__WhenSampledIn_ThenHaveSampleInHeaders)
     this.addTest("WhenSampledOutAndTraceContextInjectionAll_ThenHaveSampleInHeaders", DdUrlTransferTest__WhenSampledOutAndTraceContextInjectionAll_ThenHaveSampleInHeaders)
     this.addTest("WhenSampledOutAndTraceContextInjectioSampled_ThenHaveSampleInHeaders", DdUrlTransferTest__WhenSampledOutAndTraceContextInjectioSampled_ThenHaveSampleInHeaders)
+
+    this.addTest("WhenParseUuidLastSegment_WithValidUuid_ThenReturnsLast48Bits", DdUrlTransferTest__WhenParseUuidLastSegment_WithValidUuid_ThenReturnsLast48Bits)
+    this.addTest("WhenParseUuidLastSegment_WithInvalidUuid_ThenReturnsZero", DdUrlTransferTest__WhenParseUuidLastSegment_WithInvalidUuid_ThenReturnsZero)
+    this.addTest("WhenDeterministicSampledIn_WithRate0_ThenReturnFalse", DdUrlTransferTest__WhenDeterministicSampledIn_WithRate0_ThenReturnFalse)
+    this.addTest("WhenDeterministicSampledIn_WithRate100_ThenReturnTrue", DdUrlTransferTest__WhenDeterministicSampledIn_WithRate100_ThenReturnTrue)
+    this.addTest("WhenDeterministicSampledIn_WithHardcodedFixtures_ThenConsistentWithBackend", DdUrlTransferTest__WhenDeterministicSampledIn_WithHardcodedFixtures_ThenConsistentWithBackend)
+    this.addTest("WhenIsSampledIn_WithRate100_ThenTrue", DdUrlTransferTest__WhenIsSampledIn_WithRate100_ThenTrue)
+    this.addTest("WhenIsSampledIn_WithRate0_ThenFalse", DdUrlTransferTest__WhenIsSampledIn_WithRate0_ThenFalse)
+    this.addTest("WhenIsSampledIn_WithSameSessionId_ThenConsistentDecision", DdUrlTransferTest__WhenIsSampledIn_WithSameSessionId_ThenConsistentDecision)
+    this.addTest("WhenIsSampledIn_WithNoSession_ThenFallsBackToRandom", DdUrlTransferTest__WhenIsSampledIn_WithNoSession_ThenFallsBackToRandom)
+    this.addTest("WhenIsSampledIn_WithNoSessionAndRate100_ThenTrue", DdUrlTransferTest__WhenIsSampledIn_WithNoSessionAndRate100_ThenTrue)
+    this.addTest("WhenIsSampledIn_WithNoSessionAndRate0_ThenFalse", DdUrlTransferTest__WhenIsSampledIn_WithNoSessionAndRate0_ThenFalse)
     return this
 end function
 
@@ -339,7 +351,7 @@ function DdUrlTransferTest__WhenAddSampledInHeaders_ThenHeadersHaveSessionId() a
     fakeGlobal = createFakeGlobal(fakeSessionId)
     fakeHeaderType = IG_GetOneOf(["b3", "datadog", "b3multi", "tracecontext"])
     ddUrlTransfer = datadogroku_DdUrlTransfer(fakeGlobal)
-    ddUrlTransfer._addSampledInHeaders(fakeHeaderType)
+    ddUrlTransfer._addSampledInHeaders(fakeHeaderType, fakeSessionId)
     resultList = ddUrlTransfer.GetHeader("baggage")
     Assert.that(resultList).hasSize(1)
     Assert.that(resultList[0]).isEqualTo("session.id="+fakeSessionId)
@@ -515,7 +527,7 @@ function DdUrlTransferTest__WhenSampledOutAndTraceContextInjectioSampled_ThenHav
 end function
 
 function createFakeGlobal(fakeSessionId as string) as object
-    fakeDatadogRumAgent = CreateObject("roSGNode", "datadogRoku_RumAgent") 
+    fakeDatadogRumAgent = CreateObject("roSGNode", "datadogRoku_RumAgent")
     fakeSampleRate = IG_GetDouble()
     fakeId = IG_GetString(8)
     fakeName = IG_GetString(16)
@@ -533,5 +545,205 @@ function createFakeGlobal(fakeSessionId as string) as object
     }
     return fakeGlobal
 
+end function
+
+'----------------------------------------------------------------
+' Given: a valid UUID string
+'  When: _parseUuidLastSegment is called
+'  Then: returns the last segment as a LongInteger (48-bit value)
+'----------------------------------------------------------------
+function DdUrlTransferTest__WhenParseUuidLastSegment_WithValidUuid_ThenReturnsLast48Bits() as string
+    fakeGlobal = createFakeGlobal(IG_GetString(16))
+    ddUrlTransfer = datadogroku_DdUrlTransfer(fakeGlobal)
+
+    ' Last segment "000000000001" = 1
+    result& = ddUrlTransfer._parseUuidLastSegment("00000000-0000-4000-8000-000000000001")
+    Assert.that(result&).isEqualTo(1&)
+
+    ' Last segment "0000deadbeef" = 0xdeadbeef = 3735928559
+    result2& = ddUrlTransfer._parseUuidLastSegment("00000000-0000-4000-8000-0000deadbeef")
+    Assert.that(result2&).isEqualTo(3735928559&)
+
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a string with fewer than 5 UUID segments
+'  When: _parseUuidLastSegment is called
+'  Then: returns 0
+'----------------------------------------------------------------
+function DdUrlTransferTest__WhenParseUuidLastSegment_WithInvalidUuid_ThenReturnsZero() as string
+    fakeGlobal = createFakeGlobal(IG_GetString(16))
+    ddUrlTransfer = datadogroku_DdUrlTransfer(fakeGlobal)
+
+    result& = ddUrlTransfer._parseUuidLastSegment("not-a-valid")
+    Assert.that(result&).isEqualTo(0&)
+
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: sampleRate = 0
+'  When: _isDeterministicSampledIn is called with any seed
+'  Then: always returns false
+'----------------------------------------------------------------
+function DdUrlTransferTest__WhenDeterministicSampledIn_WithRate0_ThenReturnFalse() as string
+    fakeGlobal = createFakeGlobal(IG_GetString(16))
+    ddUrlTransfer = datadogroku_DdUrlTransfer(fakeGlobal)
+
+    fakeSeed& = IG_GetInteger()
+    Assert.that(ddUrlTransfer._isDeterministicSampledIn(fakeSeed&, 0)).isEqualTo(false)
+
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: sampleRate = 100
+'  When: _isDeterministicSampledIn is called with any seed
+'  Then: always returns true
+'----------------------------------------------------------------
+function DdUrlTransferTest__WhenDeterministicSampledIn_WithRate100_ThenReturnTrue() as string
+    fakeGlobal = createFakeGlobal(IG_GetString(16))
+    ddUrlTransfer = datadogroku_DdUrlTransfer(fakeGlobal)
+
+    fakeSeed& = IG_GetInteger()
+    Assert.that(ddUrlTransfer._isDeterministicSampledIn(fakeSeed&, 100)).isEqualTo(true)
+
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: hardcoded seed/rate pairs derived from Android DeterministicSamplerTest fixtures
+'  When: _isDeterministicSampledIn is called
+'  Then: results are consistent with Android and backend Knuth sampling
+'----------------------------------------------------------------
+function DdUrlTransferTest__WhenDeterministicSampledIn_WithHardcodedFixtures_ThenConsistentWithBackend() as string
+    fakeGlobal = createFakeGlobal(IG_GetString(16))
+    ddUrlTransfer = datadogroku_DdUrlTransfer(fakeGlobal)
+
+    ' Seeds are taken from Android's DeterministicSamplerTest hardcoded fixtures.
+    ' Rates are integers (wider intervals) around the same mathematical boundaries.
+    ' Android uses float rates (e.g. 55.9f/56.0f); Roku uses the nearest integers.
+
+    ' Seed boundary at ~55.95%: 55% → false, 56% → true
+    Assert.that(ddUrlTransfer._isDeterministicSampledIn(4815162342&, 55.0)).isEqualTo(false)
+    Assert.that(ddUrlTransfer._isDeterministicSampledIn(4815162342&, 56.0)).isEqualTo(true)
+
+    ' Seed boundary at ~90.55%: 90% → false, 91% → true
+    Assert.that(ddUrlTransfer._isDeterministicSampledIn(1415926535897932384&, 90.0)).isEqualTo(false)
+    Assert.that(ddUrlTransfer._isDeterministicSampledIn(1415926535897932384&, 91.0)).isEqualTo(true)
+
+    ' Seed boundary at ~7.45%: 7% → false, 8% → true
+    Assert.that(ddUrlTransfer._isDeterministicSampledIn(718281828459045235&, 7.0)).isEqualTo(false)
+    Assert.that(ddUrlTransfer._isDeterministicSampledIn(718281828459045235&, 8.0)).isEqualTo(true)
+
+    ' Seed boundary at ~32.15%: 32% → false, 33% → true
+    Assert.that(ddUrlTransfer._isDeterministicSampledIn(41421356237309504&, 32.0)).isEqualTo(false)
+    Assert.that(ddUrlTransfer._isDeterministicSampledIn(41421356237309504&, 33.0)).isEqualTo(true)
+
+    ' Seed boundary at ~68.25%: 68% → false, 69% → true
+    Assert.that(ddUrlTransfer._isDeterministicSampledIn(6180339887498948482&, 68.0)).isEqualTo(false)
+    Assert.that(ddUrlTransfer._isDeterministicSampledIn(6180339887498948482&, 69.0)).isEqualTo(true)
+
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: traceSampleRate = 100 and a session ID
+'  When: _isSampledIn is called
+'  Then: returns true
+'----------------------------------------------------------------
+function DdUrlTransferTest__WhenIsSampledIn_WithRate100_ThenTrue() as string
+    fakeSessionId = IG_GetString(16)
+    fakeGlobal = createFakeGlobal(fakeSessionId)
+    ddUrlTransfer = datadogroku_DdUrlTransfer(fakeGlobal)
+    ddUrlTransfer.SetTraceSampleRate(100)
+
+    Assert.that(ddUrlTransfer._isSampledIn(fakeSessionId)).isEqualTo(true)
+
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: traceSampleRate = 0 and a session ID
+'  When: _isSampledIn is called
+'  Then: returns false
+'----------------------------------------------------------------
+function DdUrlTransferTest__WhenIsSampledIn_WithRate0_ThenFalse() as string
+    fakeSessionId = IG_GetString(16)
+    fakeGlobal = createFakeGlobal(fakeSessionId)
+    ddUrlTransfer = datadogroku_DdUrlTransfer(fakeGlobal)
+    ddUrlTransfer.SetTraceSampleRate(0)
+
+    Assert.that(ddUrlTransfer._isSampledIn(fakeSessionId)).isEqualTo(false)
+
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: two independent DdUrlTransfer instances sharing the same session ID
+'  When: _isSampledIn is called on each
+'  Then: both return the same deterministic decision
+'----------------------------------------------------------------
+function DdUrlTransferTest__WhenIsSampledIn_WithSameSessionId_ThenConsistentDecision() as string
+    fakeSessionId = IG_GetString(8) + "-" + IG_GetString(4) + "-" + IG_GetString(4) + "-" + IG_GetString(4) + "-" + IG_GetString(12)
+
+    fakeGlobal1 = createFakeGlobal(fakeSessionId)
+    ddUrlTransfer1 = datadogroku_DdUrlTransfer(fakeGlobal1)
+    ddUrlTransfer1.SetTraceSampleRate(50)
+
+    fakeGlobal2 = createFakeGlobal(fakeSessionId)
+    ddUrlTransfer2 = datadogroku_DdUrlTransfer(fakeGlobal2)
+    ddUrlTransfer2.SetTraceSampleRate(50)
+
+    Assert.that(ddUrlTransfer2._isSampledIn(fakeSessionId)).isEqualTo(ddUrlTransfer1._isSampledIn(fakeSessionId))
+
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: no active session (empty sessionId)
+'  When: _isSampledIn is called
+'  Then: falls back to random — returns a boolean without crashing
+'----------------------------------------------------------------
+function DdUrlTransferTest__WhenIsSampledIn_WithNoSession_ThenFallsBackToRandom() as string
+    fakeGlobal = createFakeGlobal("")
+    ddUrlTransfer = datadogroku_DdUrlTransfer(fakeGlobal)
+    ddUrlTransfer.SetTraceSampleRate(50)
+
+    result = ddUrlTransfer._isSampledIn("")
+    Assert.that(result).isNotInvalid()
+
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: no active session and traceSampleRate = 100
+'  When: _isSampledIn is called
+'  Then: returns true (short-circuits before random fallback)
+'----------------------------------------------------------------
+function DdUrlTransferTest__WhenIsSampledIn_WithNoSessionAndRate100_ThenTrue() as string
+    fakeGlobal = createFakeGlobal("")
+    ddUrlTransfer = datadogroku_DdUrlTransfer(fakeGlobal)
+    ddUrlTransfer.SetTraceSampleRate(100)
+
+    Assert.that(ddUrlTransfer._isSampledIn("")).isEqualTo(true)
+
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: no active session and traceSampleRate = 0
+'  When: _isSampledIn is called
+'  Then: returns false (short-circuits before random fallback)
+'----------------------------------------------------------------
+function DdUrlTransferTest__WhenIsSampledIn_WithNoSessionAndRate0_ThenFalse() as string
+    fakeGlobal = createFakeGlobal("")
+    ddUrlTransfer = datadogroku_DdUrlTransfer(fakeGlobal)
+    ddUrlTransfer.SetTraceSampleRate(0)
+
+    Assert.that(ddUrlTransfer._isSampledIn("")).isEqualTo(false)
+
+    return ""
 end function
 


### PR DESCRIPTION
### What does this PR do?

Previously, each HTTP request through DdUrlTransfer made an independent random sampling decision, so two requests in the same session could get different decisions.

This change makes trace sampling deterministic per-session: the last 48 bits of the session UUID are used as a seed for the same Knuth multiplicative hash (× 1111111111111111111) used by the Android and iOS SDKs. Requests in the same session now always receive the same sampling decision, consistent with backend expectations.

When no active session is present, the previous random fallback is preserved.

Note on implementation: BrightScript's LongInteger * does not wrap on 64-bit overflow — it uses double arithmetic for large products. The Knuth multiplication is therefore implemented via 16-bit chunk decomposition to stay within safe integer range, then assembled as a double for the threshold comparison.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

