### PR TITLE
Update Sample app service name to "com.datadog.roku.sample"

### DIFF
--- a/sample/source/main.bs
+++ b/sample/source/main.bs
@@ -37,6 +37,7 @@ sub RunUserInterface(args as dynamic)
         applicationId: credentials.datadogApplicationId,
         site: credentials.site,
         env: "prod",
+        service: "com.datadog.roku.sample",
         launchArgs: args,
         traceSampleRate: 100,
         tracingHeaderTypes: credentials.mirrorHostsTracingHeaderTypes,


### PR DESCRIPTION
### What does this PR do?

Before this PR, since the service name is not explicitly set through sample app, it will fall back to channel name by default, which is "datadog_sample", which is not easy to identify as Roku service.

This PR changes it to "com.datadog.roku.sample" to aligned with other mobile SDK service



### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

