### PR TITLE
Add device information to RUM crash events

### DIFF
--- a/dist/components/rum/RumCrashReporterTask.brs
+++ b/dist/components/rum/RumCrashReporterTask.brs
@@ -106,6 +106,7 @@ sub sendCrashReportFromViewEventFile(filepath as string)
         }
         context: lastViewEvent.context
         date: timestamp&
+        device: lastViewEvent.device
         error: {
             id: CreateObject("roDeviceInfo").GetRandomUUID()
             is_crash: true

--- a/library/components/rum/RumCrashReporterTask.bs
+++ b/library/components/rum/RumCrashReporterTask.bs
@@ -98,6 +98,7 @@ sub sendCrashReportFromViewEventFile(filepath as string)
         },
         context: lastViewEvent.context,
         date: timestamp&,
+        device: lastViewEvent.device,
         error: {
             id: CreateObject("roDeviceInfo").GetRandomUUID(),
             is_crash: true,

--- a/test/source/tests/rum/Test__RumCrashReporterTask.bs
+++ b/test/source/tests/rum/Test__RumCrashReporterTask.bs
@@ -97,6 +97,12 @@ function RumCrashReporterTaskTest__WhenReasonIsValid_ThenWriteErrorAndViewEvents
         },
         context: m.global.datadogContext,
         date: IG_GetLongInteger(),
+        device: {
+            type: "tv",
+            name: IG_GetString(16),
+            model: IG_GetString(16),
+            brand: "Roku"
+        },
         service: m.fakeGlobalContext,
         session: {
             has_replay: false,
@@ -140,6 +146,7 @@ function RumCrashReporterTaskTest__WhenReasonIsValid_ThenWriteErrorAndViewEvents
     Assert.that(errorEvent.source).isEqualTo("roku")
     Assert.that(errorEvent.type).isEqualTo("error")
     Assert.that(errorEvent.version).isEqualTo(fakePreviousViewEvent.version)
+    Assert.that(errorEvent.device).isEqualTo(fakePreviousViewEvent.device)
     Assert.that(errorEvent.view.id).isEqualTo(fakePreviousViewEvent.view.id)
     Assert.that(errorEvent.view.name).isEqualTo(fakePreviousViewEvent.view.name)
     Assert.that(errorEvent.view.url).isEqualTo(fakePreviousViewEvent.view.url)
@@ -203,6 +210,12 @@ function RumCrashReporterTaskTest__WhenReasonIsValid_ThenWriteErrorWithStackAndV
         },
         context: m.global.datadogContext,
         date: IG_GetLongInteger(),
+        device: {
+            type: "tv",
+            name: IG_GetString(16),
+            model: IG_GetString(16),
+            brand: "Roku"
+        },
         service: m.fakeGlobalContext,
         session: {
             has_replay: false,
@@ -248,6 +261,7 @@ function RumCrashReporterTaskTest__WhenReasonIsValid_ThenWriteErrorWithStackAndV
     Assert.that(errorEvent.source).isEqualTo("roku")
     Assert.that(errorEvent.type).isEqualTo("error")
     Assert.that(errorEvent.version).isEqualTo(fakePreviousViewEvent.version)
+    Assert.that(errorEvent.device).isEqualTo(fakePreviousViewEvent.device)
     Assert.that(errorEvent.view.id).isEqualTo(fakePreviousViewEvent.view.id)
     Assert.that(errorEvent.view.name).isEqualTo(fakePreviousViewEvent.view.name)
     Assert.that(errorEvent.view.url).isEqualTo(fakePreviousViewEvent.view.url)
@@ -302,6 +316,12 @@ function RumCrashReporterTaskTest__WhenReasonIsUnknown_ThenWriteErrorAndViewEven
         },
         context: m.global.datadogContext,
         date: IG_GetLongInteger(),
+        device: {
+            type: "tv",
+            name: IG_GetString(16),
+            model: IG_GetString(16),
+            brand: "Roku"
+        },
         service: m.fakeGlobalContext,
         session: {
             has_replay: false,
@@ -369,6 +389,12 @@ function RumCrashReporterTaskTest__WhenLastViewIsCurrentSession_ThenDoNothing() 
         },
         context: m.global.datadogContext,
         date: IG_GetLongInteger(),
+        device: {
+            type: "tv",
+            name: IG_GetString(16),
+            model: IG_GetString(16),
+            brand: "Roku"
+        },
         service: m.fakeGlobalContext,
         session: {
             has_replay: false,
@@ -428,6 +454,12 @@ function RumCrashReporterTaskTest__WhenExitreasonIsIgnored_ThenDoNothing() as st
         },
         context: m.global.datadogContext,
         date: IG_GetLongInteger(),
+        device: {
+            type: "tv",
+            name: IG_GetString(16),
+            model: IG_GetString(16),
+            brand: "Roku"
+        },
         service: m.fakeGlobalContext,
         session: {
             has_replay: false,
@@ -482,6 +514,12 @@ function RumCrashReporterTaskTest__WhenExitreasonIsCustomIgnored_ThenDoNothing()
         },
         context: m.global.datadogContext,
         date: IG_GetLongInteger(),
+        device: {
+            type: "tv",
+            name: IG_GetString(16),
+            model: IG_GetString(16),
+            brand: "Roku"
+        },
         service: m.fakeGlobalContext,
         session: {
             has_replay: false,
@@ -534,6 +572,12 @@ function RumCrashReporterTaskTest__WhenExitreasonIsEmpty_ThenDoNothing() as stri
         },
         context: m.global.datadogContext,
         date: IG_GetLongInteger(),
+        device: {
+            type: "tv",
+            name: IG_GetString(16),
+            model: IG_GetString(16),
+            brand: "Roku"
+        },
         service: m.fakeGlobalContext,
         session: {
             has_replay: false,


### PR DESCRIPTION
### What does this PR do?

Adds the `device` block to RUM crash/error events generated by `RumCrashReporterTask`.

When a crash is detected, the reporter reconstructs an error event from the last
known view event but did not carry over the `device` field. As a result, crash
events were missing the device attribution (`type` / `name` / `model` / `brand`)
that every other RUM event (view, action, resource, error, log) already includes.

Changes:
- `library/components/rum/RumCrashReporterTask.bs`: copy `device` from the last
  view event into the crash event (kept in the existing alphabetical key order).
- `dist/components/rum/RumCrashReporterTask.brs`: regenerated transpiled output.
- `test/source/tests/rum/Test__RumCrashReporterTask.bs`: add a `device` block to
  the fake view events and assert it propagates to the emitted crash event.

### Motivation

We ran into this while debugging crashes in our Roku app: the crash events were
missing device info, even though all our other RUM events had it. Crashes are
probably where that context matters most — being able to see which Roku models or
OS versions are affected makes triage a lot easier. This small change just carries
the `device` block over to crash events too, so they line up with the rest of the
SDK (and with Datadog's RUM error schema, which already supports `device`).

### Additional Notes

- The `device` value is taken verbatim from the persisted last view event, so no
  new device lookup or `roDeviceInfo` call is introduced on the crash path.
- `dist/` was regenerated with `bsc` so `check-dist` passes; no other generated
  files changed.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

