### PR TITLE
Fix release skill: merge release branch without rebasing

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -165,26 +165,16 @@ And confirm the package page is accessible at: `https://www.npmjs.com/package/da
 
 Never push directly to `main` or `develop`. Both merges must go through PRs.
 
-Merge release branch into main via a PR. Fetch and rebase onto main first to ensure the branch is up to date:
+Open the PRs directly from `release/<version>` and merge each with a merge commit, so the tagged commit stays reachable from `main` and `develop`.
 
 ```bash
-git fetch origin main
-git checkout -b merge/release-<version>-to-main release/<version>
-git rebase origin/main
-git push -u origin merge/release-<version>-to-main
-gh pr create --base main --head merge/release-<version>-to-main --title "Merge release <version> to main" --body ""
+gh pr create --base main --head release/<version> --title "Merge release <version> to main" --body ""
 ```
 
 **GATE: Wait for user to confirm the PR has been merged.**
 
-Merge release branch into develop via a PR. Fetch and rebase onto develop first to ensure the branch is up to date:
-
 ```bash
-git fetch origin develop
-git checkout -b merge/release-<version>-to-develop release/<version>
-git rebase origin/develop
-git push -u origin merge/release-<version>-to-develop
-gh pr create --base develop --head merge/release-<version>-to-develop --title "Merge release <version> to develop" --body ""
+gh pr create --base develop --head release/<version> --title "Merge release <version> to develop" --body ""
 ```
 
 **GATE: Wait for user to confirm the PR has been merged.**


### PR DESCRIPTION
### What does this PR do?
Fixes Step 8 of the release skill so release tags land correctly.

Previously the skill rebased the release branch onto `main`/`develop` before merging, which rewrote the commit SHAs and left the version tag pointing at an orphaned commit (not an ancestor of either branch — as happened with the `1.4.0` tag). Step 8 now merges the release branch directly with a merge commit, keeping the tagged commit reachable from both `main` and `develop` (as it was for 1.2.0–1.3.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)