### PR TITLE
Issue #170: Allow for > 1 header type in the 'tracingHeaderTypes' configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,13 @@ which supports most features of the `roUrlTransfer` component (except anything r
 For example, here's how to do a `GetToString` call:
 
 ```brightscript
-    validHosts = {}
-    validHosts["example.com"] = "tracecontext" ' add tracing for requests to "example.com" URLs using W3C's tracecontext headers
+    validHosts = [
+        ' add tracing for requests to "example.com" URLs using W3C's tracecontext headers
+        { host: "example.com", header: "tracecontext" }
+        ' a host can be associated with several header types (like the Browser SDK's
+        ' allowedTracingUrls). All of them are injected sharing the same trace/span id:
+        { host: "api.example.com", header: ["datadog", "tracecontext"] }
+    ]
     sampleRate = 50.0 ' only trace 50% of requests
     ddUrlTransfer = datadogroku_DdUrlTransfer(m.global.datadogRumAgent, sampleRate, validHosts)
     ddUrlTransfer.SetUrl(url)

--- a/dist/source/datadogSdk.brs
+++ b/dist/source/datadogSdk.brs
@@ -15,9 +15,11 @@
 '  - version (string, optional) the version of the channel to report in logs and RUM events
 '  - traceSampleRate (integer, optional) the rate of traces to keep when instrumenting network request
 '     as an integer between 0 and 100 (default is 100)
-'  - tracingHeaderTypes (array) a array of associative arrays. Each array item must have a the following entries:
+'  - tracingHeaderTypes (array) a array of associative arrays. Each array item must have the following entries:
 '       - 'host': the host name  for which requests will have a trace generated (e.g.: example.com)
-'       - 'header': one of the supported tracing header types :
+'       - 'header': either a single tracing header type, or an array of tracing header types. When several
+'           types are provided for a host, all of them are injected into the request (sharing the same trace
+'           and span ids), matching the Datadog Browser SDK `allowedTracingUrls` behavior. Supported values:
 '           - "b3": Open Telemetry B3 Single header (cf: https://github.com/openzipkin/b3-propagation#single-header)
 '           - "b3multi": Open Telemetry B3 Multiple header (cf: https://github.com/openzipkin/b3-propagation#multiple-headers)
 '           - "tracecontext": W3C Trace Context header (cf: https://www.w3.org/TR/trace-context/)

--- a/dist/source/wrapper/DdUrlTransfer.brs
+++ b/dist/source/wrapper/DdUrlTransfer.brs
@@ -619,7 +619,7 @@ function __DdUrlTransfer_builder()
     instance._traceRequest = sub()
         sessionId = m.global.datadogRumContext?.sessionId
         isSampledIn = m._isSampledIn(sessionId)
-        headerTypes = getTracedHeaderType(m.roUrlTransfer.GetUrl(), m.tracingHeaderTypes)
+        headerTypes = getTracedHeaderTypes(m.roUrlTransfer.GetUrl(), m.tracingHeaderTypes)
         if (headerTypes.count() > 0)
             ddLogInfo("Tracing request to " + m.roUrlTransfer.GetUrl() + " with headers " + FormatJson(headerTypes))
             if (isSampledIn)

--- a/dist/source/wrapper/DdUrlTransfer.brs
+++ b/dist/source/wrapper/DdUrlTransfer.brs
@@ -28,9 +28,11 @@ function __DdUrlTransfer_builder()
     ' ----------------------------------------------------------------
     ' Sets the traced hosts.
     '
-    ' @param tracingHeaderTypes (array) a array of associative arrays. Each array item must have a the following entries:
+    ' @param tracingHeaderTypes (array) a array of associative arrays. Each array item must have the following entries:
     '   - 'host': the host name  for which requests will have a trace generated (e.g.: example.com)
-    '   - 'header': one of the supported tracing header types :
+    '   - 'header': either a single tracing header type, or an array of tracing header types. When several
+    '       types are provided for a host, all of them are injected into the request (sharing the same
+    '       trace and span ids), matching the Datadog Browser SDK `allowedTracingUrls` behavior. Supported values:
     '       - "b3": Open Telemetry B3 Single header (cf: https://github.com/openzipkin/b3-propagation#single-header)
     '       - "b3multi": Open Telemetry B3 Multiple header (cf: https://github.com/openzipkin/b3-propagation#multiple-headers)
     '       - "tracecontext": W3C Trace Context header (cf: https://www.w3.org/TR/trace-context/)
@@ -617,15 +619,15 @@ function __DdUrlTransfer_builder()
     instance._traceRequest = sub()
         sessionId = m.global.datadogRumContext?.sessionId
         isSampledIn = m._isSampledIn(sessionId)
-        headerType = getTracedHeaderType(m.roUrlTransfer.GetUrl(), m.tracingHeaderTypes)
-        if (headerType <> invalid)
-            ddLogInfo("Tracing request to " + m.roUrlTransfer.GetUrl() + " with headers " + headerType)
+        headerTypes = getTracedHeaderType(m.roUrlTransfer.GetUrl(), m.tracingHeaderTypes)
+        if (headerTypes.count() > 0)
+            ddLogInfo("Tracing request to " + m.roUrlTransfer.GetUrl() + " with headers " + FormatJson(headerTypes))
             if (isSampledIn)
                 ddLogInfo("Request trace is sampled in")
-                m._addSampledInHeaders(headerType, sessionId)
+                m._addSampledInHeaders(headerTypes, sessionId)
             else if (m.traceContextInjection = "all")
                 ddLogInfo("Request trace is sampled out")
-                m._addSampledOutHeaders(headerType)
+                m._addSampledOutHeaders(headerTypes)
             else
                 ddLogInfo("Request trace is sampled out, but no header is added.")
             end if
@@ -711,42 +713,50 @@ function __DdUrlTransfer_builder()
     end function
     ' ----------------------------------------------------------------
     ' (Internal) adds the relevant headers for distributed tracing,
-    ' matching the given type
-    ' @param headerType (string) the header type to use
+    ' matching the given types. A single trace/span id is generated and
+    ' shared across all header types so that the same trace is propagated
+    ' whatever propagation format the downstream service relies on.
+    ' @param headerTypes (array) the list of header types to use
     ' ----------------------------------------------------------------
-    instance._addSampledInHeaders = sub(headerType as object, sessionId as dynamic)
+    instance._addSampledInHeaders = sub(headerTypes as object, sessionId as dynamic)
         m._deleteTracingHeaders()
         if (sessionId <> invalid and sessionId.len() > 0)
             m.AddHeader("baggage", "session.id=" + sessionId)
         end if
+        ' A single trace context is shared by every propagation format.
+        traceContext = generateTraceContext()
+        m.traceId = traceContext.traceIdFullHex
+        m.spanId = traceContext.spanIdDec
+        for each headerType in headerTypes
+            m._addSampledInHeadersForType(headerType, traceContext)
+        end for
+    end sub
+    ' ----------------------------------------------------------------
+    ' (Internal) adds the headers for a single propagation format using
+    ' the provided shared trace context.
+    ' @param headerType (TracingHeaderType) the header type to use
+    ' @param traceContext (object) the shared trace context (see generateTraceContext)
+    ' ----------------------------------------------------------------
+    instance._addSampledInHeadersForType = sub(headerType as object, traceContext as object)
         if (headerType = "datadog")
             ' Datadog uses a complex system for compatibility purposes
-            ddId = generateUniqueIdDd()
-            m.traceId = ddId[0]
-            m.spanId = generateUniqueId64(10)
-            m.AddHeader("x-datadog-trace-id", ddId[1])
-            m.AddHeader("x-datadog-tags", "_dd.p.tid=" + ddId[2])
-            m.AddHeader("x-datadog-parent-id", m.spanId)
+            m.AddHeader("x-datadog-trace-id", traceContext.traceIdLowDec)
+            m.AddHeader("x-datadog-tags", "_dd.p.tid=" + traceContext.traceIdHighHex)
+            m.AddHeader("x-datadog-parent-id", traceContext.spanIdDec)
             m.AddHeader("x-datadog-sampling-priority", "1")
             m.AddHeader("x-datadog-origin", "rum")
         else if (headerType = "b3")
-            m.traceId = generateUniqueId128(16)
-            m.spanId = generateUniqueId64(16)
-            hexTraceId = padLeft(m.traceId, 32, "0")
-            hexSpanId = padLeft(m.spanId, 16, "0")
+            hexTraceId = padLeft(traceContext.traceIdFullHex, 32, "0")
+            hexSpanId = padLeft(traceContext.spanIdHex, 16, "0")
             b3 = hexTraceId + "-" + hexSpanId + "-1"
             m.AddHeader("b3", b3)
         else if (headerType = "b3multi")
-            m.traceId = generateUniqueId128(16)
-            m.spanId = generateUniqueId64(16)
-            m.AddHeader("X-B3-TraceId", m.traceId)
-            m.AddHeader("X-B3-SpanId", m.spanId)
+            m.AddHeader("X-B3-TraceId", traceContext.traceIdFullHex)
+            m.AddHeader("X-B3-SpanId", traceContext.spanIdHex)
             m.AddHeader("X-B3-Sampled", "1")
         else if (headerType = "tracecontext")
-            m.traceId = generateUniqueId128(16)
-            m.spanId = generateUniqueId64(16)
-            hexTraceId = padLeft(m.traceId, 32, "0")
-            hexSpanId = padLeft(m.spanId, 16, "0")
+            hexTraceId = padLeft(traceContext.traceIdFullHex, 32, "0")
+            hexSpanId = padLeft(traceContext.spanIdHex, 16, "0")
             traceparent = "00-" + hexTraceId + "-" + hexSpanId + "-01"
             m.AddHeader("traceparent", traceparent)
             usrId = m.global.datadogUserInfo.id
@@ -760,31 +770,31 @@ function __DdUrlTransfer_builder()
             end if
             m.AddHeader("tracestate", tracestate)
         else
-            m.traceId = invalid
-            m.spanId = invalid
             ddLogWarning("Cannot trace request, header type is unknown: " + headerType)
         end if
     end sub
     ' ----------------------------------------------------------------
     ' (Internal) adds the relevant headers for distributed tracing,
-    ' matching the given type, to sample this request out
-    ' @param headerType (TracingHeaderType) the header type to use
+    ' matching the given types, to sample this request out
+    ' @param headerTypes (array) the list of header types to use
     ' ----------------------------------------------------------------
-    instance._addSampledOutHeaders = sub(headerType as object)
+    instance._addSampledOutHeaders = sub(headerTypes as object)
         m._deleteTracingHeaders()
         m.traceId = invalid
         m.spanId = invalid
-        if (headerType = "datadog")
-            m.AddHeader("x-datadog-sampling-priority", "0")
-        else if (headerType = "b3")
-            m.AddHeader("b3", "0")
-        else if (headerType = "b3multi")
-            m.AddHeader("X-B3-Sampled", "0")
-        else if (headerType = "tracecontext")
-            m.AddHeader("traceparent", "00-" + padLeft("", 32, "0") + "-" + padLeft("", 16, "0") + "-00")
-        else
-            ddLogWarning("Cannot trace request, header type is unknown: " + headerType)
-        end if
+        for each headerType in headerTypes
+            if (headerType = "datadog")
+                m.AddHeader("x-datadog-sampling-priority", "0")
+            else if (headerType = "b3")
+                m.AddHeader("b3", "0")
+            else if (headerType = "b3multi")
+                m.AddHeader("X-B3-Sampled", "0")
+            else if (headerType = "tracecontext")
+                m.AddHeader("traceparent", "00-" + padLeft("", 32, "0") + "-" + padLeft("", 16, "0") + "-00")
+            else
+                ddLogWarning("Cannot trace request, header type is unknown: " + headerType)
+            end if
+        end for
     end sub
     ' ----------------------------------------------------------------
     ' (Internal) delete the tracing headers to avoid duplicated value
@@ -841,18 +851,21 @@ end function
 '*****************************************************************
 
 ' ----------------------------------------------------------------
-' Verifies whether the given url uses one of the provided hosts
+' Returns every tracing header type configured for the given url's host.
+' Mirrors the Datadog Browser SDK `allowedTracingUrls` behavior where a
+' single host can be associated with several propagators, all of which
+' are injected into the request.
 ' @param url (string) a url
-' @param tracingHeaderTypes (array) a array of associative arrays. Each array item must have a the following entries:
+' @param tracingHeaderTypes (array) a array of associative arrays. Each array item must have the following entries:
 '   - 'host': the host name  for which requests will have a trace generated (e.g.: example.com)
-'   - 'header': one of the supported tracing header types :
+'   - 'header': either a single tracing header type, or an array of tracing header types. Supported values:
 '       - "b3": Open Telemetry B3 Single header (cf: https://github.com/openzipkin/b3-propagation#single-header)
 '       - "b3multi": Open Telemetry B3 Multiple header (cf: https://github.com/openzipkin/b3-propagation#multiple-headers)
 '       - "tracecontext": W3C Trace Context header (cf: https://www.w3.org/TR/trace-context/)
 '       - "datadog": Datadog's `x-datadog-*` headers (cf: https://docs.datadoghq.com/real_user_monitoring/connect_rum_and_traces)
-' @return (dynamic) the tracing header to use or invalid
+' @return (array) the deduplicated list of tracing header types to use (empty if the host is not configured)
 ' ----------------------------------------------------------------
-function getTracedHeaderType(url as string, tracingHeaderTypes as object) as dynamic
+function getTracedHeaderTypes(url as string, tracingHeaderTypes as object) as object
     tokens = url.split("/")
     ' assuming we have "scheme://host[/…]",
     ' tokens[0] = 'scheme:'
@@ -860,12 +873,54 @@ function getTracedHeaderType(url as string, tracingHeaderTypes as object) as dyn
     ' tokens[2] = 'host'
     ' tokens[3+] = params
     urlHost = tokens[2]
+    headerTypes = []
+    seen = {}
     for each item in tracingHeaderTypes
         if (item.host = urlHost)
-            return item.header
+            header = item.header
+            if (GetInterface(header, "ifArray") <> invalid)
+                for each headerType in header
+                    if (headerType <> invalid and not seen.doesExist(headerType))
+                        seen[headerType] = true
+                        headerTypes.Push(headerType)
+                    end if
+                end for
+            else if (header <> invalid and not seen.doesExist(header))
+                seen[header] = true
+                headerTypes.Push(header)
+            end if
         end if
     end for
-    return invalid
+    return headerTypes
+end function
+
+' ----------------------------------------------------------------
+' Generates a single trace context (trace id and span id) and exposes
+' the representations required by the different propagation formats.
+' Sharing one context guarantees the same trace is propagated regardless
+' of which header(s) the downstream service reads.
+' @return (object) an associative array with the following entries:
+'   - traceIdFullHex (string) the full 128 bit trace id in hexadecimal
+'   - traceIdLowDec (string) the low 64 bit part of the trace id in decimal (Datadog's `x-datadog-trace-id`)
+'   - traceIdHighHex (string) the high 64 bit part of the trace id in hexadecimal (Datadog's `_dd.p.tid`)
+'   - spanIdDec (string) the 64 bit span id in decimal
+'   - spanIdHex (string) the 64 bit span id in hexadecimal
+' ----------------------------------------------------------------
+function generateTraceContext() as object
+    maxInt = 4294967295
+    traceHigh0& = Rnd(maxInt) - 1
+    traceHigh1& = Rnd(maxInt) - 1
+    traceLow0& = Rnd(maxInt) - 1
+    traceLow1& = Rnd(maxInt) - 1
+    spanLow0& = Rnd(maxInt) - 1
+    spanLow1& = Rnd(maxInt) - 1
+    return {
+        traceIdFullHex: printIdToString(traceHigh0&, traceHigh1&, traceLow0&, traceLow1&, 16)
+        traceIdLowDec: printIdToString(0, 0, traceLow0&, traceLow1&, 10)
+        traceIdHighHex: printIdToString(0, 0, traceHigh0&, traceHigh1&, 16)
+        spanIdDec: printIdToString(0, 0, spanLow0&, spanLow1&, 10)
+        spanIdHex: printIdToString(0, 0, spanLow0&, spanLow1&, 16)
+    }
 end function
 
 ' ----------------------------------------------------------------

--- a/library/source/datadogSdk.bs
+++ b/library/source/datadogSdk.bs
@@ -15,9 +15,11 @@
 '  - version (string, optional) the version of the channel to report in logs and RUM events
 '  - traceSampleRate (integer, optional) the rate of traces to keep when instrumenting network request
 '     as an integer between 0 and 100 (default is 100)
-'  - tracingHeaderTypes (array) a array of associative arrays. Each array item must have a the following entries:
+'  - tracingHeaderTypes (array) a array of associative arrays. Each array item must have the following entries:
 '       - 'host': the host name  for which requests will have a trace generated (e.g.: example.com)
-'       - 'header': one of the supported tracing header types :
+'       - 'header': either a single tracing header type, or an array of tracing header types. When several
+'           types are provided for a host, all of them are injected into the request (sharing the same trace
+'           and span ids), matching the Datadog Browser SDK `allowedTracingUrls` behavior. Supported values:
 '           - "b3": Open Telemetry B3 Single header (cf: https://github.com/openzipkin/b3-propagation#single-header)
 '           - "b3multi": Open Telemetry B3 Multiple header (cf: https://github.com/openzipkin/b3-propagation#multiple-headers)
 '           - "tracecontext": W3C Trace Context header (cf: https://www.w3.org/TR/trace-context/)

--- a/library/source/wrapper/DdUrlTransfer.bs
+++ b/library/source/wrapper/DdUrlTransfer.bs
@@ -31,9 +31,11 @@ class DdUrlTransfer
     ' ----------------------------------------------------------------
     ' Sets the traced hosts.
     '
-    ' @param tracingHeaderTypes (array) a array of associative arrays. Each array item must have a the following entries:
+    ' @param tracingHeaderTypes (array) a array of associative arrays. Each array item must have the following entries:
     '   - 'host': the host name  for which requests will have a trace generated (e.g.: example.com)
-    '   - 'header': one of the supported tracing header types :
+    '   - 'header': either a single tracing header type, or an array of tracing header types. When several
+    '       types are provided for a host, all of them are injected into the request (sharing the same
+    '       trace and span ids), matching the Datadog Browser SDK `allowedTracingUrls` behavior. Supported values:
     '       - "b3": Open Telemetry B3 Single header (cf: https://github.com/openzipkin/b3-propagation#single-header)
     '       - "b3multi": Open Telemetry B3 Multiple header (cf: https://github.com/openzipkin/b3-propagation#multiple-headers)
     '       - "tracecontext": W3C Trace Context header (cf: https://www.w3.org/TR/trace-context/)
@@ -652,15 +654,15 @@ class DdUrlTransfer
     sub _traceRequest()
         sessionId = m.global.datadogRumContext?.sessionId
         isSampledIn = m._isSampledIn(sessionId)
-        headerType = getTracedHeaderType(m.roUrlTransfer.GetUrl(), m.tracingHeaderTypes)
-        if (headerType <> invalid)
-            ddLogInfo("Tracing request to " + m.roUrlTransfer.GetUrl() + " with headers " + headerType)
+        headerTypes = getTracedHeaderTypes(m.roUrlTransfer.GetUrl(), m.tracingHeaderTypes)
+        if (headerTypes.count() > 0)
+            ddLogInfo("Tracing request to " + m.roUrlTransfer.GetUrl() + " with headers " + FormatJson(headerTypes))
             if (isSampledIn)
                 ddLogInfo("Request trace is sampled in")
-                m._addSampledInHeaders(headerType, sessionId)
+                m._addSampledInHeaders(headerTypes, sessionId)
             else if (m.traceContextInjection = TraceContextInjection.All)
                 ddLogInfo("Request trace is sampled out")
-                m._addSampledOutHeaders(headerType)
+                m._addSampledOutHeaders(headerTypes)
             else 
                 ddLogInfo("Request trace is sampled out, but no header is added.")
             end if
@@ -757,42 +759,53 @@ class DdUrlTransfer
 
     ' ----------------------------------------------------------------
     ' (Internal) adds the relevant headers for distributed tracing,
-    ' matching the given type
-    ' @param headerType (string) the header type to use
+    ' matching the given types. A single trace/span id is generated and
+    ' shared across all header types so that the same trace is propagated
+    ' whatever propagation format the downstream service relies on.
+    ' @param headerTypes (array) the list of header types to use
     ' ----------------------------------------------------------------
-    sub _addSampledInHeaders(headerType as TracingHeaderType, sessionId as dynamic)
+    sub _addSampledInHeaders(headerTypes as object, sessionId as dynamic)
         m._deleteTracingHeaders()
         if (sessionId <> invalid and sessionId.len() > 0)
             m.AddHeader("baggage","session.id=" + sessionId)
         end if
+
+        ' A single trace context is shared by every propagation format.
+        traceContext = generateTraceContext()
+        m.traceId = traceContext.traceIdFullHex
+        m.spanId = traceContext.spanIdDec
+
+        for each headerType in headerTypes
+            m._addSampledInHeadersForType(headerType, traceContext)
+        end for
+    end sub
+
+    ' ----------------------------------------------------------------
+    ' (Internal) adds the headers for a single propagation format using
+    ' the provided shared trace context.
+    ' @param headerType (TracingHeaderType) the header type to use
+    ' @param traceContext (object) the shared trace context (see generateTraceContext)
+    ' ----------------------------------------------------------------
+    sub _addSampledInHeadersForType(headerType as TracingHeaderType, traceContext as object)
         if (headerType = TracingHeaderType.datadog)
             ' Datadog uses a complex system for compatibility purposes
-            ddId = generateUniqueIdDd()
-            m.traceId = ddId[0]
-            m.spanId = generateUniqueId64(10)
-            m.AddHeader("x-datadog-trace-id", ddId[1])
-            m.AddHeader("x-datadog-tags", "_dd.p.tid=" + ddId[2])
-            m.AddHeader("x-datadog-parent-id", m.spanId)
+            m.AddHeader("x-datadog-trace-id", traceContext.traceIdLowDec)
+            m.AddHeader("x-datadog-tags", "_dd.p.tid=" + traceContext.traceIdHighHex)
+            m.AddHeader("x-datadog-parent-id", traceContext.spanIdDec)
             m.AddHeader("x-datadog-sampling-priority", "1")
             m.AddHeader("x-datadog-origin", "rum")
         else if (headerType = TracingHeaderType.b3)
-            m.traceId = generateUniqueId128(16)
-            m.spanId = generateUniqueId64(16)
-            hexTraceId = padLeft(m.traceId, 32, "0")
-            hexSpanId = padLeft(m.spanId, 16, "0")
+            hexTraceId = padLeft(traceContext.traceIdFullHex, 32, "0")
+            hexSpanId = padLeft(traceContext.spanIdHex, 16, "0")
             b3 = hexTraceId + "-" + hexSpanId + "-1"
             m.AddHeader("b3", b3)
         else if (headerType = TracingHeaderType.b3multi)
-            m.traceId = generateUniqueId128(16)
-            m.spanId = generateUniqueId64(16)
-            m.AddHeader("X-B3-TraceId", m.traceId)
-            m.AddHeader("X-B3-SpanId", m.spanId)
+            m.AddHeader("X-B3-TraceId", traceContext.traceIdFullHex)
+            m.AddHeader("X-B3-SpanId", traceContext.spanIdHex)
             m.AddHeader("X-B3-Sampled", "1")
         else if (headerType = TracingHeaderType.tracecontext)
-            m.traceId = generateUniqueId128(16)
-            m.spanId = generateUniqueId64(16)
-            hexTraceId = padLeft(m.traceId, 32, "0")
-            hexSpanId = padLeft(m.spanId, 16, "0")
+            hexTraceId = padLeft(traceContext.traceIdFullHex, 32, "0")
+            hexSpanId = padLeft(traceContext.spanIdHex, 16, "0")
             traceparent = "00-" + hexTraceId + "-" + hexSpanId + "-01"
             m.AddHeader("traceparent", traceparent)
             usrId = m.global.datadogUserInfo.id
@@ -806,32 +819,32 @@ class DdUrlTransfer
             end if
             m.AddHeader("tracestate", tracestate)
         else
-            m.traceId = invalid
-            m.spanId = invalid
             ddLogWarning("Cannot trace request, header type is unknown: " + headerType)
         end if
     end sub
 
     ' ----------------------------------------------------------------
     ' (Internal) adds the relevant headers for distributed tracing,
-    ' matching the given type, to sample this request out
-    ' @param headerType (TracingHeaderType) the header type to use
+    ' matching the given types, to sample this request out
+    ' @param headerTypes (array) the list of header types to use
     ' ----------------------------------------------------------------
-    sub _addSampledOutHeaders(headerType as TracingHeaderType)
+    sub _addSampledOutHeaders(headerTypes as object)
         m._deleteTracingHeaders()
         m.traceId = invalid
         m.spanId = invalid
-        if (headerType = TracingHeaderType.datadog)
-            m.AddHeader("x-datadog-sampling-priority", "0")
-        else if (headerType = TracingHeaderType.b3)
-            m.AddHeader("b3", "0")
-        else if (headerType = TracingHeaderType.b3multi)
-            m.AddHeader("X-B3-Sampled", "0")
-        else if (headerType = TracingHeaderType.tracecontext)
-            m.AddHeader("traceparent", "00-" + padLeft("", 32, "0") + "-" + padLeft("", 16, "0") + "-00")
-        else
-            ddLogWarning("Cannot trace request, header type is unknown: " + headerType)
-        end if
+        for each headerType in headerTypes
+            if (headerType = TracingHeaderType.datadog)
+                m.AddHeader("x-datadog-sampling-priority", "0")
+            else if (headerType = TracingHeaderType.b3)
+                m.AddHeader("b3", "0")
+            else if (headerType = TracingHeaderType.b3multi)
+                m.AddHeader("X-B3-Sampled", "0")
+            else if (headerType = TracingHeaderType.tracecontext)
+                m.AddHeader("traceparent", "00-" + padLeft("", 32, "0") + "-" + padLeft("", 16, "0") + "-00")
+            else
+                ddLogWarning("Cannot trace request, header type is unknown: " + headerType)
+            end if
+        end for
     end sub
 
     ' ----------------------------------------------------------------
@@ -887,18 +900,21 @@ end class
 '*****************************************************************
 
 ' ----------------------------------------------------------------
-' Verifies whether the given url uses one of the provided hosts
+' Returns every tracing header type configured for the given url's host.
+' Mirrors the Datadog Browser SDK `allowedTracingUrls` behavior where a
+' single host can be associated with several propagators, all of which
+' are injected into the request.
 ' @param url (string) a url
-' @param tracingHeaderTypes (array) a array of associative arrays. Each array item must have a the following entries:
+' @param tracingHeaderTypes (array) a array of associative arrays. Each array item must have the following entries:
 '   - 'host': the host name  for which requests will have a trace generated (e.g.: example.com)
-'   - 'header': one of the supported tracing header types :
+'   - 'header': either a single tracing header type, or an array of tracing header types. Supported values:
 '       - "b3": Open Telemetry B3 Single header (cf: https://github.com/openzipkin/b3-propagation#single-header)
 '       - "b3multi": Open Telemetry B3 Multiple header (cf: https://github.com/openzipkin/b3-propagation#multiple-headers)
 '       - "tracecontext": W3C Trace Context header (cf: https://www.w3.org/TR/trace-context/)
 '       - "datadog": Datadog's `x-datadog-*` headers (cf: https://docs.datadoghq.com/real_user_monitoring/connect_rum_and_traces)
-' @return (dynamic) the tracing header to use or invalid
+' @return (array) the deduplicated list of tracing header types to use (empty if the host is not configured)
 ' ----------------------------------------------------------------
-function getTracedHeaderType(url as string, tracingHeaderTypes as object) as dynamic
+function getTracedHeaderTypes(url as string, tracingHeaderTypes as object) as object
     tokens = url.split("/")
     ' assuming we have "scheme://host[/…]",
     ' tokens[0] = 'scheme:'
@@ -906,12 +922,55 @@ function getTracedHeaderType(url as string, tracingHeaderTypes as object) as dyn
     ' tokens[2] = 'host'
     ' tokens[3+] = params
     urlHost = tokens[2]
+    headerTypes = []
+    seen = {}
     for each item in tracingHeaderTypes
         if (item.host = urlHost)
-            return item.header
+            header = item.header
+            if (GetInterface(header, "ifArray") <> invalid)
+                for each headerType in header
+                    if (headerType <> invalid and not seen.doesExist(headerType))
+                        seen[headerType] = true
+                        headerTypes.Push(headerType)
+                    end if
+                end for
+            else if (header <> invalid and not seen.doesExist(header))
+                seen[header] = true
+                headerTypes.Push(header)
+            end if
         end if
     end for
-    return invalid
+    return headerTypes
+end function
+
+' ----------------------------------------------------------------
+' Generates a single trace context (trace id and span id) and exposes
+' the representations required by the different propagation formats.
+' Sharing one context guarantees the same trace is propagated regardless
+' of which header(s) the downstream service reads.
+' @return (object) an associative array with the following entries:
+'   - traceIdFullHex (string) the full 128 bit trace id in hexadecimal
+'   - traceIdLowDec (string) the low 64 bit part of the trace id in decimal (Datadog's `x-datadog-trace-id`)
+'   - traceIdHighHex (string) the high 64 bit part of the trace id in hexadecimal (Datadog's `_dd.p.tid`)
+'   - spanIdDec (string) the 64 bit span id in decimal
+'   - spanIdHex (string) the 64 bit span id in hexadecimal
+' ----------------------------------------------------------------
+function generateTraceContext() as object
+    maxInt = 4294967295
+    traceHigh0& = Rnd(maxInt) - 1
+    traceHigh1& = Rnd(maxInt) - 1
+    traceLow0& = Rnd(maxInt) - 1
+    traceLow1& = Rnd(maxInt) - 1
+    spanLow0& = Rnd(maxInt) - 1
+    spanLow1& = Rnd(maxInt) - 1
+
+    return {
+        traceIdFullHex: printIdToString(traceHigh0&, traceHigh1&, traceLow0&, traceLow1&, 16),
+        traceIdLowDec: printIdToString(0, 0, traceLow0&, traceLow1&, 10),
+        traceIdHighHex: printIdToString(0, 0, traceHigh0&, traceHigh1&, 16),
+        spanIdDec: printIdToString(0, 0, spanLow0&, spanLow1&, 10),
+        spanIdHex: printIdToString(0, 0, spanLow0&, spanLow1&, 16)
+    }
 end function
 
 ' ----------------------------------------------------------------

--- a/sample/credentials.json.template
+++ b/sample/credentials.json.template
@@ -7,7 +7,7 @@
     "mirrorHostsTracingHeaderTypes": [
         {
             "host": "example.com",
-            "header": "tracecontext"
+            "header": ["datadog", "tracecontext"]
         }
     ],
     "site": "us1"

--- a/test/source/tests/Test__DdUrlTransfer.bs
+++ b/test/source/tests/Test__DdUrlTransfer.bs
@@ -15,6 +15,11 @@ function TestSuite__DdUrlTransfer() as object
     this.addTest("WhenGetTracedHeaderTypeWithUnknownHost_ThenReturnsInvalid", DdUrlTransferTest__WhenGetTracedHeaderTypeWithUnknownHost_ThenReturnsInvalid)
     this.addTest("WhenGetTracedHeaderTypeWithNoHost_ThenReturnsInvalid", DdUrlTransferTest__WhenGetTracedHeaderTypeWithNoHost_ThenReturnsInvalid)
     this.addTest("WhenGetTracedHeaderTypeWithNonUrl_ThenReturnsInvalid", DdUrlTransferTest__WhenGetTracedHeaderTypeWithNonUrl_ThenReturnsInvalid)
+    this.addTest("WhenGetTracedHeaderTypesWithHeaderArray_ThenReturnsAllHeaderTypes", DdUrlTransferTest__WhenGetTracedHeaderTypesWithHeaderArray_ThenReturnsAllHeaderTypes)
+    this.addTest("WhenGetTracedHeaderTypesWithDuplicates_ThenDeduplicates", DdUrlTransferTest__WhenGetTracedHeaderTypesWithDuplicates_ThenDeduplicates)
+    this.addTest("WhenGetTracedHeaderTypesWithMultipleMatchingHosts_ThenMergesHeaderTypes", DdUrlTransferTest__WhenGetTracedHeaderTypesWithMultipleMatchingHosts_ThenMergesHeaderTypes)
+    this.addTest("WhenSampledInWithMultipleHeaderTypes_ThenInjectsAllSharingTraceContext", DdUrlTransferTest__WhenSampledInWithMultipleHeaderTypes_ThenInjectsAllSharingTraceContext)
+    this.addTest("WhenSampledOutAllWithMultipleHeaderTypes_ThenInjectsAllSampledOutHeaders", DdUrlTransferTest__WhenSampledOutAllWithMultipleHeaderTypes_ThenInjectsAllSampledOutHeaders)
 
     this.addTest("WhenPadLeftWithEmptyString_ThenReturnPaddedString", DdUrlTransferTest__WhenPadLeftWithEmptyString_ThenReturnPaddedString)
     this.addTest("WhenPadLeftWithExactSizeString_ThenReturnOriginalString", DdUrlTransferTest__WhenPadLeftWithExactSizeString_ThenReturnOriginalString)
@@ -65,10 +70,11 @@ function DdUrlTransferTest__WhenGetTracedHeaderType_ThenReturnsHeaderType() as s
     url = "https://" + validHost.host + "/" + IG_GetString(16)
 
     ' When
-    result = datadogroku_getTracedHeaderType(url, validHosts)
+    result = datadogroku_getTracedHeaderTypes(url, validHosts)
 
     ' Then
-    Assert.that(result).isEqualTo(validHost.header)
+    Assert.that(result).hasSize(1)
+    Assert.that(result[0]).isEqualTo(validHost.header)
     return ""
 end function
 
@@ -86,10 +92,11 @@ function DdUrlTransferTest__WhenGetTracedHeaderTypeWithSingleHost_ThenReturnsHea
     url = "https://" + validHost + "/" + IG_GetString(16)
 
     ' When
-    result = datadogroku_getTracedHeaderType(url, validHosts)
+    result = datadogroku_getTracedHeaderTypes(url, validHosts)
 
     ' Then
-    Assert.that(result).isEqualTo(headerType)
+    Assert.that(result).hasSize(1)
+    Assert.that(result[0]).isEqualTo(headerType)
     return ""
 end function
 
@@ -107,10 +114,10 @@ function DdUrlTransferTest__WhenGetTracedHeaderTypeWithUnknownHost_ThenReturnsIn
     url = "https://" + IG_GetString(8) + "." + IG_GetString(2) + "/" + IG_GetString(16)
 
     ' When
-    result = datadogroku_getTracedHeaderType(url, validHosts)
+    result = datadogroku_getTracedHeaderTypes(url, validHosts)
 
     ' Then
-    Assert.that(result).isInvalid()
+    Assert.that(result).hasSize(0)
     return ""
 end function
 
@@ -125,10 +132,10 @@ function DdUrlTransferTest__WhenGetTracedHeaderTypeWithNoHost_ThenReturnsInvalid
     url = "https://" + IG_GetString(8) + "." + IG_GetString(2) + "/" + IG_GetString(16)
 
     ' When
-    result = datadogroku_getTracedHeaderType(url, validHosts)
+    result = datadogroku_getTracedHeaderTypes(url, validHosts)
 
     ' Then
-    Assert.that(result).isInvalid()
+    Assert.that(result).hasSize(0)
     return ""
 end function
 
@@ -146,10 +153,82 @@ function DdUrlTransferTest__WhenGetTracedHeaderTypeWithNonUrl_ThenReturnsInvalid
     url = IG_GetString(64)
 
     ' When
-    result = datadogroku_getTracedHeaderType(url, validHosts)
+    result = datadogroku_getTracedHeaderTypes(url, validHosts)
 
     ' Then
-    Assert.that(result).isInvalid()
+    Assert.that(result).hasSize(0)
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a host configured with an array of header types
+'  When: call getTracedHeaderTypes with a url for that host
+'  Then: returns every configured header type
+'----------------------------------------------------------------
+function DdUrlTransferTest__WhenGetTracedHeaderTypesWithHeaderArray_ThenReturnsAllHeaderTypes() as string
+    ' Given
+    validHost = IG_GetString(12) + "." + IG_GetString(3)
+    validHosts = [
+        { host: validHost, header: ["datadog", "tracecontext", "b3", "b3multi"] }
+    ]
+    url = "https://" + validHost + "/" + IG_GetString(16)
+
+    ' When
+    result = datadogroku_getTracedHeaderTypes(url, validHosts)
+
+    ' Then
+    Assert.that(result).hasSize(4)
+    Assert.that(result[0]).isEqualTo("datadog")
+    Assert.that(result[1]).isEqualTo("tracecontext")
+    Assert.that(result[2]).isEqualTo("b3")
+    Assert.that(result[3]).isEqualTo("b3multi")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a host configured with duplicate header types
+'  When: call getTracedHeaderTypes with a url for that host
+'  Then: returns each header type only once
+'----------------------------------------------------------------
+function DdUrlTransferTest__WhenGetTracedHeaderTypesWithDuplicates_ThenDeduplicates() as string
+    ' Given
+    validHost = IG_GetString(12) + "." + IG_GetString(3)
+    validHosts = [
+        { host: validHost, header: ["datadog", "datadog", "tracecontext"] }
+    ]
+    url = "https://" + validHost + "/" + IG_GetString(16)
+
+    ' When
+    result = datadogroku_getTracedHeaderTypes(url, validHosts)
+
+    ' Then
+    Assert.that(result).hasSize(2)
+    Assert.that(result[0]).isEqualTo("datadog")
+    Assert.that(result[1]).isEqualTo("tracecontext")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: the same host configured across several entries (string + array)
+'  When: call getTracedHeaderTypes with a url for that host
+'  Then: returns the merged, deduplicated list of header types
+'----------------------------------------------------------------
+function DdUrlTransferTest__WhenGetTracedHeaderTypesWithMultipleMatchingHosts_ThenMergesHeaderTypes() as string
+    ' Given
+    validHost = IG_GetString(12) + "." + IG_GetString(3)
+    validHosts = [
+        { host: validHost, header: "datadog" },
+        { host: validHost, header: ["tracecontext", "datadog"] }
+    ]
+    url = "https://" + validHost + "/" + IG_GetString(16)
+
+    ' When
+    result = datadogroku_getTracedHeaderTypes(url, validHosts)
+
+    ' Then
+    Assert.that(result).hasSize(2)
+    Assert.that(result[0]).isEqualTo("datadog")
+    Assert.that(result[1]).isEqualTo("tracecontext")
     return ""
 end function
 
@@ -350,7 +429,7 @@ function DdUrlTransferTest__WhenAddSampledInHeaders_ThenHeadersHaveSessionId() a
     fakeGlobal = createFakeGlobal(fakeSessionId)
     fakeHeaderType = IG_GetOneOf(["b3", "datadog", "b3multi", "tracecontext"])
     ddUrlTransfer = datadogroku_DdUrlTransfer(fakeGlobal)
-    ddUrlTransfer._addSampledInHeaders(fakeHeaderType, fakeSessionId)
+    ddUrlTransfer._addSampledInHeaders([fakeHeaderType])
     resultList = ddUrlTransfer.GetHeader("baggage")
     Assert.that(resultList).hasSize(1)
     Assert.that(resultList[0]).isEqualTo("session.id="+fakeSessionId)
@@ -521,6 +600,59 @@ function DdUrlTransferTest__WhenSampledOutAndTraceContextInjectioSampled_ThenHav
     ddUrlTransfer._traceRequest()
     result = ddUrlTransfer.GetHeader("x-datadog-sampling-priority")
     Assert.that(result).hasSize(0)
+    return ""
+end function
+
+function DdUrlTransferTest__WhenSampledInWithMultipleHeaderTypes_ThenInjectsAllSharingTraceContext() as string
+    fakeSessionId = IG_GetString(16)
+    fakeGlobal = createFakeGlobal(fakeSessionId)
+    ddUrlTransfer = datadogroku_DdUrlTransfer(fakeGlobal)
+
+    ddUrlTransfer._addSampledInHeaders(["datadog", "tracecontext", "b3", "b3multi"])
+
+    ' the baggage session id is only added once, regardless of the number of header types
+    Assert.that(ddUrlTransfer.GetHeader("baggage")).hasSize(1)
+    Assert.that(ddUrlTransfer.GetHeader("baggage")[0]).isEqualTo("session.id=" + fakeSessionId)
+
+    ' datadog headers
+    Assert.that(ddUrlTransfer.GetHeader("x-datadog-trace-id")).hasSize(1)
+    Assert.that(ddUrlTransfer.GetHeader("x-datadog-parent-id")).hasSize(1)
+    Assert.that(ddUrlTransfer.GetHeader("x-datadog-sampling-priority")[0]).isEqualTo("1")
+    Assert.that(ddUrlTransfer.GetHeader("x-datadog-origin")[0]).isEqualTo("rum")
+
+    ' tracecontext headers
+    Assert.that(ddUrlTransfer.GetHeader("traceparent")).hasSize(1)
+    Assert.that(ddUrlTransfer.GetHeader("tracestate")).hasSize(1)
+
+    ' b3 single + b3 multi headers
+    Assert.that(ddUrlTransfer.GetHeader("b3")).hasSize(1)
+    Assert.that(ddUrlTransfer.GetHeader("X-B3-TraceId")).hasSize(1)
+    Assert.that(ddUrlTransfer.GetHeader("X-B3-SpanId")).hasSize(1)
+    Assert.that(ddUrlTransfer.GetHeader("X-B3-Sampled")[0]).isEqualTo("1")
+
+    ' every format shares the same trace and span ids
+    Assert.that(ddUrlTransfer.traceId).matches("^[0-9a-f]+$", "i")
+    Assert.that(ddUrlTransfer.spanId).matches("^[0-9]+$")
+    Assert.that(ddUrlTransfer.GetHeader("X-B3-TraceId")[0]).isEqualTo(ddUrlTransfer.traceId)
+    Assert.that(ddUrlTransfer.GetHeader("traceparent")[0]).hasSubstring(ddUrlTransfer.traceId)
+    Assert.that(ddUrlTransfer.GetHeader("b3")[0]).hasSubstring(ddUrlTransfer.traceId)
+    Assert.that(ddUrlTransfer.GetHeader("x-datadog-parent-id")[0]).isEqualTo(ddUrlTransfer.spanId)
+    return ""
+end function
+
+function DdUrlTransferTest__WhenSampledOutAllWithMultipleHeaderTypes_ThenInjectsAllSampledOutHeaders() as string
+    fakeSessionId = IG_GetString(16)
+    fakeGlobal = createFakeGlobal(fakeSessionId)
+    ddUrlTransfer = datadogroku_DdUrlTransfer(fakeGlobal)
+
+    ddUrlTransfer._addSampledOutHeaders(["datadog", "tracecontext", "b3", "b3multi"])
+
+    Assert.that(ddUrlTransfer.GetHeader("x-datadog-sampling-priority")[0]).isEqualTo("0")
+    Assert.that(ddUrlTransfer.GetHeader("b3")[0]).isEqualTo("0")
+    Assert.that(ddUrlTransfer.GetHeader("X-B3-Sampled")[0]).isEqualTo("0")
+    Assert.that(ddUrlTransfer.GetHeader("traceparent")).hasSize(1)
+    Assert.that(ddUrlTransfer.traceId).isInvalid()
+    Assert.that(ddUrlTransfer.spanId).isInvalid()
     return ""
 end function
 

--- a/test/source/tests/Test__DdUrlTransfer.bs
+++ b/test/source/tests/Test__DdUrlTransfer.bs
@@ -429,7 +429,7 @@ function DdUrlTransferTest__WhenAddSampledInHeaders_ThenHeadersHaveSessionId() a
     fakeGlobal = createFakeGlobal(fakeSessionId)
     fakeHeaderType = IG_GetOneOf(["b3", "datadog", "b3multi", "tracecontext"])
     ddUrlTransfer = datadogroku_DdUrlTransfer(fakeGlobal)
-    ddUrlTransfer._addSampledInHeaders([fakeHeaderType])
+    ddUrlTransfer._addSampledInHeaders([fakeHeaderType], fakeSessionId)
     resultList = ddUrlTransfer.GetHeader("baggage")
     Assert.that(resultList).hasSize(1)
     Assert.that(resultList[0]).isEqualTo("session.id="+fakeSessionId)
@@ -608,7 +608,7 @@ function DdUrlTransferTest__WhenSampledInWithMultipleHeaderTypes_ThenInjectsAllS
     fakeGlobal = createFakeGlobal(fakeSessionId)
     ddUrlTransfer = datadogroku_DdUrlTransfer(fakeGlobal)
 
-    ddUrlTransfer._addSampledInHeaders(["datadog", "tracecontext", "b3", "b3multi"])
+    ddUrlTransfer._addSampledInHeaders(["datadog", "tracecontext", "b3", "b3multi"], fakeSessionId)
 
     ' the baggage session id is only added once, regardless of the number of header types
     Assert.that(ddUrlTransfer.GetHeader("baggage")).hasSize(1)


### PR DESCRIPTION
### What does this PR do?

Implement support for more than one header type per host. Make this logic backwards compatible for older SDK versions. 

### Motivation

Issue #170 

### Additional Notes

Inspired by the Datadog Browser SDK configuration.

### Review checklist (to be filled by reviewers)

- [X] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [X] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [X] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

