### PR TITLE
Add missing device and Os information to RUM crash events

### DIFF
--- a/dist/components/rum/RumCrashReporterTask.brs
+++ b/dist/components/rum/RumCrashReporterTask.brs
@@ -107,6 +107,7 @@ sub sendCrashReportFromViewEventFile(filepath as string)
         context: lastViewEvent.context
         date: timestamp&
         device: lastViewEvent.device
+        os: lastViewEvent.os
         error: {
             id: CreateObject("roDeviceInfo").GetRandomUUID()
             is_crash: true

--- a/dist/components/rum/RumCrashReporterTask.brs
+++ b/dist/components/rum/RumCrashReporterTask.brs
@@ -106,6 +106,7 @@ sub sendCrashReportFromViewEventFile(filepath as string)
         }
         context: lastViewEvent.context
         date: timestamp&
+        device: lastViewEvent.device
         error: {
             id: CreateObject("roDeviceInfo").GetRandomUUID()
             is_crash: true

--- a/library/components/rum/RumCrashReporterTask.bs
+++ b/library/components/rum/RumCrashReporterTask.bs
@@ -98,6 +98,7 @@ sub sendCrashReportFromViewEventFile(filepath as string)
         },
         context: lastViewEvent.context,
         date: timestamp&,
+        device: lastViewEvent.device,
         error: {
             id: CreateObject("roDeviceInfo").GetRandomUUID(),
             is_crash: true,

--- a/library/components/rum/RumCrashReporterTask.bs
+++ b/library/components/rum/RumCrashReporterTask.bs
@@ -99,6 +99,7 @@ sub sendCrashReportFromViewEventFile(filepath as string)
         context: lastViewEvent.context,
         date: timestamp&,
         device: lastViewEvent.device,
+        os: lastViewEvent.os,
         error: {
             id: CreateObject("roDeviceInfo").GetRandomUUID(),
             is_crash: true,

--- a/test/source/tests/rum/Test__RumCrashReporterTask.bs
+++ b/test/source/tests/rum/Test__RumCrashReporterTask.bs
@@ -43,6 +43,17 @@ sub RumCrashReporterTaskTest__SetUp()
         m.testSuite.fakeGlobalContext[IG_GetString(16) + i.toStr()] = IG_GetOneOf([IG_GetString(12), IG_GetInteger(), IG_GetFloat(), IG_GetBoolean()])
         m.testSuite.fakeGlobalUserInfo[IG_GetString(16) + i.toStr()] = IG_GetOneOf([IG_GetString(12), IG_GetInteger(), IG_GetFloat(), IG_GetBoolean()])
     end for
+    m.testSuite.fakeDevice = {
+        type: "tv",
+        name: IG_GetString(16),
+        model: IG_GetString(16),
+        brand: "Roku"
+    }
+    m.testSuite.fakeOs = {
+        name: "Roku",
+        version: IG_GetString(8),
+        version_major: IG_GetString(4)
+    }
 
     ' Global configuration
     m.testSuite.global.addFields({
@@ -97,12 +108,8 @@ function RumCrashReporterTaskTest__WhenReasonIsValid_ThenWriteErrorAndViewEvents
         },
         context: m.global.datadogContext,
         date: IG_GetLongInteger(),
-        device: {
-            type: "tv",
-            name: IG_GetString(16),
-            model: IG_GetString(16),
-            brand: "Roku"
-        },
+        device: m.fakeDevice,
+        os: m.fakeOs,
         service: m.fakeGlobalContext,
         session: {
             has_replay: false,
@@ -147,6 +154,7 @@ function RumCrashReporterTaskTest__WhenReasonIsValid_ThenWriteErrorAndViewEvents
     Assert.that(errorEvent.type).isEqualTo("error")
     Assert.that(errorEvent.version).isEqualTo(fakePreviousViewEvent.version)
     Assert.that(errorEvent.device).isEqualTo(fakePreviousViewEvent.device)
+    Assert.that(errorEvent.os).isEqualTo(fakePreviousViewEvent.os)
     Assert.that(errorEvent.view.id).isEqualTo(fakePreviousViewEvent.view.id)
     Assert.that(errorEvent.view.name).isEqualTo(fakePreviousViewEvent.view.name)
     Assert.that(errorEvent.view.url).isEqualTo(fakePreviousViewEvent.view.url)
@@ -210,12 +218,8 @@ function RumCrashReporterTaskTest__WhenReasonIsValid_ThenWriteErrorWithStackAndV
         },
         context: m.global.datadogContext,
         date: IG_GetLongInteger(),
-        device: {
-            type: "tv",
-            name: IG_GetString(16),
-            model: IG_GetString(16),
-            brand: "Roku"
-        },
+        device: m.fakeDevice,
+        os: m.fakeOs,
         service: m.fakeGlobalContext,
         session: {
             has_replay: false,
@@ -262,6 +266,7 @@ function RumCrashReporterTaskTest__WhenReasonIsValid_ThenWriteErrorWithStackAndV
     Assert.that(errorEvent.type).isEqualTo("error")
     Assert.that(errorEvent.version).isEqualTo(fakePreviousViewEvent.version)
     Assert.that(errorEvent.device).isEqualTo(fakePreviousViewEvent.device)
+    Assert.that(errorEvent.os).isEqualTo(fakePreviousViewEvent.os)
     Assert.that(errorEvent.view.id).isEqualTo(fakePreviousViewEvent.view.id)
     Assert.that(errorEvent.view.name).isEqualTo(fakePreviousViewEvent.view.name)
     Assert.that(errorEvent.view.url).isEqualTo(fakePreviousViewEvent.view.url)
@@ -316,12 +321,8 @@ function RumCrashReporterTaskTest__WhenReasonIsUnknown_ThenWriteErrorAndViewEven
         },
         context: m.global.datadogContext,
         date: IG_GetLongInteger(),
-        device: {
-            type: "tv",
-            name: IG_GetString(16),
-            model: IG_GetString(16),
-            brand: "Roku"
-        },
+        device: m.fakeDevice,
+        os: m.fakeOs,
         service: m.fakeGlobalContext,
         session: {
             has_replay: false,
@@ -359,6 +360,8 @@ function RumCrashReporterTaskTest__WhenReasonIsUnknown_ThenWriteErrorAndViewEven
     Assert.that(errorEvent.error.type).isEqualTo(fakeUnknownExitStatus)
     Assert.that(errorEvent.error.is_crash).isEqualTo(true)
     Assert.that(errorEvent.context).isEqualTo(fakePreviousViewEvent.context)
+    Assert.that(errorEvent.device).isEqualTo(fakePreviousViewEvent.device)
+    Assert.that(errorEvent.os).isEqualTo(fakePreviousViewEvent.os)
 
     Assert.that(lastViewFilePath).doesNotExist()
     return ""
@@ -389,12 +392,8 @@ function RumCrashReporterTaskTest__WhenLastViewIsCurrentSession_ThenDoNothing() 
         },
         context: m.global.datadogContext,
         date: IG_GetLongInteger(),
-        device: {
-            type: "tv",
-            name: IG_GetString(16),
-            model: IG_GetString(16),
-            brand: "Roku"
-        },
+        device: m.fakeDevice,
+        os: m.fakeOs,
         service: m.fakeGlobalContext,
         session: {
             has_replay: false,
@@ -454,12 +453,8 @@ function RumCrashReporterTaskTest__WhenExitreasonIsIgnored_ThenDoNothing() as st
         },
         context: m.global.datadogContext,
         date: IG_GetLongInteger(),
-        device: {
-            type: "tv",
-            name: IG_GetString(16),
-            model: IG_GetString(16),
-            brand: "Roku"
-        },
+        device: m.fakeDevice,
+        os: m.fakeOs,
         service: m.fakeGlobalContext,
         session: {
             has_replay: false,
@@ -514,12 +509,8 @@ function RumCrashReporterTaskTest__WhenExitreasonIsCustomIgnored_ThenDoNothing()
         },
         context: m.global.datadogContext,
         date: IG_GetLongInteger(),
-        device: {
-            type: "tv",
-            name: IG_GetString(16),
-            model: IG_GetString(16),
-            brand: "Roku"
-        },
+        device: m.fakeDevice,
+        os: m.fakeOs,
         service: m.fakeGlobalContext,
         session: {
             has_replay: false,
@@ -572,12 +563,8 @@ function RumCrashReporterTaskTest__WhenExitreasonIsEmpty_ThenDoNothing() as stri
         },
         context: m.global.datadogContext,
         date: IG_GetLongInteger(),
-        device: {
-            type: "tv",
-            name: IG_GetString(16),
-            model: IG_GetString(16),
-            brand: "Roku"
-        },
+        device: m.fakeDevice,
+        os: m.fakeOs,
         service: m.fakeGlobalContext,
         session: {
             has_replay: false,

--- a/test/source/tests/rum/Test__RumCrashReporterTask.bs
+++ b/test/source/tests/rum/Test__RumCrashReporterTask.bs
@@ -97,6 +97,12 @@ function RumCrashReporterTaskTest__WhenReasonIsValid_ThenWriteErrorAndViewEvents
         },
         context: m.global.datadogContext,
         date: IG_GetLongInteger(),
+        device: {
+            type: "tv",
+            name: IG_GetString(16),
+            model: IG_GetString(16),
+            brand: "Roku"
+        },
         service: m.fakeGlobalContext,
         session: {
             has_replay: false,
@@ -140,6 +146,7 @@ function RumCrashReporterTaskTest__WhenReasonIsValid_ThenWriteErrorAndViewEvents
     Assert.that(errorEvent.source).isEqualTo("roku")
     Assert.that(errorEvent.type).isEqualTo("error")
     Assert.that(errorEvent.version).isEqualTo(fakePreviousViewEvent.version)
+    Assert.that(errorEvent.device).isEqualTo(fakePreviousViewEvent.device)
     Assert.that(errorEvent.view.id).isEqualTo(fakePreviousViewEvent.view.id)
     Assert.that(errorEvent.view.name).isEqualTo(fakePreviousViewEvent.view.name)
     Assert.that(errorEvent.view.url).isEqualTo(fakePreviousViewEvent.view.url)
@@ -203,6 +210,12 @@ function RumCrashReporterTaskTest__WhenReasonIsValid_ThenWriteErrorWithStackAndV
         },
         context: m.global.datadogContext,
         date: IG_GetLongInteger(),
+        device: {
+            type: "tv",
+            name: IG_GetString(16),
+            model: IG_GetString(16),
+            brand: "Roku"
+        },
         service: m.fakeGlobalContext,
         session: {
             has_replay: false,
@@ -248,6 +261,7 @@ function RumCrashReporterTaskTest__WhenReasonIsValid_ThenWriteErrorWithStackAndV
     Assert.that(errorEvent.source).isEqualTo("roku")
     Assert.that(errorEvent.type).isEqualTo("error")
     Assert.that(errorEvent.version).isEqualTo(fakePreviousViewEvent.version)
+    Assert.that(errorEvent.device).isEqualTo(fakePreviousViewEvent.device)
     Assert.that(errorEvent.view.id).isEqualTo(fakePreviousViewEvent.view.id)
     Assert.that(errorEvent.view.name).isEqualTo(fakePreviousViewEvent.view.name)
     Assert.that(errorEvent.view.url).isEqualTo(fakePreviousViewEvent.view.url)
@@ -302,6 +316,12 @@ function RumCrashReporterTaskTest__WhenReasonIsUnknown_ThenWriteErrorAndViewEven
         },
         context: m.global.datadogContext,
         date: IG_GetLongInteger(),
+        device: {
+            type: "tv",
+            name: IG_GetString(16),
+            model: IG_GetString(16),
+            brand: "Roku"
+        },
         service: m.fakeGlobalContext,
         session: {
             has_replay: false,
@@ -369,6 +389,12 @@ function RumCrashReporterTaskTest__WhenLastViewIsCurrentSession_ThenDoNothing() 
         },
         context: m.global.datadogContext,
         date: IG_GetLongInteger(),
+        device: {
+            type: "tv",
+            name: IG_GetString(16),
+            model: IG_GetString(16),
+            brand: "Roku"
+        },
         service: m.fakeGlobalContext,
         session: {
             has_replay: false,
@@ -428,6 +454,12 @@ function RumCrashReporterTaskTest__WhenExitreasonIsIgnored_ThenDoNothing() as st
         },
         context: m.global.datadogContext,
         date: IG_GetLongInteger(),
+        device: {
+            type: "tv",
+            name: IG_GetString(16),
+            model: IG_GetString(16),
+            brand: "Roku"
+        },
         service: m.fakeGlobalContext,
         session: {
             has_replay: false,
@@ -482,6 +514,12 @@ function RumCrashReporterTaskTest__WhenExitreasonIsCustomIgnored_ThenDoNothing()
         },
         context: m.global.datadogContext,
         date: IG_GetLongInteger(),
+        device: {
+            type: "tv",
+            name: IG_GetString(16),
+            model: IG_GetString(16),
+            brand: "Roku"
+        },
         service: m.fakeGlobalContext,
         session: {
             has_replay: false,
@@ -534,6 +572,12 @@ function RumCrashReporterTaskTest__WhenExitreasonIsEmpty_ThenDoNothing() as stri
         },
         context: m.global.datadogContext,
         date: IG_GetLongInteger(),
+        device: {
+            type: "tv",
+            name: IG_GetString(16),
+            model: IG_GetString(16),
+            brand: "Roku"
+        },
         service: m.fakeGlobalContext,
         session: {
             has_replay: false,


### PR DESCRIPTION
### What does this PR do?

`os` and `device` fields are not copied from last view when reporting crash event in a new session, this PR adds them.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

