### PR TITLE
Emit decimal span_id and zero-padded 32-char hex trace_id in RUM resource events

### DIFF
--- a/dist/source/wrapper/DdUrlTransfer.brs
+++ b/dist/source/wrapper/DdUrlTransfer.brs
@@ -727,44 +727,40 @@ function __DdUrlTransfer_builder()
         if (sessionId <> invalid and sessionId.len() > 0)
             m.AddHeader("baggage", "session.id=" + sessionId)
         end if
+        traceId = generateTraceId()
+        spanId = generateSpanId()
+        m.traceId = traceId.hex
+        m.spanId = spanId.decimal
         if (headerType = "datadog")
             ' Datadog uses a complex system for compatibility purposes
-            ddId = generateUniqueIdDd()
-            m.traceId = ddId[0]
-            m.spanId = generateUniqueId64(10)
-            m.AddHeader("x-datadog-trace-id", ddId[1])
-            m.AddHeader("x-datadog-tags", "_dd.p.tid=" + ddId[2])
-            m.AddHeader("x-datadog-parent-id", m.spanId)
+            m.AddHeader("x-datadog-trace-id", traceId.lowDecimal)
+            ' Only forward the high-order bits when they carry information: a
+            ' zero high part means a 64 bit trace id, for which the _dd.p.tid
+            ' tag must be omitted (matching the other Datadog SDKs).
+            if (traceId.highHex <> "0000000000000000")
+                m.AddHeader("x-datadog-tags", "_dd.p.tid=" + traceId.highHex)
+            end if
+            m.AddHeader("x-datadog-parent-id", spanId.decimal)
             m.AddHeader("x-datadog-sampling-priority", "1")
             m.AddHeader("x-datadog-origin", "rum")
         else if (headerType = "b3")
-            m.traceId = generateUniqueId128(16)
-            m.spanId = generateUniqueId64(16)
-            hexTraceId = padLeft(m.traceId, 32, "0")
-            hexSpanId = padLeft(m.spanId, 16, "0")
-            b3 = hexTraceId + "-" + hexSpanId + "-1"
+            b3 = traceId.hex + "-" + spanId.hex + "-1"
             m.AddHeader("b3", b3)
         else if (headerType = "b3multi")
-            m.traceId = generateUniqueId128(16)
-            m.spanId = generateUniqueId64(16)
-            m.AddHeader("X-B3-TraceId", m.traceId)
-            m.AddHeader("X-B3-SpanId", m.spanId)
+            m.AddHeader("X-B3-TraceId", traceId.hex)
+            m.AddHeader("X-B3-SpanId", spanId.hex)
             m.AddHeader("X-B3-Sampled", "1")
         else if (headerType = "tracecontext")
-            m.traceId = generateUniqueId128(16)
-            m.spanId = generateUniqueId64(16)
-            hexTraceId = padLeft(m.traceId, 32, "0")
-            hexSpanId = padLeft(m.spanId, 16, "0")
-            traceparent = "00-" + hexTraceId + "-" + hexSpanId + "-01"
+            traceparent = "00-" + traceId.hex + "-" + spanId.hex + "-01"
             m.AddHeader("traceparent", traceparent)
             usrId = m.global.datadogUserInfo.id
             if (usrId <> invalid)
                 usrIdByteArray = CreateObject("roByteArray")
                 usrIdByteArray.FromAsciiString(usrId)
                 usrIdBase64 = usrIdByteArray.ToBase64String().Replace("=", "~")
-                tracestate = "dd=s:1;o:rum;p:" + hexSpanId + ";t.usr.id:" + usrIdBase64
+                tracestate = "dd=s:1;o:rum;p:" + spanId.hex + ";t.usr.id:" + usrIdBase64
             else
-                tracestate = "dd=s:1;o:rum;p:" + hexSpanId
+                tracestate = "dd=s:1;o:rum;p:" + spanId.hex
             end if
             m.AddHeader("tracestate", tracestate)
         else
@@ -877,46 +873,84 @@ function getTracedHeaderType(url as string, tracingHeaderTypes as object) as dyn
 end function
 
 ' ----------------------------------------------------------------
-' Generates a unique identifier as a 64 bits random number
-' @param radix (integer) the radix to use when representing the id as a string
-' @return (string) the generated Unique id
+' Generates a 128 bit trace id with all the representations required
+' by the supported tracing headers and the RUM resource event.
+'
+' The backend (rum-span-mapper) only correlates a RUM resource to an APM
+' span when `_dd.trace_id` is either a 64 bit decimal number or a 128 bit
+' hexadecimal number padded to exactly 32 chars; an unpadded hexadecimal
+' id (shorter than 32 chars) is rejected. We therefore zero-pad the id.
+'
+' @return (object) an associative array with the following entries:
+'   - hex (string) the full 128 bit id as a 32 char zero-padded hexadecimal
+'       string (used by the RUM event, the W3C and the B3 headers)
+'   - lowDecimal (string) the low 64 bit part in decimal (used by the legacy
+'       x-datadog-trace-id header)
+'   - highHex (string) the high 64 bit part as a 16 char zero-padded
+'       hexadecimal string (used by the _dd.p.tid Datadog tag)
 ' ----------------------------------------------------------------
-function generateUniqueId64(radix = 10 as integer) as string
-    maxInt = 4294967295
-    return printIdToString(0, 0, Rnd(maxInt) - 1, Rnd(maxInt) - 1, radix)
+function generateTraceId() as object
+    high0& = random32()
+    high1& = random32()
+    low0& = random32()
+    low1& = random32()
+    return {
+        hex: padLeft(printIdToString(high0&, high1&, low0&, low1&, 16), 32, "0")
+        lowDecimal: renderId64(low0&, low1&).decimal
+        highHex: renderId64(high0&, high1&).hex
+    }
 end function
 
 ' ----------------------------------------------------------------
-' Generates a unique identifier as a 128 bits random number
-' @param radix (integer) the radix to use when representing the id as a string
-' @return (string) the generated Unique id
+' Generates a 64 bit span id with all the representations required
+' by the supported tracing headers and the RUM resource event.
+'
+' The backend (rum-span-mapper) only correlates a RUM resource to an APM
+' span when `_dd.span_id` is a strictly positive decimal number; a
+' hexadecimal span id is rejected. We therefore expose a decimal form for
+' the RUM event and the Datadog header, and a hexadecimal form for the
+' W3C and B3 headers.
+'
+' @return (object) an associative array with the following entries:
+'   - decimal (string) the id in decimal (used by the RUM event and the
+'       x-datadog-parent-id header)
+'   - hex (string) the id as a 16 char zero-padded hexadecimal string
+'       (used by the W3C and B3 headers)
 ' ----------------------------------------------------------------
-function generateUniqueId128(radix = 10 as integer) as string
-    maxInt = 4294967295
-    return printIdToString(Rnd(maxInt) - 1, Rnd(maxInt) - 1, Rnd(maxInt) - 1, Rnd(maxInt) - 1, radix)
+function generateSpanId() as object
+    return renderId64(random32(), random32())
 end function
 
 ' ----------------------------------------------------------------
-' Generates a unique identifier as a 128 bits random number, fit for Datadog's specification
-' @return (array) the array with the generated id as a list of strings:
-'     - the full 128 bit id in hexadecimal
-'     - the low 64 bit part of the id in decimal (compatible with Datadog's legacy x-datadog-trace-id header)
-'     - the high 64 bit part of the id in id in hexadecimal
+' Renders a 64 bit id (given as two 32 bit halves) in the representations
+' shared by the trace and span id generators.
+' @param hi& (longinteger) the high 32 bits
+' @param lo& (longinteger) the low 32 bits
+' @return (object) an associative array with the following entries:
+'   - decimal (string) the id in decimal (used by the RUM event and the
+'       Datadog headers)
+'   - hex (string) the id as a 16 char zero-padded hexadecimal string
+'       (used by the W3C and B3 headers)
 ' ----------------------------------------------------------------
-function generateUniqueIdDd() as object
-    maxInt = 4294967295
-    high0& = Rnd(maxInt) - 1
-    high1& = Rnd(maxInt) - 1
-    low0& = Rnd(maxInt) - 1
-    low1& = Rnd(maxInt) - 1
-    fullId = printIdToString(high0&, high1&, low0&, low1&, 16)
-    lowId = printIdToString(0, 0, low0&, low1&, 10)
-    highId = printIdToString(0, 0, high0&, high1&, 16)
-    return [
-        fullId
-        lowId
-        highId
-    ]
+function renderId64(hi& as longinteger, lo& as longinteger) as object
+    return {
+        decimal: printIdToString(0, 0, hi&, lo&, 10)
+        hex: padLeft(printIdToString(0, 0, hi&, lo&, 16), 16, "0")
+    }
+end function
+
+' ----------------------------------------------------------------
+' Generates a uniformly distributed unsigned 32 bit value.
+'
+' BrightScript's `Rnd(n)` takes a signed 32 bit Integer, so it cannot be
+' asked directly for the full unsigned 32 bit range; we assemble the value
+' from two independent 16 bit draws instead.
+' @return (longinteger) a value in [0, 4294967295]
+' ----------------------------------------------------------------
+function random32() as longinteger
+    high& = Rnd(65536) - 1 ' 0..65535
+    low& = Rnd(65536) - 1 ' 0..65535
+    return (high& << 16) + low&
 end function
 
 function printIdToString(li0& as longinteger, li1& as longinteger, li2& as longinteger, li3& as longinteger, radix = 10 as integer) as string
@@ -947,6 +981,12 @@ function printIdToString(li0& as longinteger, li1& as longinteger, li2& as longi
             id = chr(digit + 87) + id ' char 'a' is 97 = 10 + 87
         end if
     end while
+    ' A zero value produces no digits in the loop above; return "0" rather than
+    ' an empty string so decimal ids stay valid (e.g. the backend requires
+    ' `_dd.span_id` to be a strictly positive decimal, and "" / missing is rejected).
+    if (id = "")
+        return "0"
+    end if
     return id
 end function
 

--- a/library/source/wrapper/DdUrlTransfer.bs
+++ b/library/source/wrapper/DdUrlTransfer.bs
@@ -773,44 +773,42 @@ class DdUrlTransfer
         if (sessionId <> invalid and sessionId.len() > 0)
             m.AddHeader("baggage","session.id=" + sessionId)
         end if
+
+        traceId = generateTraceId()
+        spanId = generateSpanId()
+        m.traceId = traceId.hex
+        m.spanId = spanId.decimal
+
         if (headerType = TracingHeaderType.datadog)
             ' Datadog uses a complex system for compatibility purposes
-            ddId = generateUniqueIdDd()
-            m.traceId = ddId[0]
-            m.spanId = generateUniqueId64(10)
-            m.AddHeader("x-datadog-trace-id", ddId[1])
-            m.AddHeader("x-datadog-tags", "_dd.p.tid=" + ddId[2])
-            m.AddHeader("x-datadog-parent-id", m.spanId)
+            m.AddHeader("x-datadog-trace-id", traceId.lowDecimal)
+            ' Only forward the high-order bits when they carry information: a
+            ' zero high part means a 64 bit trace id, for which the _dd.p.tid
+            ' tag must be omitted (matching the other Datadog SDKs).
+            if (traceId.highHex <> "0000000000000000")
+                m.AddHeader("x-datadog-tags", "_dd.p.tid=" + traceId.highHex)
+            end if
+            m.AddHeader("x-datadog-parent-id", spanId.decimal)
             m.AddHeader("x-datadog-sampling-priority", "1")
             m.AddHeader("x-datadog-origin", "rum")
         else if (headerType = TracingHeaderType.b3)
-            m.traceId = generateUniqueId128(16)
-            m.spanId = generateUniqueId64(16)
-            hexTraceId = padLeft(m.traceId, 32, "0")
-            hexSpanId = padLeft(m.spanId, 16, "0")
-            b3 = hexTraceId + "-" + hexSpanId + "-1"
+            b3 = traceId.hex + "-" + spanId.hex + "-1"
             m.AddHeader("b3", b3)
         else if (headerType = TracingHeaderType.b3multi)
-            m.traceId = generateUniqueId128(16)
-            m.spanId = generateUniqueId64(16)
-            m.AddHeader("X-B3-TraceId", m.traceId)
-            m.AddHeader("X-B3-SpanId", m.spanId)
+            m.AddHeader("X-B3-TraceId", traceId.hex)
+            m.AddHeader("X-B3-SpanId", spanId.hex)
             m.AddHeader("X-B3-Sampled", "1")
         else if (headerType = TracingHeaderType.tracecontext)
-            m.traceId = generateUniqueId128(16)
-            m.spanId = generateUniqueId64(16)
-            hexTraceId = padLeft(m.traceId, 32, "0")
-            hexSpanId = padLeft(m.spanId, 16, "0")
-            traceparent = "00-" + hexTraceId + "-" + hexSpanId + "-01"
+            traceparent = "00-" + traceId.hex + "-" + spanId.hex + "-01"
             m.AddHeader("traceparent", traceparent)
             usrId = m.global.datadogUserInfo.id
             if (usrId <> invalid)
                 usrIdByteArray = CreateObject("roByteArray")
                 usrIdByteArray.FromAsciiString(usrId)
                 usrIdBase64 = usrIdByteArray.ToBase64String().Replace("=", "~")
-                tracestate = "dd=s:1;o:rum;p:" + hexSpanId + ";t.usr.id:" + usrIdBase64
+                tracestate = "dd=s:1;o:rum;p:" + spanId.hex + ";t.usr.id:" + usrIdBase64
             else
-                tracestate = "dd=s:1;o:rum;p:" + hexSpanId
+                tracestate = "dd=s:1;o:rum;p:" + spanId.hex
             end if
             m.AddHeader("tracestate", tracestate)
         else
@@ -923,45 +921,85 @@ function getTracedHeaderType(url as string, tracingHeaderTypes as object) as dyn
 end function
 
 ' ----------------------------------------------------------------
-' Generates a unique identifier as a 64 bits random number
-' @param radix (integer) the radix to use when representing the id as a string
-' @return (string) the generated Unique id
+' Generates a 128 bit trace id with all the representations required
+' by the supported tracing headers and the RUM resource event.
+'
+' The backend (rum-span-mapper) only correlates a RUM resource to an APM
+' span when `_dd.trace_id` is either a 64 bit decimal number or a 128 bit
+' hexadecimal number padded to exactly 32 chars; an unpadded hexadecimal
+' id (shorter than 32 chars) is rejected. We therefore zero-pad the id.
+'
+' @return (object) an associative array with the following entries:
+'   - hex (string) the full 128 bit id as a 32 char zero-padded hexadecimal
+'       string (used by the RUM event, the W3C and the B3 headers)
+'   - lowDecimal (string) the low 64 bit part in decimal (used by the legacy
+'       x-datadog-trace-id header)
+'   - highHex (string) the high 64 bit part as a 16 char zero-padded
+'       hexadecimal string (used by the _dd.p.tid Datadog tag)
 ' ----------------------------------------------------------------
-function generateUniqueId64(radix = 10 as integer) as string
-    maxInt = 4294967295
-    return printIdToString(0, 0, Rnd(maxInt) - 1, Rnd(maxInt) - 1, radix)
+function generateTraceId() as object
+    high0& = random32()
+    high1& = random32()
+    low0& = random32()
+    low1& = random32()
+
+    return {
+        hex: padLeft(printIdToString(high0&, high1&, low0&, low1&, 16), 32, "0"),
+        lowDecimal: renderId64(low0&, low1&).decimal,
+        highHex: renderId64(high0&, high1&).hex
+    }
 end function
 
-
 ' ----------------------------------------------------------------
-' Generates a unique identifier as a 128 bits random number
-' @param radix (integer) the radix to use when representing the id as a string
-' @return (string) the generated Unique id
+' Generates a 64 bit span id with all the representations required
+' by the supported tracing headers and the RUM resource event.
+'
+' The backend (rum-span-mapper) only correlates a RUM resource to an APM
+' span when `_dd.span_id` is a strictly positive decimal number; a
+' hexadecimal span id is rejected. We therefore expose a decimal form for
+' the RUM event and the Datadog header, and a hexadecimal form for the
+' W3C and B3 headers.
+'
+' @return (object) an associative array with the following entries:
+'   - decimal (string) the id in decimal (used by the RUM event and the
+'       x-datadog-parent-id header)
+'   - hex (string) the id as a 16 char zero-padded hexadecimal string
+'       (used by the W3C and B3 headers)
 ' ----------------------------------------------------------------
-function generateUniqueId128(radix = 10 as integer) as string
-    maxInt = 4294967295
-    return printIdToString(Rnd(maxInt) - 1, Rnd(maxInt) - 1, Rnd(maxInt) - 1, Rnd(maxInt) - 1, radix)
+function generateSpanId() as object
+    return renderId64(random32(), random32())
 end function
 
 ' ----------------------------------------------------------------
-' Generates a unique identifier as a 128 bits random number, fit for Datadog's specification
-' @return (array) the array with the generated id as a list of strings:
-'     - the full 128 bit id in hexadecimal
-'     - the low 64 bit part of the id in decimal (compatible with Datadog's legacy x-datadog-trace-id header)
-'     - the high 64 bit part of the id in id in hexadecimal
+' Renders a 64 bit id (given as two 32 bit halves) in the representations
+' shared by the trace and span id generators.
+' @param hi& (longinteger) the high 32 bits
+' @param lo& (longinteger) the low 32 bits
+' @return (object) an associative array with the following entries:
+'   - decimal (string) the id in decimal (used by the RUM event and the
+'       Datadog headers)
+'   - hex (string) the id as a 16 char zero-padded hexadecimal string
+'       (used by the W3C and B3 headers)
 ' ----------------------------------------------------------------
-function generateUniqueIdDd() as object
-    maxInt = 4294967295
-    high0& = Rnd(maxInt) - 1
-    high1& = Rnd(maxInt) - 1
-    low0& = Rnd(maxInt) - 1
-    low1& = Rnd(maxInt) - 1
+function renderId64(hi& as longinteger, lo& as longinteger) as object
+    return {
+        decimal: printIdToString(0, 0, hi&, lo&, 10),
+        hex: padLeft(printIdToString(0, 0, hi&, lo&, 16), 16, "0")
+    }
+end function
 
-    fullId = printIdToString(high0&, high1&, low0&, low1&, 16)
-    lowId = printIdToString(0, 0, low0&, low1&, 10)
-    highId = printIdToString(0, 0, high0&, high1&, 16)
-
-    return [fullId, lowId, highId]
+' ----------------------------------------------------------------
+' Generates a uniformly distributed unsigned 32 bit value.
+'
+' BrightScript's `Rnd(n)` takes a signed 32 bit Integer, so it cannot be
+' asked directly for the full unsigned 32 bit range; we assemble the value
+' from two independent 16 bit draws instead.
+' @return (longinteger) a value in [0, 4294967295]
+' ----------------------------------------------------------------
+function random32() as longinteger
+    high& = Rnd(65536) - 1 ' 0..65535
+    low& = Rnd(65536) - 1 ' 0..65535
+    return (high& << 16) + low&
 end function
 
 function printIdToString(li0& as longinteger, li1& as longinteger, li2& as longinteger, li3& as longinteger, radix = 10 as integer) as string
@@ -996,6 +1034,13 @@ function printIdToString(li0& as longinteger, li1& as longinteger, li2& as longi
             id = chr(digit + 87) + id ' char 'a' is 97 = 10 + 87
         end if
     end while
+
+    ' A zero value produces no digits in the loop above; return "0" rather than
+    ' an empty string so decimal ids stay valid (e.g. the backend requires
+    ' `_dd.span_id` to be a strictly positive decimal, and "" / missing is rejected).
+    if (id = "")
+        return "0"
+    end if
 
     return id
 end function

--- a/test/source/tests/Test__DdUrlTransfer.bs
+++ b/test/source/tests/Test__DdUrlTransfer.bs
@@ -21,17 +21,18 @@ function TestSuite__DdUrlTransfer() as object
     this.addTest("WhenPadLeftWithLargeString_ThenReturnOriginalString", DdUrlTransferTest__WhenPadLeftWithLargeString_ThenReturnOriginalString)
     this.addTest("WhenPadLeftWithSmallString_ThenReturnOriginalString", DdUrlTransferTest__WhenPadLeftWithSmallString_ThenReturnOriginalString)
 
-    this.addTest("WhenGenerateUniqueId64_ThenGenerateIdDecimal", DdUrlTransferTest__WhenGenerateUniqueId64_ThenGenerateIdDecimal)
-    this.addTest("WhenGenerateUniqueId64_ThenGenerateIdHexadecimal", DdUrlTransferTest__WhenGenerateUniqueId64_ThenGenerateIdHexadecimal)
-    this.addTest("WhenGenerateUniqueId128_ThenGenerateIdDecimal", DdUrlTransferTest__WhenGenerateUniqueId128_ThenGenerateIdDecimal)
-    this.addTest("WhenGenerateUniqueId128_ThenGenerateIdHexadecimal", DdUrlTransferTest__WhenGenerateUniqueId128_ThenGenerateIdHexadecimal)
-    this.addTest("WhenGenerateUniqueIdDd_ThenGenerateAllId", DdUrlTransferTest__WhenGenerateUniqueIdDd_ThenGenerateAllId)
+    this.addTest("WhenGenerateTraceId_ThenAllRepresentationsAreValid", DdUrlTransferTest__WhenGenerateTraceId_ThenAllRepresentationsAreValid)
+    this.addTest("WhenGenerateSpanId_ThenDecimalAndPaddedHex", DdUrlTransferTest__WhenGenerateSpanId_ThenDecimalAndPaddedHex)
     this.addTest("WhenPrintIdToString_ThenGenerateStringId", DdUrlTransferTest__WhenPrintIdToString_ThenGenerateStringId)
     this.addTest("WhenAddSampledInHeaders_ThenHeadersHaveSessionId", DdUrlTransferTest__WhenAddSampledInHeaders_ThenHeadersHaveSessionId)
     this.addTest("WhenDeleteTracingHeaders_ThenDeleteOnlySessionId", DdUrlTransferTest__WhenDeleteTracingHeaders_ThenDeleteOnlySessionId)
     this.addTest("WhenDeleteTracingHeaders_ThenDeleteCorrectHeaders", DdUrlTransferTest__WhenDeleteTracingHeaders_ThenDeleteCorrectHeaders)
 
     this.addTest("WhenSampledIn_ThenHaveSampleInHeaders", DdUrlTransferTest__WhenSampledIn_ThenHaveSampleInHeaders)
+    this.addTest("WhenSampledInWithDatadog_ThenEventIdsAndHeadersAreValid", DdUrlTransferTest__WhenSampledInWithDatadog_ThenEventIdsAndHeadersAreValid)
+    this.addTest("WhenSampledInWithB3_ThenEventIdsAndHeadersAreValid", DdUrlTransferTest__WhenSampledInWithB3_ThenEventIdsAndHeadersAreValid)
+    this.addTest("WhenSampledInWithB3Multi_ThenEventIdsAndHeadersAreValid", DdUrlTransferTest__WhenSampledInWithB3Multi_ThenEventIdsAndHeadersAreValid)
+    this.addTest("WhenSampledInWithTraceContext_ThenEventIdsAndHeadersAreValid", DdUrlTransferTest__WhenSampledInWithTraceContext_ThenEventIdsAndHeadersAreValid)
     this.addTest("WhenSampledOutAndTraceContextInjectionAll_ThenHaveSampleInHeaders", DdUrlTransferTest__WhenSampledOutAndTraceContextInjectionAll_ThenHaveSampleInHeaders)
     this.addTest("WhenSampledOutAndTraceContextInjectioSampled_ThenHaveSampleInHeaders", DdUrlTransferTest__WhenSampledOutAndTraceContextInjectioSampled_ThenHaveSampleInHeaders)
 
@@ -231,93 +232,37 @@ end function
 
 '----------------------------------------------------------------
 ' Given:
-'  When: call the generateUniqueId64 method
-'  Then: returns a 64 bits unique id
+'  When: call the generateTraceId method
+'  Then: returns a trace id with a 32 char zero-padded hexadecimal form
+'        (required by the backend), a decimal low part and a 16 char
+'        zero-padded hexadecimal high part
 '----------------------------------------------------------------
-function DdUrlTransferTest__WhenGenerateUniqueId64_ThenGenerateIdDecimal() as string
-    ' Given
-
+function DdUrlTransferTest__WhenGenerateTraceId_ThenAllRepresentationsAreValid() as string
     ' When
-    id = datadogroku_generateUniqueId64()
+    traceId = datadogroku_generateTraceId()
 
     ' Then
-    ' 64 bit ids will never have more than 20 chars in decimal representation
-    Assert.that(Len(id)).isInRange(1, 20)
-    Assert.that(id).matches("^[0-9]+$")
+    Assert.that(traceId.hex).matches("^[0-9a-f]{32}$", "i")
+    Assert.that(traceId.lowDecimal).matches("^[0-9]+$")
+    Assert.that(traceId.highHex).matches("^[0-9a-f]{16}$", "i")
+    ' the full hex id always ends with the low 64 bits and starts with the high 64 bits
+    Assert.that(traceId.hex).matches("^" + traceId.highHex + "[0-9a-f]{16}$", "i")
     return ""
 end function
 
 '----------------------------------------------------------------
 ' Given:
-'  When: call the generateUniqueId64 method
-'  Then: returns a 64 bits unique id
+'  When: call the generateSpanId method
+'  Then: returns a span id with a decimal form (required by the backend)
+'        and a 16 char zero-padded hexadecimal form
 '----------------------------------------------------------------
-function DdUrlTransferTest__WhenGenerateUniqueId64_ThenGenerateIdHexadecimal() as string
-    ' Given
-
+function DdUrlTransferTest__WhenGenerateSpanId_ThenDecimalAndPaddedHex() as string
     ' When
-    id = datadogroku_generateUniqueId64(16)
+    spanId = datadogroku_generateSpanId()
 
     ' Then
-    ' 64 bit ids will never have more than 16 chars in hexadecimal representation
-    Assert.that(Len(id)).isInRange(1, 16)
-    Assert.that(id).matches("^[0-9a-f]+$", "i")
-    return ""
-end function
-
-'----------------------------------------------------------------
-' Given:
-'  When: call the generateUniqueId64 method
-'  Then: returns a 64 bits unique id
-'----------------------------------------------------------------
-function DdUrlTransferTest__WhenGenerateUniqueId128_ThenGenerateIdDecimal() as string
-    ' Given
-
-    ' When
-    id = datadogroku_generateUniqueId128()
-
-    ' Then
-    ' 64 bit ids will never have more than 39 chars in decimal representation
-    Assert.that(Len(id)).isInRange(1, 39)
-    Assert.that(id).matches("^[0-9]+$")
-    return ""
-end function
-
-'----------------------------------------------------------------
-' Given:
-'  When: call the generateUniqueId64 method
-'  Then: returns a 64 bits unique id
-'----------------------------------------------------------------
-function DdUrlTransferTest__WhenGenerateUniqueId128_ThenGenerateIdHexadecimal() as string
-    ' Given
-
-    ' When
-    id = datadogroku_generateUniqueId128(16)
-
-    ' Then
-    ' 64 bit ids will never have more than 32 chars in hexadecimal representation
-    Assert.that(Len(id)).isInRange(1, 32)
-    Assert.that(id).matches("^[0-9a-f]+$", "i")
-    return ""
-end function
-
-'----------------------------------------------------------------
-' Given:
-'  When: call the printIdToString method
-'  Then: returns a 64 bits unique id
-'----------------------------------------------------------------
-function DdUrlTransferTest__WhenGenerateUniqueIdDd_ThenGenerateAllId() as string
-    ' Given
-
-    ' When
-    id = datadogroku_generateUniqueIdDd()
-
-    ' Then
-    Assert.that(id).hasSize(3)
-    ' the full id always starts with the high id as both are hexadecimal representations
-    Assert.that(id[0]).matches("^" + id[2] + "[0-9a-f]{16}$", "i")
-    Assert.that(id[1]).matches("^[0-9]+$", "i")
-    Assert.that(id[2]).matches("^[0-9a-f]+$", "i")
+    Assert.that(spanId.decimal).matches("^[0-9]+$")
+    Assert.that(spanId.hex).matches("^[0-9a-f]{16}$", "i")
     return ""
 end function
 
@@ -340,6 +285,10 @@ function DdUrlTransferTest__WhenPrintIdToString_ThenGenerateStringId() as string
     Assert.that(datadogroku_printIdToString(0, 0, 16, 0, hexRadix)).isEqualTo("1000000000")
     Assert.that(datadogroku_printIdToString(0, 815, 0, 0, hexRadix)).isEqualTo("32f0000000000000000")
     Assert.that(datadogroku_printIdToString(23, 0, 0, 0, hexRadix)).isEqualTo("17000000000000000000000000")
+
+    ' a zero value must render as "0", not an empty string, in any radix
+    Assert.that(datadogroku_printIdToString(0, 0, 0, 0, decRadix)).isEqualTo("0")
+    Assert.that(datadogroku_printIdToString(0, 0, 0, 0, hexRadix)).isEqualTo("0")
 
     return ""
 end function
@@ -459,6 +408,110 @@ function DdUrlTransferTest__WhenSampledIn_ThenHaveSampleInHeaders() as string
     result = ddUrlTransfer.GetHeader("baggage")
     Assert.that(result[0]).isEqualTo("session.id=" + fakeSessionId)
     return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a request sampled in with the "datadog" header type
+'  When: _traceRequest is called
+'  Then: the RUM event trace id is 32 char hexadecimal and the span id is
+'        decimal (so the backend rum-span-mapper can correlate it to APM),
+'        and the datadog headers carry the decimal / hex representations
+'----------------------------------------------------------------
+function DdUrlTransferTest__WhenSampledInWithDatadog_ThenEventIdsAndHeadersAreValid() as string
+    ddUrlTransfer = sampledInTraceRequest("datadog")
+
+    ' Wire headers
+    Assert.that(ddUrlTransfer.GetHeader("x-datadog-trace-id")[0]).matches("^[0-9]+$")
+    Assert.that(ddUrlTransfer.GetHeader("x-datadog-parent-id")[0]).isEqualTo(ddUrlTransfer.spanId)
+    Assert.that(ddUrlTransfer.GetHeader("x-datadog-tags")[0]).matches("^_dd.p.tid=[0-9a-f]{16}$", "i")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a request sampled in with the "b3" header type
+'  When: _traceRequest is called
+'  Then: the RUM event trace id is 32 char hexadecimal and the span id is
+'        decimal, and the b3 header uses the padded hexadecimal forms
+'----------------------------------------------------------------
+function DdUrlTransferTest__WhenSampledInWithB3_ThenEventIdsAndHeadersAreValid() as string
+    ddUrlTransfer = sampledInTraceRequest("b3")
+
+    ' Wire header
+    Assert.that(ddUrlTransfer.GetHeader("b3")[0]).matches("^[0-9a-f]{32}-[0-9a-f]{16}-1$", "i")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a request sampled in with the "b3multi" header type
+'  When: _traceRequest is called
+'  Then: the RUM event trace id is 32 char hexadecimal and the span id is
+'        decimal, and the X-B3-* headers use the padded hexadecimal forms
+'----------------------------------------------------------------
+function DdUrlTransferTest__WhenSampledInWithB3Multi_ThenEventIdsAndHeadersAreValid() as string
+    ddUrlTransfer = sampledInTraceRequest("b3multi")
+
+    ' Wire headers
+    Assert.that(ddUrlTransfer.GetHeader("X-B3-TraceId")[0]).matches("^[0-9a-f]{32}$", "i")
+    Assert.that(ddUrlTransfer.GetHeader("X-B3-SpanId")[0]).matches("^[0-9a-f]{16}$", "i")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Given: a request sampled in with the "tracecontext" header type
+'  When: _traceRequest is called
+'  Then: the RUM event trace id is 32 char hexadecimal and the span id is
+'        decimal, and the traceparent header uses the padded hexadecimal forms
+'----------------------------------------------------------------
+function DdUrlTransferTest__WhenSampledInWithTraceContext_ThenEventIdsAndHeadersAreValid() as string
+    ddUrlTransfer = sampledInTraceRequest("tracecontext")
+
+    ' Wire header
+    Assert.that(ddUrlTransfer.GetHeader("traceparent")[0]).matches("^00-[0-9a-f]{32}-[0-9a-f]{16}-01$", "i")
+    return ""
+end function
+
+'----------------------------------------------------------------
+' Runs a sampled-in trace request for the given header type and asserts the
+' shared RUM event contract: the trace id is a 32 char hexadecimal string and
+' the span id is decimal (so the backend rum-span-mapper can correlate the
+' resource to an APM span). Returns the ddUrlTransfer so the caller can assert
+' the header-type-specific wire headers.
+'----------------------------------------------------------------
+function sampledInTraceRequest(headerType as string) as object
+    ddUrlTransfer = datadogroku_DdUrlTransfer(createTracingGlobal(headerType))
+    ddUrlTransfer.SetUrl("https://datadog.com")
+    ddUrlTransfer._traceRequest()
+
+    ' RUM event fields (validated by the backend)
+    Assert.that(ddUrlTransfer.traceId).matches("^[0-9a-f]{32}$", "i")
+    Assert.that(ddUrlTransfer.spanId).matches("^[0-9]+$")
+    return ddUrlTransfer
+end function
+
+'----------------------------------------------------------------
+' Builds a fake global node configured to trace requests to datadog.com
+' with the given tracing header type, at a 100% sample rate.
+'----------------------------------------------------------------
+function createTracingGlobal(headerType as string) as object
+    fakeDatadogRumAgent = CreateObject("roSGNode", "datadogRoku_RumAgent")
+    fakeGlobal = {
+        datadogRumContext: {
+            sessionId: IG_GetString(16)
+        },
+        datadogRumAgent: fakeDatadogRumAgent,
+        datadogTraceAgent: {
+            traceSampleRate: 100,
+            tracingHeaderTypes: [
+                {
+                    "host": "datadog.com",
+                    "header": headerType
+                }
+            ],
+            traceContextInjection: "sampled"
+        },
+        datadogUserInfo: { id: IG_GetString(8), name: IG_GetString(16), email: IG_GetString(32) }
+    }
+    return fakeGlobal
 end function
 
 


### PR DESCRIPTION
### What does this PR do?

Fixes RUM → APM correlation for resources tracked via `DdUrlTransfer`. RUM resource events now carry a backend-valid `_dd.trace_id` (32-char zero-padded hexadecimal) and `_dd.span_id` (decimal), so the rum-span-mapper backend can generate the corresponding APM span instead of silently dropping the event.


Trace IDs were appearing on the RUM side but the trace was never propagated to APM.


<img width="1059" height="462" alt="image" src="https://github.com/user-attachments/assets/b4c24cf4-32bc-407e-a540-f772274e9b2a" />


 The rum-span-mapper backend validates each RUM resource before generating a span:

- _dd.span_id [must be a strictly positive decimal number](https://github.com/DataDog/logs-backend/blob/b227d684e35fc72df11de9491b372f159e5099e4/domains/rum/apps/rum-span-mapper/src/main/java/com/dd/rum/spanmapper/actors/Filterer.java#L203) (NumberUtils.isDigits + > 0).
- _dd.trace_id [must be either a decimal 64-bit number or a 128-bit hexadecimal padded to exactly 32 chars ](https://github.com/DataDog/logs-backend/blob/b227d684e35fc72df11de9491b372f159e5099e4/domains/rum/apps/rum-span-mapper/src/main/java/com/dd/rum/spanmapper/models/ParsedTraceId.java#L9)(ParsedTraceId.is128bitsHexEncodedTraceId).

The Roku SDK violated both:
|   Header type |  span_id written to event | Result|
| --- | ---| --- |
|datadog| decimal| trace_id sometimes unpadded → intermittently dropped|
|b3 / b3multi / tracecontext|hexadecimal| INVALID_SPAN_ID → always dropped|

A hex span_id containing any a–f fails isDigits, so for the W3C/B3 header types correlation essentially never worked; an unpadded trace_id (leading-zero nibbles) caused intermittent failures across all types.

Changes

- Added `generateTraceId()` / `generateSpanId()` helpers that generate an id once and expose every representation each consumer needs (decimal, 16-char and 32-char zero-padded hex).
- Reworked `_addSampledInHeaders` so the RUM event always stores traceId as 32-char padded hex and spanId as decimal, while each wire header keeps its own required format (datadog low-decimal + _dd.p.tid hex, b3/b3multi/tracecontext padded hex).


### After change

<img width="1056" height="652" alt="image" src="https://github.com/user-attachments/assets/72aa94ac-cc85-4f59-89cc-7a9585da1364" />


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

