### PR TITLE
Use request dispatch time as RUM resource start date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Next release: 1.6.0
+* [BUGFIX] Use the request dispatch time as the RUM resource start date so client resource spans align with upstream APM spans instead of drifting later.
 
 # 1.5.0 / 2026-06-03
 * [FEATURE] Support trace sampling based on Session Id. See [#169](https://github.com/DataDog/dd-sdk-roku/pull/169)

--- a/dist/components/rum/RumActionScope.brs
+++ b/dist/components/rum/RumActionScope.brs
@@ -62,8 +62,12 @@ sub handleEvent(event as object, writer as object)
         end if
     else if (event.eventType = "addResource")
         if (isValidResource(event.resource))
-            transferTime& = secToMillis(event.resource.transferTime)
-            resourceStartTimestamp& = timestamp& - transferTime&
+            if (event.resource.startTime <> invalid)
+                resourceStartTimestamp& = event.resource.startTime
+            else
+                transferTime& = secToMillis(event.resource.transferTime)
+                resourceStartTimestamp& = timestamp& - transferTime&
+            end if
             if (resourceStartTimestamp& <= (threshold&))
                 m.resourceCount++
                 m.lastEventTimestamp& = timestamp&

--- a/dist/components/rum/RumViewScope.brs
+++ b/dist/components/rum/RumViewScope.brs
@@ -335,6 +335,7 @@ end sub
 '  - bytesDownloaded (dynamic) the size of the downloaded payload (in bytes as integer) or invalid
 '  - traceId (dynamic) the id of the trace forwarded in the request header (as string), or invalid
 '  - spanId (dynamic) the id of the span forwarded in the request header (as string), or invalid
+'  - startTime (dynamic) the wall-clock dispatch time (ms since EPOCH) when the request started, or invalid
 ' @param context (object) an assocarray of custom attributes to add to the view
 ' @param writer (object) the writer node (see WriterTask component)
 ' ----------------------------------------------------------------
@@ -346,7 +347,14 @@ sub sendResource(resource as object, context as object, writer as object)
     if (m.top.activeAction <> invalid)
         actionId = m.top.activeAction.callfunc("getRumContext", invalid).actionId
     end if
-    startTimestampMs& = timestamp& - secToMillis(resource.transferTime)
+    ' Prefer the dispatch time captured when the request started; falling back to
+    ' (now - transferTime) drifts the resource start later by the latency between the
+    ' request completing and this event being serialized.
+    if (resource.startTime <> invalid)
+        startTimestampMs& = resource.startTime
+    else
+        startTimestampMs& = timestamp& - secToMillis(resource.transferTime)
+    end if
     resourceEvent = {
         _dd: {
             format_version: 2

--- a/dist/source/wrapper/DdUrlTransfer.brs
+++ b/dist/source/wrapper/DdUrlTransfer.brs
@@ -109,6 +109,10 @@ function __DdUrlTransfer_builder()
         m.roUrlTransfer.SetMessagePort(port)
         url = m.roUrlTransfer.GetUrl()
         m._traceRequest()
+        ' Capture the wall-clock dispatch time so the RUM resource start date reflects
+        ' when the request actually started, rather than being back-computed from the
+        ' report time (now - transferTime), which drifts with reporting latency.
+        startTime& = getTimestamp()
         timer.Mark()
         result = m.roUrlTransfer.AsyncGetToString()
         if (not result)
@@ -133,6 +137,7 @@ function __DdUrlTransfer_builder()
                             url: url
                             method: "GET"
                             transferTime: transferTime#
+                            startTime: startTime&
                             httpCode: httpCode
                             status: status
                             bytesDownloaded: bytesDownloaded
@@ -170,6 +175,10 @@ function __DdUrlTransfer_builder()
         m.roUrlTransfer.SetMessagePort(port)
         url = m.roUrlTransfer.GetUrl()
         m._traceRequest()
+        ' Capture the wall-clock dispatch time so the RUM resource start date reflects
+        ' when the request actually started, rather than being back-computed from the
+        ' report time (now - transferTime), which drifts with reporting latency.
+        startTime& = getTimestamp()
         timer.Mark()
         result = m.roUrlTransfer.AsyncGetToFile(filename)
         if (not result)
@@ -194,6 +203,7 @@ function __DdUrlTransfer_builder()
                             url: url
                             method: "GET"
                             transferTime: transferTime#
+                            startTime: startTime&
                             httpCode: httpCode
                             status: status
                             bytesDownloaded: bytesDownloaded
@@ -226,6 +236,10 @@ function __DdUrlTransfer_builder()
         m.roUrlTransfer.SetMessagePort(port)
         url = m.roUrlTransfer.GetUrl()
         m._traceRequest()
+        ' Capture the wall-clock dispatch time so the RUM resource start date reflects
+        ' when the request actually started, rather than being back-computed from the
+        ' report time (now - transferTime), which drifts with reporting latency.
+        startTime& = getTimestamp()
         timer.Mark()
         result = m.roUrlTransfer.AsyncPostFromString(request)
         if (not result)
@@ -248,6 +262,7 @@ function __DdUrlTransfer_builder()
                             url: url
                             method: "POST"
                             transferTime: transferTime#
+                            startTime: startTime&
                             httpCode: httpCode
                             status: status
                             traceId: m.traceId
@@ -280,6 +295,10 @@ function __DdUrlTransfer_builder()
         m.roUrlTransfer.SetMessagePort(port)
         url = m.roUrlTransfer.GetUrl()
         m._traceRequest()
+        ' Capture the wall-clock dispatch time so the RUM resource start date reflects
+        ' when the request actually started, rather than being back-computed from the
+        ' report time (now - transferTime), which drifts with reporting latency.
+        startTime& = getTimestamp()
         timer.Mark()
         result = m.roUrlTransfer.AsyncPostFromFile(filename)
         if (not result)
@@ -302,6 +321,7 @@ function __DdUrlTransfer_builder()
                             url: url
                             method: "POST"
                             transferTime: transferTime#
+                            startTime: startTime&
                             httpCode: httpCode
                             status: status
                             traceId: m.traceId

--- a/library/components/rum/RumActionScope.bs
+++ b/library/components/rum/RumActionScope.bs
@@ -58,8 +58,12 @@ sub handleEvent(event as object, writer as object)
         end if
     else if (event.eventType = RawEvent.addResource)
         if (isValidResource(event.resource))
-            transferTime& = secToMillis(event.resource.transferTime)
-            resourceStartTimestamp& = timestamp& - transferTime&
+            if (event.resource.startTime <> invalid)
+                resourceStartTimestamp& = event.resource.startTime
+            else
+                transferTime& = secToMillis(event.resource.transferTime)
+                resourceStartTimestamp& = timestamp& - transferTime&
+            end if
             if (resourceStartTimestamp& <= (threshold&))
                 m.resourceCount++
                 m.lastEventTimestamp& = timestamp&

--- a/library/components/rum/RumViewScope.bs
+++ b/library/components/rum/RumViewScope.bs
@@ -323,6 +323,7 @@ end sub
 '  - bytesDownloaded (dynamic) the size of the downloaded payload (in bytes as integer) or invalid
 '  - traceId (dynamic) the id of the trace forwarded in the request header (as string), or invalid
 '  - spanId (dynamic) the id of the span forwarded in the request header (as string), or invalid
+'  - startTime (dynamic) the wall-clock dispatch time (ms since EPOCH) when the request started, or invalid
 ' @param context (object) an assocarray of custom attributes to add to the view
 ' @param writer (object) the writer node (see WriterTask component)
 ' ----------------------------------------------------------------
@@ -335,7 +336,14 @@ sub sendResource(resource as object, context as object, writer as object)
     if (m.top.activeAction <> invalid)
         actionId = m.top.activeAction@.getRumContext().actionId
     end if
-    startTimestampMs& = timestamp& - secToMillis(resource.transferTime)
+    ' Prefer the dispatch time captured when the request started; falling back to
+    ' (now - transferTime) drifts the resource start later by the latency between the
+    ' request completing and this event being serialized.
+    if (resource.startTime <> invalid)
+        startTimestampMs& = resource.startTime
+    else
+        startTimestampMs& = timestamp& - secToMillis(resource.transferTime)
+    end if
 
     resourceEvent = {
         _dd: {

--- a/library/source/wrapper/DdUrlTransfer.bs
+++ b/library/source/wrapper/DdUrlTransfer.bs
@@ -121,6 +121,10 @@ class DdUrlTransfer
 
         url = m.roUrlTransfer.GetUrl()
         m._traceRequest()
+        ' Capture the wall-clock dispatch time so the RUM resource start date reflects
+        ' when the request actually started, rather than being back-computed from the
+        ' report time (now - transferTime), which drifts with reporting latency.
+        startTime& = getTimestamp()
         timer.Mark()
         result = m.roUrlTransfer.AsyncGetToString()
         if (not result)
@@ -146,6 +150,7 @@ class DdUrlTransfer
                             url: url,
                             method: "GET",
                             transferTime: transferTime#,
+                            startTime: startTime&,
                             httpCode: httpCode,
                             status: status,
                             bytesDownloaded: bytesDownloaded,
@@ -186,6 +191,10 @@ class DdUrlTransfer
 
         url = m.roUrlTransfer.GetUrl()
         m._traceRequest()
+        ' Capture the wall-clock dispatch time so the RUM resource start date reflects
+        ' when the request actually started, rather than being back-computed from the
+        ' report time (now - transferTime), which drifts with reporting latency.
+        startTime& = getTimestamp()
         timer.Mark()
         result = m.roUrlTransfer.AsyncGetToFile(filename)
         if (not result)
@@ -211,6 +220,7 @@ class DdUrlTransfer
                             url: url,
                             method: "GET",
                             transferTime: transferTime#,
+                            startTime: startTime&,
                             httpCode: httpCode,
                             status: status,
                             bytesDownloaded: bytesDownloaded,
@@ -246,6 +256,10 @@ class DdUrlTransfer
 
         url = m.roUrlTransfer.GetUrl()
         m._traceRequest()
+        ' Capture the wall-clock dispatch time so the RUM resource start date reflects
+        ' when the request actually started, rather than being back-computed from the
+        ' report time (now - transferTime), which drifts with reporting latency.
+        startTime& = getTimestamp()
         timer.Mark()
         result = m.roUrlTransfer.AsyncPostFromString(request)
         if (not result)
@@ -269,6 +283,7 @@ class DdUrlTransfer
                             url: url,
                             method: "POST",
                             transferTime: transferTime#,
+                            startTime: startTime&,
                             httpCode: httpCode,
                             status: status,
                             traceId: m.traceId,
@@ -304,6 +319,10 @@ class DdUrlTransfer
 
         url = m.roUrlTransfer.GetUrl()
         m._traceRequest()
+        ' Capture the wall-clock dispatch time so the RUM resource start date reflects
+        ' when the request actually started, rather than being back-computed from the
+        ' report time (now - transferTime), which drifts with reporting latency.
+        startTime& = getTimestamp()
         timer.Mark()
         result = m.roUrlTransfer.AsyncPostFromFile(filename)
         if (not result)
@@ -327,6 +346,7 @@ class DdUrlTransfer
                             url: url,
                             method: "POST",
                             transferTime: transferTime#,
+                            startTime: startTime&,
                             httpCode: httpCode,
                             status: status,
                             traceId: m.traceId,

--- a/test/source/tests/rum/Test__RumActionScope.bs
+++ b/test/source/tests/rum/Test__RumActionScope.bs
@@ -26,6 +26,8 @@ function TestSuite__RumActionScope() as object
     this.addTest("WhenHandleResourceEvent_ThenWriteActionEvent", RumActionScopeTest__WhenHandleResourceEvent_ThenWriteActionEvent, RumActionScopeTest__SetUp, RumActionScopeTest__TearDown)
     this.addTest("WhenHandleResourceEventAfterTimeout_ThenWriteActionEvent", RumActionScopeTest__WhenHandleResourceEventAfterTimeout_ThenWriteActionEvent, RumActionScopeTest__SetUp, RumActionScopeTest__TearDown)
     this.addTest("WhenHandleLongResourceEvent_ThenWriteActionEvent", RumActionScopeTest__WhenHandleLongResourceEvent_ThenWriteActionEvent, RumActionScopeTest__SetUp, RumActionScopeTest__TearDown)
+    this.addTest("WhenHandleResourceEventWithStartTime_ThenCountsResourceInAction", RumActionScopeTest__WhenHandleResourceEventWithStartTime_ThenCountsResourceInAction, RumActionScopeTest__SetUp, RumActionScopeTest__TearDown)
+    this.addTest("WhenHandleResourceEventWithStartTimeAfterThreshold_ThenIgnoresResource", RumActionScopeTest__WhenHandleResourceEventWithStartTimeAfterThreshold_ThenIgnoresResource, RumActionScopeTest__SetUp, RumActionScopeTest__TearDown)
 
     this.addTest("WhenHandleFailedResourceEvent_ThenWriteActionEvent", RumActionScopeTest__WhenHandleFailedResourceEvent_ThenWriteActionEvent, RumActionScopeTest__SetUp, RumActionScopeTest__TearDown)
     this.addTest("WhenHandleFailedResourceEventAfterTimeout_ThenWriteActionEvent", RumActionScopeTest__WhenHandleFailedResourceEventAfterTimeout_ThenWriteActionEvent, RumActionScopeTest__SetUp, RumActionScopeTest__TearDown)
@@ -753,6 +755,101 @@ function RumActionScopeTest__WhenHandleLongResourceEvent_ThenWriteActionEvent() 
     Assert.that(actionEvent.action.error.count).isEqualTo(0)
     Assert.that(actionEvent.action.resource.count).isEqualTo(1)
     Assert.that(actionEvent.context).contains(m.fakeInitialContext)
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a RumActionScope
+'  When: handling a resource event carrying an explicit startTime within the threshold
+'  Then: counts the resource in the action (startTime is used for attribution, not transferTime)
+'----------------------------------------------------------------
+function RumActionScopeTest__WhenHandleResourceEventWithStartTime_ThenCountsResourceInAction() as string
+    ' Given
+    fakeApplicationId = IG_GetString(32)
+    fakeApplicationVersion = IG_GetString(32)
+    fakeService = IG_GetString(32)
+    fakeSessionId = IG_GetString(32)
+    fakeViewId = IG_GetString(32)
+    fakeViewName = IG_GetString(32)
+    fakeViewUrl = IG_GetString(32)
+    fakeParentContext = {
+        applicationId: fakeApplicationId,
+        service: fakeService,
+        sessionId: fakeSessionId,
+        applicationVersion: fakeApplicationVersion,
+        viewId: fakeViewId,
+        viewName: fakeViewName,
+        viewUrl: fakeViewUrl,
+        deviceName: m.fakeDeviceName,
+        deviceModel: m.fakeDeviceModel,
+        osVersion: m.fakeOsVersion,
+        osVersionMajor: m.fakeOsVersionMajor
+    }
+    m.mockParentScope@.stubCall("getRumContext", {}, fakeParentContext)
+    ' Capture startTime shortly after action creation — within the 100 ms inactivity threshold.
+    sleep(10)
+    fakeStartTime& = datadogroku_getTimestamp()
+    fakeResourceEvent = { mock: "event", eventType: "addResource", resource: { status: "ok", url: IG_GetString(32), transferTime: 0.001, startTime: fakeStartTime& } }
+    fakeEvent = { mock: "event", eventType: IG_GetString(16) }
+
+    ' When
+    m.testedScope@.handleEvent(fakeResourceEvent, m.mockWriter)
+    sleep(300)
+    m.testedScope@.handleEvent(fakeEvent, m.mockWriter)
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    Assert.that(updates).hasSize(1)
+    actionEvent = ParseJson(updates[0])
+    Assert.that(actionEvent).isNotInvalid()
+    Assert.that(actionEvent.type).isEqualTo("action")
+    Assert.that(actionEvent.action.resource.count).isEqualTo(1)
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a RumActionScope
+'  When: handling a resource event whose explicit startTime is after the inactivity threshold
+'  Then: does not count the resource in the action (attribution uses startTime, not arrival time)
+'----------------------------------------------------------------
+function RumActionScopeTest__WhenHandleResourceEventWithStartTimeAfterThreshold_ThenIgnoresResource() as string
+    ' Given
+    fakeApplicationId = IG_GetString(32)
+    fakeApplicationVersion = IG_GetString(32)
+    fakeService = IG_GetString(32)
+    fakeSessionId = IG_GetString(32)
+    fakeViewId = IG_GetString(32)
+    fakeViewName = IG_GetString(32)
+    fakeViewUrl = IG_GetString(32)
+    fakeParentContext = {
+        applicationId: fakeApplicationId,
+        service: fakeService,
+        sessionId: fakeSessionId,
+        applicationVersion: fakeApplicationVersion,
+        viewId: fakeViewId,
+        viewName: fakeViewName,
+        viewUrl: fakeViewUrl,
+        deviceName: m.fakeDeviceName,
+        deviceModel: m.fakeDeviceModel,
+        osVersion: m.fakeOsVersion,
+        osVersionMajor: m.fakeOsVersionMajor
+    }
+    m.mockParentScope@.stubCall("getRumContext", {}, fakeParentContext)
+    ' Capture startTime after the 100 ms inactivity threshold has elapsed.
+    sleep(200)
+    fakeStartTime& = datadogroku_getTimestamp()
+    fakeResourceEvent = { mock: "event", eventType: "addResource", resource: { status: "ok", url: IG_GetString(32), transferTime: 0.001, startTime: fakeStartTime& } }
+
+    ' When
+    m.testedScope@.handleEvent(fakeResourceEvent, m.mockWriter)
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    Assert.that(updates).hasSize(1)
+    actionEvent = ParseJson(updates[0])
+    Assert.that(actionEvent).isNotInvalid()
+    Assert.that(actionEvent.type).isEqualTo("action")
+    Assert.that(actionEvent.action.resource.count).isEqualTo(0)
     return ""
 end function
 

--- a/test/source/tests/rum/Test__RumViewScope.bs
+++ b/test/source/tests/rum/Test__RumViewScope.bs
@@ -44,6 +44,7 @@ function TestSuite__RumViewScope() as object
     this.addTest("WhenHandleAddResourceEventWithUserInfo_ThenWriteViewEvent", RumViewScopeTest__WhenHandleAddResourceEventWithUserInfo_ThenWriteViewEvent, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
     this.addTest("WhenHandleAddResourceEventWithAction_ThenWriteViewEvent", RumViewScopeTest__WhenHandleAddResourceEventWithAction_ThenWriteViewEvent, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
     this.addTest("WhenHandleAddMinimalResourceEvent_ThenWriteViewEvent", RumViewScopeTest__WhenHandleAddMinimalResourceEvent_ThenWriteViewEvent, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
+    this.addTest("WhenHandleAddResourceEventWithStartTime_ThenUsesStartTimeAsDate", RumViewScopeTest__WhenHandleAddResourceEventWithStartTime_ThenUsesStartTimeAsDate, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
 
     this.addTest("WhenHandleAddFailedResourceEvent_ThenWriteViewEvent", RumViewScopeTest__WhenHandleAddFailedResourceEvent_ThenWriteViewEvent, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
     this.addTest("WhenHandleAddFailedResourceEventWithGlobalContext_ThenWriteViewEvent", RumViewScopeTest__WhenHandleAddFailedResourceEventWithGlobalContext_ThenWriteViewEvent, RumViewScopeTest__SetUp, RumViewScopeTest__TearDown)
@@ -1387,6 +1388,55 @@ function RumViewScopeTest__WhenHandleAddResourceEvent_ThenWriteViewEvent() as st
     Assert.that(resourceEvent.resource.size).isEqualTo(fakeSize)
     ' TODO RUMM-2529 assert traceId and spanId
     ' TODO RUMM-2530 assert timings (dns, ssl, …)?
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a RumViewScope
+'  When: handling an event (addResource) carrying an explicit startTime
+'  Then: writes a resource event whose date is the provided startTime
+'        (not back-computed from now - transferTime)
+'----------------------------------------------------------------
+function RumViewScopeTest__WhenHandleAddResourceEventWithStartTime_ThenUsesStartTimeAsDate() as string
+    ' Given
+    fakeApplicationId = IG_GetString(32)
+    fakeApplicationVersion = IG_GetString(32)
+    fakeService = IG_GetString(32)
+    fakeSessionId = IG_GetString(32)
+    fakeParentContext = {
+        applicationId: fakeApplicationId,
+        service: fakeService,
+        sessionId: fakeSessionId,
+        applicationVersion: fakeApplicationVersion,
+        deviceName: m.fakeDeviceName,
+        deviceModel: m.fakeDeviceModel,
+        osVersion: m.fakeOsVersion,
+        osVersionMajor: m.fakeOsVersionMajor
+    }
+    m.mockParentScope@.stubCall("getRumContext", {}, fakeParentContext)
+    fakeResourceUrl = IG_GetString(128)
+    fakeMethod = IG_GetOneOf(["GET", "POST", "HEAD", "PUT"])
+    fakeHttpCode = IG_GetInteger(600)
+    fakeDurationNs& = IG_GetInteger()
+    nsToSec# = 1000000000
+    fakeTransferTime# = fakeDurationNs& / nsToSec#
+    fakeSize = IG_GetInteger()
+    ' Dispatch time well before "now" so it is distinguishable from (now - transferTime).
+    fakeStartTime& = datadogroku_getTimestamp() - 3600000 ' one hour earlier
+    fakeResource = { url: fakeResourceUrl, method: fakeMethod, status: "ok", httpCode: fakeHttpCode, transferTime: fakeTransferTime#, bytesDownloaded: fakeSize, startTime: fakeStartTime& }
+    fakeEvent = { mock: "event", eventType: "addResource", resource: fakeResource }
+
+    ' When
+    m.testedScope@.handleEvent(fakeEvent, m.mockWriter)
+
+    ' Then
+    updates = m.mockWriter@.getFieldUpdates("writeEvent")
+    Assert.that(updates).hasSize(1)
+    resourceEvent = ParseJson(updates[0])
+    Assert.that(resourceEvent).isNotInvalid()
+    Assert.that(resourceEvent.type).isEqualTo("resource")
+    Assert.that(resourceEvent.date).isEqualTo(fakeStartTime&)
+    Assert.that(resourceEvent.resource.duration).isInRange(fakeDurationNs& - 1000, fakeDurationNs& + 1000)
     return ""
 end function
 


### PR DESCRIPTION
Resource events derived their start date from the report time (now - transferTime) at the moment the event was serialized on the RUM thread. Any latency between request completion and serialization shifted the resource start later, so client resource spans could appear to start after the upstream APM spans they parent.

Capture the wall-clock dispatch time in DdUrlTransfer when the request starts and carry it on the resource as `startTime`. RumViewScope and RumActionScope now prefer this explicit start time, falling back to the previous computation when it is absent.

### What does this PR do?

Capture the wall clock time when the HTTP request starts, not when the request is serialized. 

### Motivation

When integrating our app's HTTP requests with tracing headers, we observed incorrect client request start times in flame graphs. The delta was very similar to behavior we observed with the Operations API that led to #160. 

### Additional Notes

See https://github.com/DataDog/dd-sdk-roku/issues/172

### Review checklist (to be filled by reviewers)

- [X] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [X] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [X] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

