### PR TITLE
Unify BrighterScript build tooling across all targets

### DIFF
--- a/dist/components/rum/RumScope.brs
+++ b/dist/components/rum/RumScope.brs
@@ -28,7 +28,7 @@ end function
 ' @param event (object) the event to handle
 ' @param writer (object) the writer node (see WriterTask component)
 ' ----------------------------------------------------------------
-sub handleEvent(event as object, writer as object)
+sub handleEvent(event as object, _writer as object)
     ddLogVerbose("RumScope::handleEvent(" + FormatJson(event) + ", writer)")
 end sub
 

--- a/library/components/rum/RumScope.bs
+++ b/library/components/rum/RumScope.bs
@@ -30,7 +30,7 @@ end function
 ' @param event (object) the event to handle
 ' @param writer (object) the writer node (see WriterTask component)
 ' ----------------------------------------------------------------
-sub handleEvent(event as object, writer as object)
+sub handleEvent(event as object, _writer as object)
     ddLogVerbose("RumScope::handleEvent(" + FormatJson(event) + ", writer)")
 end sub
 

--- a/library/package.json
+++ b/library/package.json
@@ -6,9 +6,5 @@
   "scripts": {},
   "ropm": {
     "rootDir": "."
-  },
-  "devDependencies": {
-    "@rokucommunity/bslint": "^0.8.11",
-    "brighterscript": "^0.65.1"
   }
 }

--- a/sample/package.json
+++ b/sample/package.json
@@ -7,10 +7,6 @@
   "ropm": {
     "rootDir": "."
   },
-  "devDependencies": {
-    "@rokucommunity/bslint": "^0.8.11",
-    "brighterscript": "^0.65.1"
-  },
   "dependencies": {
     "datadog-roku": "../"
   }

--- a/tools/roku/build.sh
+++ b/tools/roku/build.sh
@@ -24,7 +24,7 @@ do
 
     # Needs to happen after calling bsc as it needs bslint in node_modules
     echo " - Cleanup node junk"
-    rm -r node_modules
+    rm -rf node_modules
 
     # back to root folder
     cd $cwd 


### PR DESCRIPTION
## Summary

- `library/` and `sample/` had `brighterscript@^0.65.1` and `bslint@^0.8.11` pinned locally, while `test/` had no devDependencies at all and silently fell back to the root's `0.69.13`. This meant two different compiler versions were running during the same build.
- Removed devDependencies from `library/` and `sample/` so all three targets now resolve `bsc` and `bslint` from the root `package.json` — one version, one place to update.
- Fixed `build.sh` to use `rm -rf` instead of `rm -r` so it doesn't error when a folder has no local `node_modules`.
- Renamed the unused `writer` param to `_writer` in the `RumScope` stub to match the existing `_ph` convention and silence the runtime lint warning (the param must exist to satisfy the interface, but this base implementation doesn't use it).

The compiler version change (`0.65.27` → `0.69.13`) produces byte-for-byte identical `dist/` output — verified by diffing before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)